### PR TITLE
HiDPI support in Atomic Player title bar on Mac OSX

### DIFF
--- a/Data/AtomicEditor/Deployment/MacOS/AtomicPlayer.app/Contents/Info.plist
+++ b/Data/AtomicEditor/Deployment/MacOS/AtomicPlayer.app/Contents/Info.plist
@@ -39,5 +39,7 @@
         <key>URHO3D_PREFIX_PATH</key>
         <string>../Resources</string>
     </dict>
+    <key>NSHighResolutionCapable</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
before
<img width="233" alt="hidpi_before" src="https://cloud.githubusercontent.com/assets/2587873/13902819/390e2e52-ee9e-11e5-9a63-f48dfda34659.png">

after
<img width="243" alt="hidpi_after" src="https://cloud.githubusercontent.com/assets/2587873/13902820/432aa10e-ee9e-11e5-990a-6ead96aca893.png">