### PR TITLE
Variant to Uint8Array mapping

### DIFF
--- a/Source/Atomic/Web/Web.h
+++ b/Source/Atomic/Web/Web.h
@@ -32,7 +32,7 @@ namespace Atomic
 class WebRequest;
 class WebSocket;
 
-class WebPrivate;
+struct WebPrivate;
 
 /// %Web subsystem. Manages HTTP requests and WebSocket communications.
 class ATOMIC_API Web : public Object

--- a/Source/AtomicJS/Javascript/JSAPI.h
+++ b/Source/AtomicJS/Javascript/JSAPI.h
@@ -63,4 +63,6 @@ void js_to_variant(duk_context* ctx, int variantIdx, Variant &v);
 
 void js_object_to_variantmap(duk_context* ctx, int objIdx, VariantMap &v);
 
+/// Returns true if the item is a buffer, and if data and size are passed, they are given values to access the buffer data.
+duk_bool_t js_check_is_buffer_and_get_data(duk_context* ctx, duk_idx_t idx, void** data, duk_size_t* size);
 }


### PR DESCRIPTION
The `Uint8Array` will now map to `PODVector<unsigned char>` for Variant types. That means that you can now pass binary data to event callbacks. I singled out this typed-array type because many JS serialization formats (like [EJSON](https://www.meteor.com/ejson)) which support binary data work with it exclusively.

I haven't looked into the JSBind code, yet. The last step would be to allow `PODVector<unsigned char>` to be used as a function parameter or return value. I'm not sure where that code is.

@JoshEngebretson: Could you point me to the JSBind code where I would add a type as a parameter/return value? I'd like to get the `WebSocket::SendBinary()` call working from a script, and it takes a `const PODVector<unsigned char>&` as a parameter.