### PR TITLE
Linux build enhancements

### DIFF
--- a/Build/CIScripts/BuildLinux.js
+++ b/Build/CIScripts/BuildLinux.js
@@ -1,0 +1,75 @@
+var fs = require('fs-extra');
+var bcommon = require("./BuildCommon");
+var host = require("./Host");
+
+var buildDir = bcommon.artifactsRoot + "Build/Linux/";
+
+namespace('build', function() {
+
+  task('linux_player', {
+    async: true
+  }, function() {
+
+    var atomicTool = host.getAtomicToolBinary();
+
+    var playerBuildDir = buildDir + "AtomicPlayer/";
+
+    bcommon.cleanCreateDir(playerBuildDir);
+    bcommon.cleanCreateDir(bcommon.getGenScriptRootDir("MACOSX"));
+
+    process.chdir(playerBuildDir);
+
+    var cmds = [
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/Atomic/ LINUX",
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/AtomicPlayer/ LINUX",
+      "cmake -DATOMIC_DEV_BUILD=0 -DLINUX=1 ../../../../",
+      "make"
+    ];
+
+    jake.exec(cmds, function() {
+      var macPlayerBinary = playerBuildDir + "Source/AtomicPlayer/Application/Release/Contents/Linux/AtomicPlayer";
+      fs.copySync(macPlayerBinary, buildDir + "Bin/AtomicPlayer");
+      console.log("Built Linux Player");
+      complete();
+
+    }, {
+      printStdout: true
+    });
+
+  });
+
+  task('linux_editor', {
+    async: true
+  }, function() {
+
+    var atomicTool = host.getAtomicToolBinary();
+
+    var editorBuildDir = buildDir + "AtomicEditor/";
+
+    bcommon.cleanCreateDir(editorBuildDir);
+
+    process.chdir(editorBuildDir);
+
+    var cmds = [
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/Atomic/ LINUX",
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/AtomicPlayer/ LINUX",
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/ToolCore/ LINUX",
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/Editor/ LINUX",
+      atomicTool + " bind " + bcommon.atomicRoot + " Script/Packages/AtomicNET/ LINUX",
+      "cmake -DATOMIC_DEV_BUILD=0 -DLINUX=1 ../../../../",
+      "make"
+    ];
+
+    jake.exec(cmds, function() {
+      var macEditorBinary = editorBuildDir + "Source/AtomicEditor/Release/Contents/Linux/AtomicEditor";
+      fs.copySync(macEditorBinary, buildDir + "Bin/AtomicEditor");
+      console.log("Built Linux Editor");
+      complete();
+
+    }, {
+      printStdout: true
+    });
+
+  });
+
+}); // end of build namespace

--- a/Build/CIScripts/BuildLinux.js
+++ b/Build/CIScripts/BuildLinux.js
@@ -15,7 +15,7 @@ namespace('build', function() {
     var playerBuildDir = buildDir + "AtomicPlayer/";
 
     bcommon.cleanCreateDir(playerBuildDir);
-    bcommon.cleanCreateDir(bcommon.getGenScriptRootDir("MACOSX"));
+    bcommon.cleanCreateDir(bcommon.getGenScriptRootDir("LINUX"));
 
     process.chdir(playerBuildDir);
 

--- a/Build/CIScripts/Host.js
+++ b/Build/CIScripts/Host.js
@@ -15,3 +15,11 @@ if (os.platform() == "darwin") {
   require("./BuildWindows");
   require("./GenWindowsEditor");
 }
+else if (os.platform() == "linux") {
+  module.exports = require("./HostLinux");
+  require("./BuildLinux");
+  require("./BuildWeb");
+  require("./BuildAndroid");
+  require("./GenEditorData");
+  require("./GenLinuxEditor");
+}

--- a/Build/CIScripts/HostLinux.js
+++ b/Build/CIScripts/HostLinux.js
@@ -1,0 +1,53 @@
+var fs = require('fs-extra');
+var bcommon = require("./BuildCommon");
+
+var buildDir = bcommon.artifactsRoot + "Build/Mac/";
+var atomicToolBinary = buildDir + "Bin/AtomicTool";
+
+function clean() {
+
+  bcommon.testRemoveDir(buildDir);
+
+}
+
+function getAtomicToolBinary() {
+
+  return atomicToolBinary;
+
+}
+
+namespace('build', function() {
+
+  task('atomictool', {
+    async: true
+  }, function() {
+
+    var toolBuildDir = buildDir + "AtomicTool/";
+
+    bcommon.cleanCreateDir(toolBuildDir);
+
+    process.chdir(toolBuildDir);
+
+    var cmds = [
+      'cmake ../../../../ -DATOMICTOOL_NOGEN=1 -G Xcode',
+      'xcodebuild -target AtomicTool -configuration Release'
+    ]
+
+    jake.exec(cmds, function() {
+
+      var srcToolBinary = toolBuildDir + "Source/AtomicTool/Release/AtomicTool"
+      fs.copySync(srcToolBinary, atomicToolBinary);
+      console.log("Built MacOSX AtomicTool");
+      complete();
+
+    }, {
+      printStdout: true
+    });
+
+  });
+
+}); // end of build namespace
+
+
+exports.clean = clean;
+exports.getAtomicToolBinary = getAtomicToolBinary;

--- a/Build/CIScripts/HostLinux.js
+++ b/Build/CIScripts/HostLinux.js
@@ -1,7 +1,7 @@
 var fs = require('fs-extra');
 var bcommon = require("./BuildCommon");
 
-var buildDir = bcommon.artifactsRoot + "Build/Mac/";
+var buildDir = bcommon.artifactsRoot + "Build/Linux/";
 var atomicToolBinary = buildDir + "Bin/AtomicTool";
 
 function clean() {
@@ -29,15 +29,15 @@ namespace('build', function() {
     process.chdir(toolBuildDir);
 
     var cmds = [
-      'cmake ../../../../ -DATOMICTOOL_NOGEN=1 -G Xcode',
-      'xcodebuild -target AtomicTool -configuration Release'
+        cmds.push("cmake ../../../ -DATOMIC_DEV_BUILD=0 -DCMAKE_BUILD_TYPE=Release -DATOMIC_BUILD_2D=0 -DLINUX=1 ");
+        cmds.push("make AtomicTool")
     ]
 
     jake.exec(cmds, function() {
 
       var srcToolBinary = toolBuildDir + "Source/AtomicTool/Release/AtomicTool"
       fs.copySync(srcToolBinary, atomicToolBinary);
-      console.log("Built MacOSX AtomicTool");
+      console.log("Built Linux AtomicTool");
       complete();
 
     }, {

--- a/Build/CMake/Modules/AtomicDoc.cmake
+++ b/Build/CMake/Modules/AtomicDoc.cmake
@@ -1,0 +1,35 @@
+# create docs
+find_program(CLDOC cldoc)
+if(CLDOC)
+
+    get_property(include_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
+    get_directory_property( DEFS DIRECTORY ${CMAKE_SOURCE_DIR} COMPILE_DEFINITIONS )
+    
+    FOREACH(infileName ${include_dirs})
+        LIST(APPEND DOC_INCLUDES "-I${infileName}")
+    ENDFOREACH(infileName)
+
+    FOREACH(DefName ${DEFS})
+        LIST(APPEND DOC_DEFINES "-D${DefName}")
+    ENDFOREACH(DefName)
+
+    string(REGEX MATCHALL "([^\ ]+)" CXX_LIST "${CMAKE_CXX_FLAGS}")
+    string(REGEX MATCHALL "([^\ ]+)" C_LIST "${CMAKE_C_FLAGS}")
+
+    get_filename_component(COMPNAME ${CMAKE_CURRENT_SOURCE_DIR} NAME )
+    SET(TARGETNAME ${COMPNAME}Docs)
+
+    MESSAGE(STATUS "Enabling documentation for: " ${COMPNAME})
+
+    SET(doc_args generate ${CXX_LIST} ${C_LIST} -std=c++11 -DATOMIC_DEV_BUILD=1 ${DOC_DEFINES} ${DOC_INCLUDES} -- --type html --language c++ --output ${CMAKE_SOURCE_DIR}/Artifacts/Build/AtomicDocs )
+
+    LIST( APPEND doc_args ${SOURCE_FILES} )
+
+    add_custom_target(${TARGETNAME} COMMAND ${CLDOC} ${doc_args})
+  
+    set_target_properties(${TARGETNAME} PROPERTIES
+        EXCLUDE_FROM_ALL 1
+        EXCLUDE_FROM_DEFAULT_BUILD 1
+    )
+
+endif()

--- a/Build/CMake/Modules/AtomicDocList.cmake
+++ b/Build/CMake/Modules/AtomicDocList.cmake
@@ -1,7 +1,7 @@
 # create target to generate docs with clang based doc tool
-# NB: pretty brute force ATM
-if(EXISTS "/usr/local/bin/cldoc")
-   add_custom_target(AtomicEngineDocs 
+find_program(CLDOC cldoc)
+if(CLDOC)
+   add_custom_target(AtomicEngineDocs
     DEPENDS AtomicEditorDocs AtomicDocs
     )
 endif()

--- a/Build/CMake/Modules/AtomicDocList.cmake
+++ b/Build/CMake/Modules/AtomicDocList.cmake
@@ -1,0 +1,7 @@
+# create target to generate docs with clang based doc tool
+# NB: pretty brute force ATM
+if(EXISTS "/usr/local/bin/cldoc")
+   add_custom_target(AtomicEngineDocs 
+    DEPENDS AtomicEditorDocs AtomicDocs
+    )
+endif()

--- a/Build/CMake/Modules/AtomicLinux.cmake
+++ b/Build/CMake/Modules/AtomicLinux.cmake
@@ -1,6 +1,8 @@
+set (JAVASCRIPT_BINDINGS_PLATFORM "LINUX")
+set (ATOMIC_NODE_JAKE node Build/node_modules/jake/bin/cli.js  -f  Build/Scripts/Bootstrap.js)
+
 include(AtomicDesktop)
 
-set (JAVASCRIPT_BINDINGS_PLATFORM "LINUX")
 
 add_definitions(-DATOMIC_PLATFORM_LINUX -DATOMIC_OPENGL -DKNET_UNIX -DHAVE_INT64_T)
 

--- a/Build/Scripts/BuildCommon.js
+++ b/Build/Scripts/BuildCommon.js
@@ -25,7 +25,9 @@ namespace('build', function() {
           cmds.push(atomicRoot + "Build/Windows/node/node.exe " + atomicRoot + "Build/TypeScript/tsc.js -p " + atomicRoot + "Script");
         else if (os.platform() == "darwin")
           cmds.push(atomicRoot + "Build/Mac/node/node " + atomicRoot + "Build/TypeScript/tsc.js -p " + atomicRoot + "Script");
-
+        else if (os.platform() == "linux") {
+          cmds.push("node " + atomicRoot + "Build/TypeScript/tsc.js -p " + atomicRoot + "Script");
+        }
         jake.exec(cmds, function() {
 
           complete();

--- a/Build/Scripts/BuildLinux.js
+++ b/Build/Scripts/BuildLinux.js
@@ -1,0 +1,70 @@
+var fs = require('fs-extra');
+var path = require("path");
+var host = require("./Host");
+var atomicRoot = host.atomicRoot;
+
+var buildDir = host.artifactsRoot + "Build/Linux/";
+var editorAppFolder = host.artifactsRoot + "AtomicEditor/";
+
+namespace('build', function() {
+
+// Builds a standalone Atomic Editor, which can be distributed out of build tree
+task('atomiceditor', {
+  async: true
+}, function() {
+
+  // Clean build
+  var cleanBuild = true;
+  if (cleanBuild) {
+    common.cleanCreateDir(buildDir);
+    common.cleanCreateDir(editorAppFolder);
+    common.cleanCreateDir(host.getGenScriptRootDir("LINUX"));
+  }
+
+  // create the generated script files, so they will be picked up by cmake
+  host.createGenScriptFiles("LINUX");
+
+  process.chdir(buildDir);
+
+  var cmds = [];
+
+  cmds.push("cmake ../../../ -DATOMIC_DEV_BUILD=0 -DCMAKE_BUILD_TYPE=Release -DATOMIC_BUILD_2D=0 -DLINUX=1 ");
+  cmds.push("make GenerateScriptBindings")
+  cmds.push("make AtomicEditor AtomicPlayer")
+
+  jake.exec(cmds, function() {
+
+      // Copy the Editor binaries
+      fs.copySync(buildDir + "Source/AtomicEditor/AtomicEditor",
+        host.artifactsRoot + "AtomicEditor/AtomicEditor");
+
+      // We need some resources to run
+      fs.copySync(atomicRoot + "Resources/CoreData",
+        editorAppFolder + "Resources/CoreData");
+
+      fs.copySync(atomicRoot + "Resources/PlayerData",
+        editorAppFolder + "Resources/PlayerData");
+
+      fs.copySync(atomicRoot + "Data/AtomicEditor",
+        editorAppFolder + "Resources/ToolData");
+
+      fs.copySync(atomicRoot + "Resources/EditorData",
+        editorAppFolder + "Resources/EditorData");
+
+      fs.copySync(atomicRoot + "Artifacts/Build/Resources/EditorData/AtomicEditor/EditorScripts",
+        editorAppFolder + "Resources/EditorData/AtomicEditor/EditorScripts");
+
+      fs.copySync(buildDir +  "Source/AtomicPlayer/Application/AtomicPlayer",
+        editorAppFolder + "Resources/ToolData/Deployment/Linux/AtomicPlayer");
+
+    console.log("\n\nAtomic Editor build to " + editorAppFolder + "\n\n");
+
+    complete();
+
+  }, {
+    printStdout: true
+  });
+
+});
+
+});// end of build namespace

--- a/Build/Scripts/Host.js
+++ b/Build/Scripts/Host.js
@@ -7,6 +7,10 @@ if (os.platform() == "win32") {
   module.exports = require("./HostMac");
   require("./BuildMac");
 }
+else if (os.platform() == "linux") {
+  module.exports = require("./HostLinux");
+  require("./BuildLinux");
+}
 
 require("./BuildCommon");
 require("./BuildAndroid");

--- a/Build/Scripts/HostLinux.js
+++ b/Build/Scripts/HostLinux.js
@@ -1,0 +1,6 @@
+
+common = require("./HostCommon");
+
+// forward exports
+exports = module.exports = common;
+exports.atomicTool = exports.artifactsRoot + "Build/AtomicTool/AtomicTool";

--- a/Build_AtomicEditor.sh
+++ b/Build_AtomicEditor.sh
@@ -1,2 +1,11 @@
-#!/bin/sh
-./Build/Mac/node/node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+#!/usr/bin/env sh
+
+if [ "$(uname)" = "Darwin" ]; then
+	./Build/Mac/node/node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor  
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+	node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+elif [ "$(expr substr $(uname -s) 1 7)" = "MSYS_NT" ]; then
+    ./Build/Windows/node/node.exe ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+fi
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,4 +64,12 @@ elseif(EMSCRIPTEN)
 
 endif()
 
+find_program(CLDOC cldoc)
+if(CLDOC)
+
+   add_custom_target(docs 
+    DEPENDS AtomicEngineDocs
+    )
+endif()
+
 add_subdirectory(Source)

--- a/Script/Packages/AtomicNET/Package.json
+++ b/Script/Packages/AtomicNET/Package.json
@@ -4,5 +4,5 @@
   "namespace" : "Atomic",
   "dependencies" : ["Script/Packages/Atomic"],
   "modules" : ["NETCore", "NETScript"],
-  "platforms" : ["WINDOWS", "MACOSX"]
+  "platforms" : ["WINDOWS", "MACOSX","LINUX"]
 }

--- a/Source/Atomic/CMakeLists.txt
+++ b/Source/Atomic/CMakeLists.txt
@@ -102,3 +102,5 @@ GroupSources("UI")
 GroupSources("Web")
 
 add_library(Atomic ${SOURCE_FILES})
+
+include(AtomicDoc)

--- a/Source/AtomicEditor/Application/AEPlayerApp.cpp
+++ b/Source/AtomicEditor/Application/AEPlayerApp.cpp
@@ -84,7 +84,7 @@ void AEPlayerApplication::Setup()
 
     engineParameters_["LogLevel"] = LOG_DEBUG;
 
-#if ATOMIC_PLATFORM_WINDOWS
+#if ATOMIC_PLATFORM_WINDOWS || ATOMIC_PLATFORM_LINUX
     engineParameters_["WindowIcon"] = "Images/AtomicLogo32.png";
     engineParameters_["ResourcePrefixPath"] = "AtomicPlayer_Resources";
 #elif ATOMIC_PLATFORM_ANDROID

--- a/Source/AtomicEditor/CMakeLists.txt
+++ b/Source/AtomicEditor/CMakeLists.txt
@@ -71,3 +71,5 @@ GroupSources("Javascript")
 GroupSources("PlayerMode")
 GroupSources("Utils")
 GroupSources("Components")
+
+include(AtomicDoc)

--- a/Source/AtomicPlayer/Application/AtomicPlayer.cpp
+++ b/Source/AtomicPlayer/Application/AtomicPlayer.cpp
@@ -96,7 +96,7 @@ void AtomicPlayerApp::Setup()
     engineParameters_.InsertNew("ResourcePaths", "AtomicResources");
 #endif
 
-#if ATOMIC_PLATFORM_WINDOWS
+#if ATOMIC_PLATFORM_WINDOWS || ATOMIC_PLATFORM_LINUX
 
     engineParameters_.InsertNew("WindowIcon", "Images/AtomicLogo32.png");
     engineParameters_.InsertNew("ResourcePrefixPath", "AtomicPlayer_Resources");

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -13,3 +13,5 @@ if (NOT IOS AND NOT ANDROID AND NOT EMSCRIPTEN)
     add_subdirectory(Tools)
     add_subdirectory(AtomicNET)
 endif()
+
+include(AtomicDocList)

--- a/Source/ThirdParty/nativefiledialog/nfd_gtk.c
+++ b/Source/ThirdParty/nativefiledialog/nfd_gtk.c
@@ -213,9 +213,10 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
 
         result = NFD_OKAY;
     }
-
-    WaitForCleanup();
+ 
+   
     gtk_widget_destroy(dialog);
+    WaitForCleanup();
 
     return result;
 }
@@ -261,8 +262,8 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
         result = NFD_OKAY;
     }
 
-    WaitForCleanup();
     gtk_widget_destroy(dialog);
+    WaitForCleanup();
 
     return result;
 }

--- a/Source/ToolCore/ToolEnvironment.cpp
+++ b/Source/ToolCore/ToolEnvironment.cpp
@@ -42,6 +42,9 @@ bool ToolEnvironment::InitFromPackage()
 #ifdef ATOMIC_PLATFORM_WINDOWS
 	editorBinary_ = fileSystem->GetProgramDir() + "AtomicEditor.exe";
     String resourcesDir = fileSystem->GetProgramDir() + "Resources/";
+#elif ATOMIC_PLATFORM_LINUX
+    editorBinary_ = fileSystem->GetProgramDir() + "AtomicEditor";
+    String resourcesDir = fileSystem->GetProgramDir() + "Resources/";
 #else
     editorBinary_ = fileSystem->GetProgramDir() + "AtomicEditor";
     String resourcesDir = GetPath(RemoveTrailingSlash(fileSystem->GetProgramDir())) + "Resources/";
@@ -92,6 +95,8 @@ bool ToolEnvironment::InitFromJSON(bool atomicTool)
 
 #ifdef ATOMIC_PLATFORM_WINDOWS
         netCoreCLRAbsPath_ = GetNativePath(ToString("%s/Submodules/CoreCLR/Windows/Release/x64/", ATOMIC_ROOT_SOURCE_DIR));
+#elif ATOMIC_PLATFORM_LINUX
+        netCoreCLRAbsPath_ = GetNativePath(ToString("%s/Submodules/CoreCLR/Linux/Debug/x64/", ATOMIC_ROOT_SOURCE_DIR));
 #else
         netCoreCLRAbsPath_ = GetNativePath(ToString("%s/Submodules/CoreCLR/MacOSX/Debug/x64/", ATOMIC_ROOT_SOURCE_DIR));
 #endif
@@ -147,6 +152,8 @@ const String& ToolEnvironment::GetDevConfigFilename()
     devConfigFilename_ = fileSystem->GetUserDocumentsDir() + ".atomicgameengine/toolEnv.json";
 #elif ATOMIC_PLATFORM_WINDOWS
     devConfigFilename_ = fileSystem->GetUserDocumentsDir() + "AtomicGameEngine/toolEnv.json";
+#else
+    devConfigFilename_ = fileSystem->GetUserDocumentsDir() + ".atomicgameengine/toolEnv.json";
 #endif
 
     return devConfigFilename_;
@@ -198,6 +205,10 @@ void ToolEnvironment::SetRootBuildDir(const String& buildDir, bool setBinaryPath
         playerAppFolder_ = rootBuildDir_ + "Source/AtomicPlayer/Application/AtomicPlayer.app/";
         editorBinary_ = rootBuildDir_ + "Source/AtomicEditor/AtomicEditor.app/Contents/MacOS/AtomicEditor";
 #endif
+
+#else
+        playerBinary_ = rootBuildDir_ + "Source/AtomicPlayer/Application/AtomicPlayer";
+        editorBinary_ = rootBuildDir_ + "Source/AtomicEditor/AtomicEditor";
 
 #endif
     }


### PR DESCRIPTION
changes to build scripts and source to enable Linux builds. I also added a cmake target to build documentation with cldoc, but it still needs some work. Build_AtomicEditor.sh can now be run from the root and on completion the editor can be run from Artifacts/AtomicEditor.