### PR TITLE
Splits up AtomicEngine menu to conform with standard program menus

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,6 +21,8 @@
 
 - Matt Benic (https://github.com/mattbenic)
 
+- Nick Minkler (https://github.com/Sleaker)
+
 ### Contribution Copyright and Licensing
 
 Atomic Game Engine contribution copyrights are held by their authors.  Each author retains the copyright to their contribution and agrees to irrevocably license the contribution under the Atomic Game Engine Contribution License `CONTRIBUTION_LICENSE.md`.  Please see `CONTRIBUTING.md` for more details.

--- a/Resources/EditorData/AtomicEditor/editor/ui/mainframe.tb.txt
+++ b/Resources/EditorData/AtomicEditor/editor/ui/mainframe.tb.txt
@@ -11,10 +11,6 @@ TBLayout: distribution: gravity, axis: y
 					TBLayout: distribution: gravity
 						TBButton
 							@include definitions>menubutton
-							text Atomic Editor
-							id menu atomic editor
-						TBButton
-							@include definitions>menubutton
 							text File
 							id menu file
 						TBButton

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -16,7 +16,6 @@ class MainFrameMenu extends Atomic.ScriptObject {
 
         super();
 
-        MenuItemSources.createMenuItemSource("menu atomic editor", editorItems);
         MenuItemSources.createMenuItemSource("menu edit", editItems);
         MenuItemSources.createMenuItemSource("menu file", fileItems);
         MenuItemSources.createMenuItemSource("menu build", buildItems);
@@ -27,31 +26,7 @@ class MainFrameMenu extends Atomic.ScriptObject {
 
     handlePopupMenu(target: Atomic.UIWidget, refid: string): boolean {
 
-        if (target.id == "menu atomic editor popup") {
-
-            if (refid == "about atomic editor") {
-
-                EditorUI.getModelOps().showAbout();
-
-                return true;
-            }
-
-            if (refid == "manage license") {
-
-                EditorUI.getModelOps().showManageLicense();
-
-                return true;
-
-            }
-
-            if (refid == "quit") {
-
-                this.sendEvent("ExitRequested");
-                return true;
-
-            }
-
-        } else if (target.id == "menu edit popup") {
+        if (target.id == "menu edit popup") {
 
             if (refid == "edit play") {
                 EditorUI.getShortcuts().invokePlayOrStopPlayer();
@@ -112,7 +87,12 @@ class MainFrameMenu extends Atomic.ScriptObject {
             return false;
 
         } else if (target.id == "menu file popup") {
+            if (refid == "quit") {
 
+                this.sendEvent("ExitRequested");
+                return true;
+
+            }
             if (refid == "file new project") {
 
                 if (ToolCore.toolSystem.project) {
@@ -218,7 +198,14 @@ class MainFrameMenu extends Atomic.ScriptObject {
             }
 
         } else if (target.id == "menu help popup") {
-
+            if (refid == "about atomic editor") {
+                EditorUI.getModelOps().showAbout();
+                return true;
+            }
+            if (refid == "manage license") {
+                EditorUI.getModelOps().showManageLicense();
+                return true;
+            }
             if (refid == "help forums") {
                 Atomic.fileSystem.systemOpen("http://atomicgameengine.com/forum/")
                 return true;
@@ -244,16 +231,6 @@ export = MainFrameMenu;
 
 // initialization
 var StringID = strings.StringID;
-
-var editorItems = {
-    "About Atomic Editor": "about atomic editor",
-    "-1": null,
-    "Manage License": "manage license",
-    "-2": null,
-    "Check for Updates": "check update",
-    "-3": null,
-    "Quit": "quit"
-};
 
 var editItems = {
 
@@ -309,15 +286,21 @@ var fileItems = {
     "-2": null,
     "Save File": ["file save file", StringID.ShortcutSaveFile],
     "Save All Files": ["file save all"],
-    "Close File": ["file close file", StringID.ShortcutCloseFile]
+    "Close File": ["file close file", StringID.ShortcutCloseFile],
+     "-3": null,
+    "Quit": "quit"
 }
 
 var helpItems = {
 
+    "Check for Updates": "check update",
     "API Documentation": ["help api"],
     "-1": null,
     "Atomic Chat": ["help chat"],
     "Atomic Forums": ["help forums"],
     "-2": null,
-    "Atomic Game Engine on GitHub": ["help github"]
+    "Atomic Game Engine on GitHub": ["help github"],
+    "About Atomic Editor": "about atomic editor",
+    "-3": null,
+    "Manage License": "manage license"
 }


### PR DESCRIPTION
Moves Quit to File menu.
all other options to the Help menu.
removes AtomicEngine from the menubar.
This format mirrors major editors (Unity, VS, etc)