### PR TITLE
UI pointer events clean up

### DIFF
--- a/Source/Atomic/UI/UIListView.cpp
+++ b/Source/Atomic/UI/UIListView.cpp
@@ -252,7 +252,6 @@ ListViewItemWidget::ListViewItemWidget(ListViewItem *item, ListViewItemSource *s
     SetLayoutDistribution(LAYOUT_DISTRIBUTION_GRAVITY);
     SetLayoutDistributionPosition(LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP);
     SetPaintOverflowFadeout(false);
-    SetCapturing(false);
 
     item_->widget_ = this;
 

--- a/Source/Atomic/UI/UISelectList.cpp
+++ b/Source/Atomic/UI/UISelectList.cpp
@@ -227,7 +227,11 @@ void UISelectList::HandleUIUpdate(StringHash eventType, VariantMap& eventData)
                 select->GetScrollContainer()->ScrollBy(0, speed);
 
         }
-
+        handlingDragAndDrop_ = true;
+    }
+    else
+    {
+        handlingDragAndDrop_ = false;
     }
 
 }
@@ -237,6 +241,12 @@ bool UISelectList::OnEvent(const tb::TBWidgetEvent &ev)
     if (ev.type == EVENT_TYPE_POINTER_DOWN)
     {
         GetTBSelectList()->SetFocus(WIDGET_FOCUS_REASON_POINTER);
+    }
+    if (ev.type == EVENT_TYPE_POINTER_MOVE)
+    {
+        //if we handle drag and drop then return true, to avoid panning scroll widget by turbobadger, let the widget control scroll by itself
+        if (handlingDragAndDrop_)
+            return true;
     }
     return UIWidget::OnEvent(ev);
 }

--- a/Source/Atomic/UI/UISelectList.cpp
+++ b/Source/Atomic/UI/UISelectList.cpp
@@ -227,11 +227,6 @@ void UISelectList::HandleUIUpdate(StringHash eventType, VariantMap& eventData)
                 select->GetScrollContainer()->ScrollBy(0, speed);
 
         }
-        handlingDragAndDrop_ = true;
-    }
-    else
-    {
-        handlingDragAndDrop_ = false;
     }
 
 }
@@ -244,8 +239,10 @@ bool UISelectList::OnEvent(const tb::TBWidgetEvent &ev)
     }
     if (ev.type == EVENT_TYPE_POINTER_MOVE)
     {
+        UIDragDrop* dragDrop = GetSubsystem<UIDragDrop>();
+
         //if we handle drag and drop then return true, to avoid panning scroll widget by turbobadger, let the widget control scroll by itself
-        if (handlingDragAndDrop_)
+        if (dragDrop->GetDraggingObject())
             return true;
     }
     return UIWidget::OnEvent(ev);
@@ -275,6 +272,5 @@ void UISelectList::SetUIListView(bool value)
     ((TBSelectList*)widget_)->SetUIListView(value);
 
 }
-
 
 }

--- a/Source/Atomic/UI/UISelectList.h
+++ b/Source/Atomic/UI/UISelectList.h
@@ -77,8 +77,6 @@ protected:
     virtual bool OnEvent(const tb::TBWidgetEvent &ev);
 
 private:
-    //Returns true if we have drag and drop element on select list widget
-    bool handlingDragAndDrop_;
 };
 
 

--- a/Source/Atomic/UI/UISelectList.h
+++ b/Source/Atomic/UI/UISelectList.h
@@ -77,7 +77,8 @@ protected:
     virtual bool OnEvent(const tb::TBWidgetEvent &ev);
 
 private:
-
+    //Returns true if we have drag and drop element on select list widget
+    bool handlingDragAndDrop_;
 };
 
 

--- a/Source/AtomicEditor/Editors/ResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/ResourceEditor.cpp
@@ -61,10 +61,6 @@ public:
 
     bool OnEvent(const TBWidgetEvent &ev)
     {
-        // Don't process pointer down, we only respond to click events
-        if (ev.type == EVENT_TYPE_POINTER_DOWN)
-            return true;
-
         if (ev.type == EVENT_TYPE_CLICK)
         {
             if (ev.target->GetID() == TBIDC("unsaved_modifications_dialog"))

--- a/Source/ThirdParty/TurboBadger/tb_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.cpp
@@ -1353,6 +1353,8 @@ void TBWidget::InvokePointerDown(int x, int y, int click_count, MODIFIER_KEYS mo
 
 void TBWidget::InvokePointerUp(int x, int y, MODIFIER_KEYS modifierkeys, bool touch, int touchId)
 {
+    int ox = x;
+    int oy = y;
     //First check for the captured widget
     if (captured_widget && captured_widget->touchId_ == touchId)
     {
@@ -1366,6 +1368,8 @@ void TBWidget::InvokePointerUp(int x, int y, MODIFIER_KEYS modifierkeys, bool to
         }
         captured_widget->ReleaseCapture();
     }
+    x = ox;
+    y = oy;
     TBWidget* down_widget = GetWidgetAt(x, y, true);
 	//then if we have any down widgets, then make sure that it's not captured_widget otherwise events will be sent twice
     if (down_widget && down_widget->touchId_ == touchId && captured_widget != down_widget)

--- a/Source/ThirdParty/TurboBadger/tb_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.cpp
@@ -1353,31 +1353,35 @@ void TBWidget::InvokePointerDown(int x, int y, int click_count, MODIFIER_KEYS mo
 
 void TBWidget::InvokePointerUp(int x, int y, MODIFIER_KEYS modifierkeys, bool touch, int touchId)
 {
-    TBWidget* down_widget = GetWidgetAt(x, y, true);
-	if ((down_widget && down_widget->touchId_ == touchId) || captured_widget)
-	{
+    //First check for the captured widget
+    if (captured_widget && captured_widget->touchId_ == touchId)
+    {
+        captured_widget->ConvertFromRoot(x, y);
         TBWidgetEvent ev_up(EVENT_TYPE_POINTER_UP, x, y, touch, modifierkeys);
         TBWidgetEvent ev_click(EVENT_TYPE_CLICK, x, y, touch, modifierkeys);
-        down_widget->Invalidate();
-        down_widget->InvalidateSkinStates();
-        down_widget->OnCaptureChanged(false);
+        captured_widget->InvokeEvent(ev_up);
+        if (!cancel_click && captured_widget->GetHitStatus(x, y))
+        {
+            captured_widget->InvokeEvent(ev_click);
+        }
+        captured_widget->ReleaseCapture();
+    }
+    TBWidget* down_widget = GetWidgetAt(x, y, true);
+	//then if we have any down widgets, then make sure that it's not captured_widget otherwise events will be sent twice
+    if (down_widget && down_widget->touchId_ == touchId && captured_widget != down_widget)
+	{
 		down_widget->ConvertFromRoot(x, y);
-		down_widget->InvokeEvent(ev_up);
+        TBWidgetEvent ev_up(EVENT_TYPE_POINTER_UP, x, y, touch, modifierkeys);
+        TBWidgetEvent ev_click(EVENT_TYPE_CLICK, x, y, touch, modifierkeys);
+    	down_widget->InvokeEvent(ev_up);
         if (!cancel_click && down_widget->GetHitStatus(x, y))
         {
 			down_widget->InvokeEvent(ev_click);
         }
-        if (captured_widget)
-        {
-            captured_widget->ConvertFromRoot(x, y);
-            if (!cancel_click && captured_widget->GetHitStatus(x, y))
-            {
-                captured_widget->InvokeEvent(ev_click);
-            }
-            captured_widget->InvokeEvent(ev_up);
-            captured_widget->ReleaseCapture();
-        }
-	}
+        down_widget->Invalidate();
+        down_widget->InvalidateSkinStates();
+        down_widget->OnCaptureChanged(false);
+    }
 }
 
 void TBWidget::InvokeRightPointerDown(int x, int y, int click_count, MODIFIER_KEYS modifierkeys)
@@ -1406,7 +1410,6 @@ void TBWidget::InvokeRightPointerUp(int x, int y, MODIFIER_KEYS modifierkeys)
     widget->InvokeEvent(ev);
 
 }
-
 
 void TBWidget::MaybeInvokeLongClickOrContextMenu(bool touch)
 {


### PR DESCRIPTION
I've done small clean up for the ui pointer event(again), it's related a bit to the #512, because the click/up event was sent twice

I also fixes a scroll(it was fixed before, but it's more clearly way to do that, because UIListView should be capturing widget)