### PR TITLE
Disable unnecessary menus when there is no open project

### DIFF
--- a/Script/AtomicEditor/ui/frames/MainFrame.ts
+++ b/Script/AtomicEditor/ui/frames/MainFrame.ts
@@ -44,14 +44,18 @@ class MainFrame extends ScriptWidget {
 
         this.menu = new MainFrameMenu();
 
+        this.disableProjectMenus();
+
         this.subscribeToEvent(UIEvents.ResourceEditorChanged, (data) => this.handleResourceEditorChanged(data));
 
         this.subscribeToEvent("ProjectLoaded", (data) => {
             this.showWelcomeFrame(false);
+            this.enableProjectMenus();
         });
 
         this.subscribeToEvent("ProjectUnloaded", (data) => {
             this.showWelcomeFrame(true);
+            this.disableProjectMenus();
         });
 
         this.showWelcomeFrame(true);
@@ -119,6 +123,18 @@ class MainFrame extends ScriptWidget {
 
         return false;
 
+    }
+
+    disableProjectMenus() {
+        this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
+        this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
+        this.getWidget("menu tools").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
+    }
+
+    enableProjectMenus() {
+        this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
+        this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
+        this.getWidget("menu tools").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
     }
 
     shutdown() {


### PR DESCRIPTION
This is how menu does looks like, until project is open
![](http://puu.sh/lJkF6/2fbc69ca0e.png)
#464 