### PR TITLE
Shift drag cloning

### DIFF
--- a/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.cpp
@@ -38,9 +38,9 @@ namespace AtomicEditor
 {
 
 
-	Gizmo3D::Gizmo3D(Context* context) : Object(context),
-		dragging_(false),
-		cloning_(false)
+    Gizmo3D::Gizmo3D(Context* context) : Object(context),
+        dragging_(false),
+        cloning_(false)
 {
     ResourceCache* cache = GetSubsystem<ResourceCache>();
 
@@ -185,16 +185,16 @@ void Gizmo3D::Use()
     Ray cameraRay = view3D_->GetCameraRay();
     float scale = gizmoNode_->GetScale().x_;
 
-	// Clones an object when it's dragged while holding down Shift
-	bool dragShift = input->GetMouseButtonDown(MOUSEB_LEFT) && input->GetKeyDown(KEY_SHIFT);
+    // Clones an object when it's dragged while holding down Shift
+    bool dragShift = input->GetMouseButtonDown(MOUSEB_LEFT) && input->GetKeyDown(KEY_SHIFT);
 
-	if (dragShift && !cloning_)
-	{
-		cloning_ = true;
-		selection_->Copy();
-		selection_->Paste();
-	}
-	
+    if (dragShift && !cloning_)
+    {
+        cloning_ = true;
+        selection_->Copy();
+        selection_->Paste();
+    }
+
     // Recalculate axes only when not left-dragging
     bool drag = input->GetMouseButtonDown(MOUSEB_LEFT);// && (Abs(input->GetMouseMoveX()) > 3 || Abs(input->GetMouseMoveY()) > 3);
     if (!drag)
@@ -204,11 +204,8 @@ void Gizmo3D::Use()
             scene_->SendEvent(E_SCENEEDITEND);
             dragging_ = false;
         }
-		
-		if (cloning_)
-		{
-			cloning_ = false;
-		}
+
+        cloning_ = false;
 
         CalculateGizmoAxes();
     }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.cpp
@@ -38,8 +38,9 @@ namespace AtomicEditor
 {
 
 
-Gizmo3D::Gizmo3D(Context* context) : Object(context),
-    dragging_(false)
+	Gizmo3D::Gizmo3D(Context* context) : Object(context),
+		dragging_(false),
+		cloning_(false)
 {
     ResourceCache* cache = GetSubsystem<ResourceCache>();
 
@@ -184,6 +185,16 @@ void Gizmo3D::Use()
     Ray cameraRay = view3D_->GetCameraRay();
     float scale = gizmoNode_->GetScale().x_;
 
+	// Clones an object when it's dragged while holding down Shift
+	bool dragShift = input->GetMouseButtonDown(MOUSEB_LEFT) && input->GetKeyDown(KEY_SHIFT);
+
+	if (dragShift && !cloning_)
+	{
+		cloning_ = true;
+		selection_->Copy();
+		selection_->Paste();
+	}
+	
     // Recalculate axes only when not left-dragging
     bool drag = input->GetMouseButtonDown(MOUSEB_LEFT);// && (Abs(input->GetMouseMoveX()) > 3 || Abs(input->GetMouseMoveY()) > 3);
     if (!drag)
@@ -193,6 +204,11 @@ void Gizmo3D::Use()
             scene_->SendEvent(E_SCENEEDITEND);
             dragging_ = false;
         }
+		
+		if (cloning_)
+		{
+			cloning_ = false;
+		}
 
         CalculateGizmoAxes();
     }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.h
@@ -184,7 +184,7 @@ private:
     AxisMode axisMode_;
 
     bool dragging_;
-	bool cloning_;
+    bool cloning_;
 
     // snap settings
     float snapTranslationX_;

--- a/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/Gizmo3D.h
@@ -184,6 +184,7 @@ private:
     AxisMode axisMode_;
 
     bool dragging_;
+	bool cloning_;
 
     // snap settings
     float snapTranslationX_;


### PR DESCRIPTION
Hi @JoshEngebretson 

This PR allows the users to clone objects in the Scene by holding down on Shift and Dragging the object. 

Let me know if you'd like anything changed! :)