### PR TITLE
Fixing UIView resize behavior.

### DIFF
--- a/Source/Atomic/UI/UIView.cpp
+++ b/Source/Atomic/UI/UIView.cpp
@@ -24,6 +24,7 @@
 
 #include "UI.h"
 #include "UIView.h"
+#include "../Graphics/GraphicsEvents.h"
 
 using namespace tb;
 
@@ -38,16 +39,30 @@ UIView::UIView(Context* context) : UIWidget(context, false)
 
     UI* ui = GetSubsystem<UI>();
 
+    SubscribeToEvent(E_SCREENMODE, HANDLER(UIView, HandleScreenMode));
+
     TBRect rect = ui->GetRootWidget()->GetRect();
     widget_->SetSize(rect.w, rect.h);
 
     ui->GetRootWidget()->AddChild(widget_);
-
 }
 
 UIView::~UIView()
 {
+    // UIWidget calls UnsubscribeFromAllEvents(),
+    // so we don't need to do anything here.
+}
 
+void UIView::HandleScreenMode(StringHash eventType, VariantMap& eventData)
+{
+    TBWidget* root = widget_->GetParent();
+    if (!root)
+    {
+        UI* ui = GetSubsystem<UI>();
+        root = ui->GetRootWidget();
+    }
+
+    widget_->SetRect(root->GetRect());
 }
 
 

--- a/Source/Atomic/UI/UIView.h
+++ b/Source/Atomic/UI/UIView.h
@@ -38,6 +38,7 @@ public:
     virtual ~UIView();
 
 protected:
+    virtual void HandleScreenMode(StringHash eventType, VariantMap& eventData);
 
 private:
 


### PR DESCRIPTION
A UIView size object never gets updated after it's created. Since many other UIWidget objects size themselves based on their parent's size, any resize causes the UI to misbehave.

Many of the AtomicExamples suffer from this problem, so for an example of what this PR fixes, try ParticleEmitter3D, which has buttons on the right side of the window. Re-size the window, or make it fullscreen, and the buttons stay where they were relative to the top-left corner of the window, so they no longer are on the right side of the screen. Another example is SpaceGame, where after startup, the menu screen (and Ok button) have similar behavior.

The AtomicEditor seems pretty good about keeping things in the right place, but even it suffers from this problem: Try making a subwindow appear, such as when the Player Output window appears when running the player, then resize the main editor window. The subwindow stays relative to where it was, which is fine, even expected. Then, close the subwindow and make it reappear (relaunch the player), and although .center() was called on it in the .ts file, it centers based on the original window size, not the new window size.

This PR fixes everything described above.