### PR TITLE
Selection framing, orbit, zoom, additional camera translation and hotkeys

### DIFF
--- a/Script/AtomicEditor/ui/MainToolbar.ts
+++ b/Script/AtomicEditor/ui/MainToolbar.ts
@@ -12,6 +12,7 @@ class MainToolbar extends Atomic.UIWidget {
     translateButton: Atomic.UIButton;
     rotateButton: Atomic.UIButton;
     scaleButton: Atomic.UIButton;
+    axisButton: Atomic.UIButton;
 
     constructor(parent: Atomic.UIWidget) {
 
@@ -23,15 +24,32 @@ class MainToolbar extends Atomic.UIWidget {
         this.rotateButton = <Atomic.UIButton>this.getWidget("3d_rotate");
         this.scaleButton = <Atomic.UIButton>this.getWidget("3d_scale");
 
+        this.axisButton = <Atomic.UIButton>this.getWidget("3d_axismode");
+
         this.translateButton.value = 1;
 
         parent.addChild(this);
 
+        this.subscribeToEvent("GizmoAxisModeChanged", (ev) => this.handleGizmoAxisModeChanged(ev));
         this.subscribeToEvent("GizmoEditModeChanged", (ev) => this.handleGizmoEditModeChanged(ev));
         this.subscribeToEvent(this, "WidgetEvent", (data) => this.handleWidgetEvent(data));
     }
 
-    handleGizmoEditModeChanged(ev) {
+    handleGizmoAxisModeChanged(ev: Editor.GizmoAxisModeChangedEvent) {
+
+        if (ev.toggle) return;
+
+        if (ev.mode == Editor.AXIS_WORLD) {
+            this.axisButton.value = 1;
+            this.axisButton.text = "World";
+        } else {
+            this.axisButton.value = 0;
+            this.axisButton.text = "Local";
+        }
+
+    }
+
+    handleGizmoEditModeChanged(ev: Editor.GizmoEditModeChangedEvent) {
 
         this.translateButton.value = 0;
         this.rotateButton.value = 0;
@@ -69,9 +87,7 @@ class MainToolbar extends Atomic.UIWidget {
 
             } else if (ev.target.id == "3d_axismode") {
 
-                ev.target.text = ev.target.value ? "World" : "Local";
-
-                EditorUI.getShortcuts().invokeGizmoAxisModeChanged( ev.target.value ? Editor.AXIS_WORLD :  Editor.AXIS_LOCAL);
+                EditorUI.getShortcuts().invokeGizmoAxisModeChanged(ev.target.value ? Editor.AXIS_WORLD : Editor.AXIS_LOCAL);
                 return true;
 
             } else if (ev.target.id == "maintoolbar_play") {

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -86,9 +86,9 @@ class Shortcuts extends Atomic.ScriptObject {
 
     }
 
-    invokeGizmoAxisModeChanged(mode:Editor.AxisMode) {
+    invokeGizmoAxisModeChanged(mode:Editor.AxisMode, toggle:boolean = false) {
 
-        this.sendEvent("GizmoAxisModeChanged", { mode: mode });
+        this.sendEvent("GizmoAxisModeChanged", { mode: mode, toggle: toggle });
 
     }
 
@@ -113,6 +113,8 @@ class Shortcuts extends Atomic.ScriptObject {
               this.invokeGizmoEditModeChanged(Editor.EDIT_ROTATE);
             } else if (ev.key == Atomic.KEY_R) {
                 this.invokeGizmoEditModeChanged(Editor.EDIT_SCALE);
+            } else if (ev.key == Atomic.KEY_X) {
+                this.invokeGizmoAxisModeChanged(Editor.AXIS_WORLD, true);
             }
 
         }

--- a/Script/TypeScript/AtomicWork.d.ts
+++ b/Script/TypeScript/AtomicWork.d.ts
@@ -255,6 +255,7 @@ declare module Editor {
 
   export interface GizmoAxisModeChangedEvent {
     mode:AxisMode;
+    toggle:boolean;
   }
 
 }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.h
@@ -110,6 +110,8 @@ public:
     void SetView(SceneView3D* view3D);
 
     void SetAxisMode(AxisMode mode);
+    AxisMode GetAxisMode() const { return axisMode_; }
+
     void SetEditMode(EditMode mode);
 
     bool Selected()

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
@@ -260,15 +260,24 @@ void SceneEditor3D::HandlePlayStopped(StringHash eventType, VariantMap& eventDat
 }
 
 void SceneEditor3D::HandleGizmoEditModeChanged(StringHash eventType, VariantMap& eventData)
-{
-    EditMode mode = (EditMode) ((int)eventData[GizmoEditModeChanged::P_MODE].GetFloat());
+{    
+    EditMode mode = (EditMode) (eventData[GizmoEditModeChanged::P_MODE].GetInt());
     gizmo3D_->SetEditMode(mode);
 }
 
 void SceneEditor3D::HandleGizmoAxisModeChanged(StringHash eventType, VariantMap& eventData)
 {
-    AxisMode mode = (AxisMode) ((int)eventData[GizmoEditModeChanged::P_MODE].GetFloat());
-    gizmo3D_->SetAxisMode(mode);
+    AxisMode mode = (AxisMode) (eventData[GizmoAxisModeChanged::P_MODE].GetInt());
+    bool toggle = eventData[GizmoAxisModeChanged::P_TOGGLE].GetBool();
+    if (toggle)
+    {
+        AxisMode mode = gizmo3D_->GetAxisMode() == AXIS_WORLD ? AXIS_LOCAL : AXIS_WORLD;
+        VariantMap neventData;
+        neventData[GizmoAxisModeChanged::P_MODE] = (int) mode;
+        SendEvent(E_GIZMOAXISMODECHANGED, neventData);
+    }
+    else
+        gizmo3D_->SetAxisMode(mode);
 }
 
 

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
@@ -322,4 +322,32 @@ void SceneEditor3D::HandleSceneEditSceneModified(StringHash eventType, VariantMa
     SetModified(true);    
 }
 
+void SceneEditor3D::GetSelectionBoundingBox(BoundingBox& bbox)
+{
+    bbox.Clear();
+
+    if (selectedNode_.Null())
+        return;
+
+    // TODO: Adjust once multiple selection is in
+    if (selectedNode_.Null())
+        return;
+
+    // Get all the drawables, which define the bounding box of the selection
+    PODVector<Drawable*> drawables;
+    selectedNode_->GetDerivedComponents<Drawable>(drawables, true);
+
+    if (!drawables.Size())
+        return;
+
+    // Calculate the combined bounding box of all drawables
+    for (unsigned i = 0; i < drawables.Size(); i++  )
+    {
+        Drawable* drawable = drawables[i];
+        bbox.Merge(drawable->GetWorldBoundingBox());
+    }
+
+
+}
+
 }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.h
@@ -45,6 +45,7 @@ public:
     bool OnEvent(const TBWidgetEvent &ev);
 
     void SelectNode(Node* node);
+    void GetSelectionBoundingBox(BoundingBox& bbox);
 
     Scene* GetScene() { return scene_; }
     Gizmo3D* GetGizmo() { return gizmo3D_; }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3DEvents.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3DEvents.h
@@ -15,12 +15,14 @@ namespace AtomicEditor
 /// Variable timestep scene update.
 EVENT(E_GIZMOEDITMODECHANGED, GizmoEditModeChanged)
 {
-    PARAM(P_MODE, MODE);            // int
+    PARAM(P_MODE, Mode);            // int
 }
 
 EVENT(E_GIZMOAXISMODECHANGED, GizmoAxisModeChanged)
 {
-    PARAM(P_MODE, MODE);            // int
+    PARAM(P_MODE, Mode);            // int
+    PARAM(P_TOGGLE, Toggle);            // bool
+
 }
 
 EVENT(E_GIZMOMOVED, GizmoMoved)

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
@@ -639,7 +639,7 @@ void SceneView3D::FrameSelection()
 
     // Get all the drawables, which define the bounding box of the selection
     PODVector<Drawable*> drawables;
-    selectedNode_->GetDerivedComponents<Drawable>(drawables);
+    selectedNode_->GetDerivedComponents<Drawable>(drawables, true);
 
     if (!drawables.Size())
         return;
@@ -671,17 +671,19 @@ void SceneView3D::FrameSelection()
     // Calculate screen rect which will be used to accept projected position
     int vwidth = viewport_->GetWidth();
     int vheight = viewport_->GetHeight();
-    Rect screenRect(vwidth/6, vheight/6, vwidth - vwidth/6, vheight - vheight/6);
+
+
+    Rect screenRect(vwidth/5, vheight/5, vwidth - vwidth/5, vheight - vheight/5);
 
     // given the target selection's world position, offset by the camera node's world direction
     // keep backing up until bounding box is entirely contained in the target screen rect
-    float factor = .01f;
+    float factor = 1.0f;
     while (true)
     {
         // We don't rotate the camera during framing, otherwise this would be jarring
         Vector3 dir = cameraNode_->GetWorldDirection();
         dir *= factor;
-        Vector3 dest = selectedNode_->GetWorldPosition() - dir;
+        Vector3 dest = bbox.Center() - dir;
         cameraNode_->SetWorldPosition(dest);
 
         unsigned i;
@@ -700,7 +702,10 @@ void SceneView3D::FrameSelection()
             break;
         }
 
-        factor += 0.01f;
+        factor += 1.0f;
+
+        if (factor > 500)
+            break;
     }
 
     cameraNode_->SetWorldPosition(cameraMoveStart_);

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
@@ -198,6 +198,16 @@ void SceneView3D::MoveCamera(float timeStep)
             SetFocus();
             cameraNode_->Translate(Vector3::RIGHT * MOVE_SPEED * timeStep);
         }
+        if (input->GetKeyDown('Q'))
+        {
+            SetFocus();
+            cameraNode_->Translate(Vector3::UP * MOVE_SPEED * timeStep);
+        }
+        if (input->GetKeyDown('E'))
+        {
+            SetFocus();
+            cameraNode_->Translate(Vector3::DOWN * MOVE_SPEED * timeStep);
+        }
 
     }
 }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
@@ -22,7 +22,6 @@ class Node;
 class Camera;
 class DebugRenderer;
 class Octree;
-class SmoothedTransform;
 }
 
 namespace AtomicEditor

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
@@ -57,6 +57,7 @@ private:
 
     bool MouseInView();
     bool GetOrbitting();
+    bool GetZooming();
 
     void HandleMouseMove(StringHash eventType, VariantMap& eventData);
 

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
@@ -22,6 +22,7 @@ class Node;
 class Camera;
 class DebugRenderer;
 class Octree;
+class SmoothedTransform;
 }
 
 namespace AtomicEditor
@@ -45,6 +46,8 @@ public:
 
     void SetPitch(float pitch) { pitch_ = pitch; }
     void SetYaw(float yaw) { yaw_ = yaw; }
+
+    void FrameSelection();
 
     void Enable();
     void Disable();
@@ -83,6 +86,11 @@ private:
     bool mouseMoved_;
 
     bool enabled_;
+
+    bool cameraMove_;
+    float cameraMoveTime_;
+    Vector3 cameraMoveStart_;
+    Vector3 cameraMoveTarget_;
 
     SharedPtr<Camera> camera_;
     SharedPtr<DebugRenderer> debugRenderer_;

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
@@ -56,6 +56,7 @@ public:
 private:
 
     bool MouseInView();
+    bool GetOrbitting();
 
     void HandleMouseMove(StringHash eventType, VariantMap& eventData);
 
@@ -85,7 +86,7 @@ private:
     bool mouseLeftDown_;
     bool mouseMoved_;
 
-    bool enabled_;
+    bool enabled_;    
 
     bool cameraMove_;
     float cameraMoveTime_;
@@ -96,6 +97,7 @@ private:
     SharedPtr<DebugRenderer> debugRenderer_;
     SharedPtr<Octree> octree_;
     SharedPtr<Node> selectedNode_;
+    WeakPtr<Node> framedNode_;
 
     SharedPtr<Scene> preloadResourceScene_;
     String dragAssetGUID_;


### PR DESCRIPTION

Q/E: Translate camera up/down
F: Frame Selection
Alt + Left Mouse  - Orbit (once selection framed)
Alt + Middle Mouse - Move camera towards point ("Zoom")
X : Toggle World/Local gizmo axis mode
