### PR TITLE
Fix build directory reference in GenerateVS2015.bat

### DIFF
--- a/Build/Scripts/BuildWindows.js
+++ b/Build/Scripts/BuildWindows.js
@@ -89,7 +89,7 @@ namespace('build', function() {
 
     var cmds = [];
 
-    cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat");
+    cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot);
 
     jake.exec(cmds, function() {
 

--- a/Build/Scripts/Windows/GenerateVS2015.bat
+++ b/Build/Scripts/Windows/GenerateVS2015.bat
@@ -1,3 +1,3 @@
 call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
-cmake ..\\AtomicGameEngine -DATOMIC_DEV_BUILD=1 -G "Visual Studio 14 2015 Win64"
+cmake %1 -DATOMIC_DEV_BUILD=1 -G "Visual Studio 14 2015 Win64"
 msbuild Atomic.sln /m /p:Configuration=Debug /p:Platform=x64 /t:AtomicTool


### PR DESCRIPTION
I manage a few copies of the engine based on what I'm adding. These copies are in the same root directory, but they are all named differently: "AtomicGameEngineWS", "AtomicGameEngineWR", "AtomicGameEngineWebM", etc.

When I was using CMake directly, that was not an issue. However, now I'm using jake to invoke CMake, and that script has a hard coded "AtomicGameEngine" directory in it for the source directory, even though it had already created a binary directory based on the source directory's name.

This patch passes that directory name through to the .bat file where it was previously hardcoded, so that my directory naming scheme works again.