### PR TITLE
Fix potential crash issue when dragging a widget on top of itself

### DIFF
--- a/Source/Atomic/UI/UIDragDrop.cpp
+++ b/Source/Atomic/UI/UIDragDrop.cpp
@@ -86,7 +86,8 @@ UIDragDrop::~UIDragDrop()
 void UIDragDrop::DragEnd()
 {
     SharedPtr<UIDragObject> dragObject = dragObject_;
-    WeakPtr<UIWidget> currentTargetWidget = currentTargetWidget_;
+    SharedPtr<UIWidget> currentTargetWidget(currentTargetWidget_);
+    SharedPtr<UIWidget> dragSourceWidget(dragSourceWidget_);
 
     // clean up
     currentTargetWidget_ = 0;
@@ -94,7 +95,7 @@ void UIDragDrop::DragEnd()
     dragSourceWidget_ = 0;
     dragLayout_->SetVisibility(UI_WIDGET_VISIBILITY_GONE);
 
-    if (currentTargetWidget.Null())
+    if (currentTargetWidget.Null() || dragSourceWidget == currentTargetWidget)
     {
         return;
     }

--- a/Source/Atomic/UI/UIDragDrop.h
+++ b/Source/Atomic/UI/UIDragDrop.h
@@ -64,8 +64,8 @@ private:
     SharedPtr<UIImageWidget> dragImage_;
     SharedPtr<UITextField> dragText_;
 
-    WeakPtr<UIWidget> currentTargetWidget_;
-    WeakPtr<UIWidget> dragSourceWidget_;
+    SharedPtr<UIWidget> currentTargetWidget_;
+    SharedPtr<UIWidget> dragSourceWidget_;
 
     SharedPtr<UIDragObject> dragObject_;
 


### PR DESCRIPTION
Also don't send drop event when dropping widget on top of self