### PR TITLE
Rake windows build uses global CMAKE_DEV_BUILD var

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ namespace :build  do
 
       sh "\"#{VSCOMNTOOLS}vsvars32.bat\""
 
-      sh "cmake ../../ -DATOMIC_DEV_BUILD=0 -G \"Visual Studio 14 2015\""
+      sh "cmake ../../ #{$CMAKE_DEV_BUILD} -G \"Visual Studio 14 2015\""
 
       # specify 32 bit
       sh "msbuild /m Atomic.sln /p:Configuration=Release /p:Platform=Win32"


### PR DESCRIPTION
I got this up just a moment too late for your previous landing :) Using this var works our side running the rake for distribution builds.