### PR TITLE
Fixes for #529

### DIFF
--- a/Script/AtomicEditor/ui/frames/WelcomeFrame.ts
+++ b/Script/AtomicEditor/ui/frames/WelcomeFrame.ts
@@ -50,6 +50,20 @@ class WelcomeFrame extends ScriptWidget {
 
     addExample(example: ProjectTemplates.ProjectTemplateDefinition) {
 
+        var fileSystem = Atomic.getFileSystem();
+
+        // Verify that at least one of the projects for this example exists, otherwise bounce out
+        let exists = false;
+        example.templates.forEach(template => {
+            if (fileSystem.dirExists(template.folder)) {
+                exists = true;
+            }
+        });
+
+        if (!exists) {
+            return;
+        }
+
         var exlayout = <Atomic.UILayout>this.getWidget("examples_layout");
 
         if (!this.currentExampleLayout) {

--- a/Script/AtomicEditor/ui/modal/CreateProject.ts
+++ b/Script/AtomicEditor/ui/modal/CreateProject.ts
@@ -98,7 +98,7 @@ class CreateProject extends ModalWindow {
             }
 
             // Do the creation!
-            if (templateDetail) {
+            if (templateDetail && fileSystem.dirExists(templateDetail.folder)) {
 
                 fileSystem.copyDir(templateDetail.folder, folder);
 
@@ -127,7 +127,15 @@ class CreateProject extends ModalWindow {
                 this.sendEvent(EditorEvents.LoadProject, { path: folder });
                 return true;
             } else {
-                var message = "Unable to create project for language:  " + selectedLanguage + "\n\nPlease choose a different language";
+                let message = [
+                    "Unable to create project for:",
+                    "",
+                    `language: ${selectedLanguage}`,
+                    `template: ${templateDetail.folder}`,
+                    "",
+                    "Please choose a different language."
+                ].join("\n");
+
                 EditorUI.showModalError("New Project Editor Error", message);
                 return false;
             }


### PR DESCRIPTION
* added a check in the welcome screen to verify that an example project exists on the file system before adding it to the example browser
* added a check to the CreateProject dialog to verify that the template to clone from exists before trying to clone it