### PR TITLE
Make CMake in Linux work correctly.

### DIFF
--- a/Build/CMake/Modules/AtomicLinux.cmake
+++ b/Build/CMake/Modules/AtomicLinux.cmake
@@ -1,5 +1,5 @@
 set (JAVASCRIPT_BINDINGS_PLATFORM "LINUX")
-set (ATOMIC_NODE_JAKE node Build/node_modules/jake/bin/cli.js  -f  Build/Scripts/Bootstrap.js)
+set (ATOMIC_NODE_JAKE Build/Linux/node/node Build/node_modules/jake/bin/cli.js  -f  Build/Scripts/Bootstrap.js)
 
 include(AtomicDesktop)
 

--- a/Build/CMake/Modules/AtomicUtils.cmake
+++ b/Build/CMake/Modules/AtomicUtils.cmake
@@ -26,6 +26,6 @@ macro(GroupSources curdir)
 
 endmacro()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(NOT CMAKE_CROSSCOMPILING AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   set(LINUX TRUE CACHE BOOL "Indicates if host is Linux.")
 endif()

--- a/Build/CMake/Modules/AtomicUtils.cmake
+++ b/Build/CMake/Modules/AtomicUtils.cmake
@@ -25,3 +25,7 @@ macro(GroupSources curdir)
     endif()
 
 endmacro()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set(LINUX TRUE CACHE BOOL "Indicates if host is Linux.")
+endif()

--- a/Build/Scripts/BuildCommon.js
+++ b/Build/Scripts/BuildCommon.js
@@ -26,7 +26,7 @@ namespace('build', function() {
         else if (os.platform() == "darwin")
           cmds.push(atomicRoot + "Build/Mac/node/node " + atomicRoot + "Build/TypeScript/tsc.js -p " + atomicRoot + "Script");
         else if (os.platform() == "linux") {
-          cmds.push("node " + atomicRoot + "Build/TypeScript/tsc.js -p " + atomicRoot + "Script");
+          cmds.push(atomicRoot + "Build/Linux/node/node " + atomicRoot + "Build/TypeScript/tsc.js -p " + atomicRoot + "Script");
         }
         jake.exec(cmds, function() {
 

--- a/Build/Scripts/Host.js
+++ b/Build/Scripts/Host.js
@@ -6,8 +6,7 @@ if (os.platform() == "win32") {
 } else if (os.platform() == "darwin") {
   module.exports = require("./HostMac");
   require("./BuildMac");
-}
-else if (os.platform() == "linux") {
+} else if (os.platform() == "linux") {
   module.exports = require("./HostLinux");
   require("./BuildLinux");
 }

--- a/Source/AtomicEditor/CMakeLists.txt
+++ b/Source/AtomicEditor/CMakeLists.txt
@@ -25,9 +25,8 @@ if (APPLE)
     set(ATOMIC_EDITOR_ICON ${CMAKE_SOURCE_DIR}/Build/CMake/Modules/Atomic.icns)
     set_source_files_properties(${ATOMIC_EDITOR_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 
-elseif(LINUX)
-
 else()
+
     include_directories (${CMAKE_SOURCE_DIR}/Source/ThirdParty/libcurl/include)
     add_definitions(-DCURL_STATICLIB)
 
@@ -36,6 +35,7 @@ else()
     add_definitions(-DATOMIC_WIN32_CONSOLE)
 
     set (SOURCE_FILES ${SOURCE_FILES} ${CMAKE_SOURCE_DIR}/Build/CMake/Modules/Atomic.rc)
+
 endif(APPLE)
 
 add_executable(AtomicEditor ${EXE_TYPE} ${SOURCE_FILES} ${ATOMIC_EDITOR_ICON})
@@ -45,10 +45,10 @@ target_link_libraries(AtomicEditor ToolCore AtomicJS AtomicPlayerJS AtomicNETJS 
 if (APPLE)
     set (TARGET_PROPERTIES MACOSX_BUNDLE_INFO_PLIST MacOSXBundleInfo.plist.template)
 
-    target_link_libraries(AtomicEditor NETCore NETScript curl)
+    target_link_libraries(AtomicEditor NETCore NETScript libcurl)
 
 elseif(LINUX)
-    target_link_libraries(AtomicEditor NETCore NETScript curl nativefiledialog ${GTK3_LIBRARIES})
+    target_link_libraries(AtomicEditor NETCore NETScript libcurl nativefiledialog ${GTK3_LIBRARIES})
 
 else()
     target_link_libraries(AtomicEditor NETCore NETScript libcurl Iphlpapi Wldap32)

--- a/Source/AtomicPlayer/Application/CMakeLists.txt
+++ b/Source/AtomicPlayer/Application/CMakeLists.txt
@@ -39,19 +39,19 @@ if (MSVC)
   COMMAND ${CMAKE_COMMAND}
   ARGS -E copy_if_different \"${D3DCOMPILER_47_DLL}\" \"$<TARGET_FILE_DIR:AtomicPlayer>/D3DCompiler_47.dll\")
 
-    target_link_libraries(AtomicPlayer NETCore NETScript)
+  target_link_libraries(AtomicPlayer NETCore NETScript)
+endif(MSVC)
 
-endif()
 
 if (APPLE)
 
-if (NOT IOS)
+  if (NOT IOS)
 
     target_link_libraries(AtomicPlayer NETCore NETScript)
 
     set (TARGET_PROPERTIES MACOSX_BUNDLE_INFO_PLIST MacOSXBundleInfo.plist.template)
 
-else()
+  else()
 
     set_target_properties(AtomicPlayer PROPERTIES
       MACOSX_BUNDLE_GUI_IDENTIFIER "com.atomicgameengine.atomicplayer"
@@ -65,8 +65,17 @@ else()
 
     set (TARGET_PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/Build/CMake/Modules/iOSBundleInfo.plist.template)
 
-endif()
+  endif()
+
 endif(APPLE)
+
+
+if (LINUX)
+
+    target_link_libraries(AtomicPlayer NETCore NETScript)
+
+endif(LINUX)
+
 
 if (TARGET_PROPERTIES)
     set_target_properties (AtomicPlayer PROPERTIES ${TARGET_PROPERTIES})

--- a/Source/AtomicTool/CMakeLists.txt
+++ b/Source/AtomicTool/CMakeLists.txt
@@ -18,7 +18,7 @@ if (MSVC)
     ARGS -E copy_if_different \"${D3DCOMPILER_47_DLL}\" \"$<TARGET_FILE_DIR:AtomicTool>/D3DCompiler_47.dll\")
 
 else()
-    target_link_libraries(AtomicTool curl)
+    target_link_libraries(AtomicTool libcurl)
 endif()
 
 add_custom_command( TARGET AtomicTool POST_BUILD

--- a/Source/ToolCore/CMakeLists.txt
+++ b/Source/ToolCore/CMakeLists.txt
@@ -1,14 +1,10 @@
 include_directories (${CMAKE_SOURCE_DIR}/Source/ThirdParty/rapidjson/include
                      ${CMAKE_SOURCE_DIR}/Source/ThirdParty
                      ${CMAKE_SOURCE_DIR}/Source/ThirdParty/Assimp/include
-                     ${CMAKE_SOURCE_DIR}/Source/ThirdParty/nativefiledialog)
+                     ${CMAKE_SOURCE_DIR}/Source/ThirdParty/nativefiledialog
+                     ${CMAKE_SOURCE_DIR}/Source/ThirdParty/libcurl/include)
 
-add_definitions(-DCPLUSPLUS_WITHOUT_QT)
-
-if (MSVC)
-    include_directories (${CMAKE_SOURCE_DIR}/Source/ThirdParty/libcurl/include)
-    add_definitions(-DCURL_STATICLIB)
-endif()
+add_definitions(-DCPLUSPLUS_WITHOUT_QT -DCURL_STATICLIB)
 
 file (GLOB_RECURSE SOURCE_FILES *.cpp *.h)
 
@@ -19,7 +15,7 @@ endif()
 
 add_library(ToolCore ${SOURCE_FILES})
 
-target_link_libraries(ToolCore Assimp Poco)
+target_link_libraries(ToolCore Assimp Poco libcurl)
 
 if (LINUX)
     target_link_libraries(ToolCore NETCore NETScript)


### PR DESCRIPTION
I made a bare Ubuntu VM to see if I could compile Atomic, and I ran into quite a few pitfalls. The first few of those are documented in AtomicGameEngine/AtomicGameEngine#555 . The last few were related to node and libcurl not being present on my bare Ubuntu machine, although they are (or should be) available in the Atomic repo itself. I added node, and linked the correct libcurl. There were also some linker errors due to NETCore and NETScript not being linked in Linux. We could (probably should) automatically set the CMAKE variable LINUX to TRUE in cache if the CMAKE_SYSTEM_NAME is "Linux" instead of requiring it to be set on the cmake command line.

All of that is fixed with this PR, so hopefully this will help the Linux build along.