### PR TITLE
Don't report missing ToolPrefs as this isn't an error, raise an error…

### DIFF
--- a/Source/AtomicEditor/Application/AEPlayerApp.cpp
+++ b/Source/AtomicEditor/Application/AEPlayerApp.cpp
@@ -115,6 +115,13 @@ void AEPlayerApplication::Setup()
 
                 value = AddTrailingSlash(value);
 
+                // check that cache exists
+                if (!filesystem->DirExists(value + "Cache"))
+                {
+                    ErrorExit("Project cache folder does not exist, projects must be loaded into the Atomic Editor at least once before using the --player command line mode");
+                    return;
+                }
+
 #ifdef ATOMIC_DEV_BUILD
 
                 String resourcePaths = ToString("%s/Resources/CoreData;%s/Resources/PlayerData;%sResources;%s;%sCache",

--- a/Source/ToolCore/ToolPrefs.cpp
+++ b/Source/ToolCore/ToolPrefs.cpp
@@ -51,6 +51,11 @@ void ToolPrefs::Load()
 {
     String path = GetPrefsPath();
 
+    // Check that the tool prefs file exists
+    FileSystem* fs = GetSubsystem<FileSystem>();
+    if (!fs->FileExists(path))
+        return;
+
     SharedPtr<File> file(new File(context_, path));
 
     if (!file->IsOpen())


### PR DESCRIPTION
… dialog if --player command line is invoked without loading project into editor first at least once