### PR TITLE
Fixed binding of android and web platform on windows

### DIFF
--- a/Source/AtomicJS/JSBind/JSBModule.cpp
+++ b/Source/AtomicJS/JSBind/JSBModule.cpp
@@ -383,7 +383,13 @@ void JSBModule::Load(const String &moduleJSONFilename)
     if (this->name_ == "Graphics")
     {
 #ifdef _MSC_VER
-        sources.AddString("Graphics/Direct3D9");
+        if (JSBind::PLATFORM == "ANDROID" || JSBind::PLATFORM == "WEB")
+        {
+            sources.AddString("Graphics/OpenGL");
+        }
+        else {
+            sources.AddString("Graphics/Direct3D9");
+        }
 #else
         sources.AddString("Graphics/OpenGL");
 #endif


### PR DESCRIPTION
- JSBind should use OpenGL Graphics module when building Android and Web platform on windows