### PR TITLE
Scoping variables in js_push_variant

### DIFF
--- a/Source/AtomicJS/Javascript/JSAPI.cpp
+++ b/Source/AtomicJS/Javascript/JSAPI.cpp
@@ -452,18 +452,7 @@ void js_push_variantmap(duk_context* ctx, const VariantMap &vmap)
 
 void js_push_variant(duk_context *ctx, const Variant& v)
 {
-    VariantType type = v.GetType();
-    RefCounted* ref;
-    Vector2 vector2 = Vector2::ZERO;
-    IntVector2 intVector2 = IntVector2::ZERO;
-    Vector3 vector3 = Vector3::ZERO;
-    Vector4 vector4 = Vector4::ZERO;
-    Color color = Color::BLACK;
-    Resource* resource = NULL;
-    ResourceCache* cache = NULL;
-    ResourceRef resourceRef;
-
-    switch (type)
+    switch (v.GetType())
     {
     case VAR_NONE:
         duk_push_undefined(ctx);
@@ -472,9 +461,10 @@ void js_push_variant(duk_context *ctx, const Variant& v)
     case VAR_VOIDPTR:
         duk_push_null(ctx);
         break;
-    case VAR_PTR:
 
-        ref = v.GetPtr();
+    case VAR_PTR:
+    {
+        RefCounted* ref = v.GetPtr();
 
         // if we're null or don't have any refs, return null
         if (!ref || !ref->Refs())
@@ -485,7 +475,7 @@ void js_push_variant(duk_context *ctx, const Variant& v)
 
         // check that class is supported
         duk_push_heap_stash(ctx);
-        duk_push_pointer(ctx, (void*) ref->GetClassID());
+        duk_push_pointer(ctx, (void*)ref->GetClassID());
         duk_get_prop(ctx, -2);
 
         if (!duk_is_object(ctx, -1))
@@ -499,54 +489,67 @@ void js_push_variant(duk_context *ctx, const Variant& v)
             js_push_class_object_instance(ctx, ref);
         }
 
-        break;
+    }   break;
 
     case VAR_RESOURCEREF:
-        resourceRef = v.GetResourceRef();
-        cache = JSVM::GetJSVM(ctx)->GetContext()->GetSubsystem<ResourceCache>();
-        resource = cache->GetResource(resourceRef.type_, resourceRef.name_);
+    {
+        const ResourceRef& resourceRef(v.GetResourceRef());
+        ResourceCache* cache = JSVM::GetJSVM(ctx)->GetContext()->GetSubsystem<ResourceCache>();
+        Resource* resource = cache->GetResource(resourceRef.type_, resourceRef.name_);
         js_push_class_object_instance(ctx, resource);
-        break;
+    }   break;
 
     case VAR_BOOL:
         duk_push_boolean(ctx, v.GetBool() ? 1 : 0);
         break;
+
     case VAR_INT:
         duk_push_number(ctx, v.GetInt());
         break;
+
     case VAR_FLOAT:
         duk_push_number(ctx, v.GetFloat());
         break;
+
     case VAR_STRING:
-        duk_push_string(ctx, v.GetString().CString());
-        break;
+    {
+        const String& string(v.GetString());
+        duk_push_lstring(ctx, string.CString(), string.Length());
+    }   break;
+
     case VAR_BUFFER:
     {
         const PODVector<unsigned char>& buffer(v.GetBuffer()); // The braces are to scope this reference.
         duk_push_fixed_buffer(ctx, buffer.Size());
         duk_push_buffer_object(ctx, -1, 0, buffer.Size(), DUK_BUFOBJ_UINT8ARRAY);
         duk_replace(ctx, -2);
-        unsigned char* data((unsigned char*)duk_require_buffer_data(ctx, -1, (duk_size_t*)nullptr));
+        unsigned char* data = (unsigned char*)duk_require_buffer_data(ctx, -1, (duk_size_t*)nullptr);
         memcpy(data, buffer.Buffer(), buffer.Size());
     }   break;
+
     case VAR_VECTOR2:
-        vector2 = v.GetVector2();
+    {
+        const Vector2& vector2(v.GetVector2());
         duk_push_array(ctx);
         duk_push_number(ctx, vector2.x_);
         duk_put_prop_index(ctx, -2, 0);
         duk_push_number(ctx, vector2.y_);
         duk_put_prop_index(ctx, -2, 1);
-        break;
+    }   break;
+
     case VAR_INTVECTOR2:
-        intVector2 = v.GetIntVector2();
+    {
+        const IntVector2& intVector2(v.GetIntVector2());
         duk_push_array(ctx);
         duk_push_number(ctx, intVector2.x_);
         duk_put_prop_index(ctx, -2, 0);
         duk_push_number(ctx, intVector2.y_);
         duk_put_prop_index(ctx, -2, 1);
-        break;
+    }   break;
+
     case VAR_VECTOR3:
-        vector3 = v.GetVector3();
+    {
+        const Vector3& vector3(v.GetVector3());
         duk_push_array(ctx);
         duk_push_number(ctx, vector3.x_);
         duk_put_prop_index(ctx, -2, 0);
@@ -554,9 +557,11 @@ void js_push_variant(duk_context *ctx, const Variant& v)
         duk_put_prop_index(ctx, -2, 1);
         duk_push_number(ctx, vector3.z_);
         duk_put_prop_index(ctx, -2, 2);
-        break;
+    }   break;
+
     case VAR_QUATERNION:
-        vector3 = v.GetQuaternion().EulerAngles();
+    {
+        const Vector3& vector3(v.GetQuaternion().EulerAngles());
         duk_push_array(ctx);
         duk_push_number(ctx, vector3.x_);
         duk_put_prop_index(ctx, -2, 0);
@@ -564,9 +569,11 @@ void js_push_variant(duk_context *ctx, const Variant& v)
         duk_put_prop_index(ctx, -2, 1);
         duk_push_number(ctx, vector3.z_);
         duk_put_prop_index(ctx, -2, 2);
-        break;
+    }   break;
+
     case VAR_COLOR:
-        color = v.GetColor();
+    {
+        const Color& color(v.GetColor());
         duk_push_array(ctx);
         duk_push_number(ctx, color.r_);
         duk_put_prop_index(ctx, -2, 0);
@@ -576,9 +583,11 @@ void js_push_variant(duk_context *ctx, const Variant& v)
         duk_put_prop_index(ctx, -2, 2);
         duk_push_number(ctx, color.a_);
         duk_put_prop_index(ctx, -2, 3);
-        break;
+    }   break;
+
     case VAR_VECTOR4:
-        vector4 = v.GetVector4();
+    {
+        const Vector4& vector4(v.GetVector4());
         duk_push_array(ctx);
         duk_push_number(ctx, vector4.x_);
         duk_put_prop_index(ctx, -2, 0);
@@ -588,7 +597,7 @@ void js_push_variant(duk_context *ctx, const Variant& v)
         duk_put_prop_index(ctx, -2, 2);
         duk_push_number(ctx, vector4.w_);
         duk_put_prop_index(ctx, -2, 3);
-        break;
+    }   break;
 
     default:
         duk_push_undefined(ctx);

--- a/Source/AtomicJS/Javascript/JSAPI.h
+++ b/Source/AtomicJS/Javascript/JSAPI.h
@@ -65,4 +65,5 @@ void js_object_to_variantmap(duk_context* ctx, int objIdx, VariantMap &v);
 
 /// Returns true if the item is a buffer, and if data and size are passed, they are given values to access the buffer data.
 duk_bool_t js_check_is_buffer_and_get_data(duk_context* ctx, duk_idx_t idx, void** data, duk_size_t* size);
+
 }


### PR DESCRIPTION
I looked at this function a bit deeper, and I noticed that there were a good number of copies out of the variant, and it constructed all of the possible temporary variables whether it used them or not. It now only copies the variable out of the Variant once, and it only constructs a temporary type when it's needed.