### PR TITLE
Try closing current project automatically for user when open a new project

### DIFF
--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -128,8 +128,9 @@ class Editor extends Atomic.ScriptObject {
         if (system.project) {
 
             system.closeProject();
-
+            this.sendEvent(EditorEvents.ProjectClosed);
         }
+
     }
 
     handleProjectUnloaded(event) {

--- a/Script/AtomicEditor/editor/EditorEvents.ts
+++ b/Script/AtomicEditor/editor/EditorEvents.ts
@@ -47,6 +47,7 @@ export interface ContentFolderChangedEvent {
 }
 
 export const CloseProject = "EditorCloseProject";
+export const ProjectClosed = "EditorProjectClosed";
 
 export const LoadProject = "EditorLoadProject";
 export interface LoadProjectEvent {

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -131,22 +131,33 @@ class MainFrameMenu extends Atomic.ScriptObject {
             }
             if (refid == "file open project") {
 
-                if (ToolCore.toolSystem.project) {
-
-                    EditorUI.showModalError("Project Open",
-                        "Please close the current project before opening new one");
-
-                    return true;
-                }
-
                 var utils = new Editor.FileUtils();
                 var path = utils.openProjectFileDialog();
-                if (path) {
 
-                    this.sendEvent(EditorEvents.LoadProject, { path: path });
+                if (path=="") {
+
+                    return true;
 
                 }
 
+                var openProject = () => this.sendEvent(EditorEvents.LoadProject, { path: path });
+
+                if (ToolCore.toolSystem.project) {
+
+                    this.subscribeToEvent(EditorEvents.ProjectClosed, () => {
+
+                        this.unsubscribeFromEvent(EditorEvents.ProjectClosed);
+                        openProject();
+
+                    });
+
+                    this.sendEvent(EditorEvents.CloseProject);
+
+                } else {
+
+                    openProject();
+
+                }
 
                 return true;
 


### PR DESCRIPTION
- The "Please close the current project before opening new one" dialog becoming annoying when you switching project a lot
- And it took at least 7 mouse clicks to open a project
- Now it's 2 mouse clicks.
