### PR TITLE
Fix for missing keystrokes in the code editor on OSX.

### DIFF
--- a/Source/ThirdParty/SDL/src/video/cocoa/SDL_cocoaevents.m
+++ b/Source/ThirdParty/SDL/src/video/cocoa/SDL_cocoaevents.m
@@ -50,6 +50,8 @@
     SDL_SendQuit();
 }
 
+// ATOMIC: Fixes missing WebView keystrokes on OSX
+// (see https://bugzilla.libsdl.org/show_bug.cgi?id=3107)
 // Dispatch events here so that we can handle events caught by
 // nextEventMatchingMask in SDL, as well as events caught by other
 // processes (such as CEF) that are passed down to NSApp.

--- a/Source/ThirdParty/SDL/src/video/cocoa/SDL_cocoaevents.m
+++ b/Source/ThirdParty/SDL/src/video/cocoa/SDL_cocoaevents.m
@@ -39,7 +39,7 @@
 @interface SDLApplication : NSApplication
 
 - (void)terminate:(id)sender;
-
+- (void)sendEvent:(NSEvent *)theEvent;
 @end
 
 @implementation SDLApplication
@@ -48,6 +48,39 @@
 - (void)terminate:(id)sender
 {
     SDL_SendQuit();
+}
+
+// Dispatch events here so that we can handle events caught by
+// nextEventMatchingMask in SDL, as well as events caught by other
+// processes (such as CEF) that are passed down to NSApp.
+- (void)sendEvent:(NSEvent *)theEvent
+{
+    SDL_VideoDevice *_this = SDL_GetVideoDevice();
+
+    switch ([theEvent type]) {
+        case NSLeftMouseDown:
+        case NSOtherMouseDown:
+        case NSRightMouseDown:
+        case NSLeftMouseUp:
+        case NSOtherMouseUp:
+        case NSRightMouseUp:
+        case NSLeftMouseDragged:
+        case NSRightMouseDragged:
+        case NSOtherMouseDragged: /* usually middle mouse dragged */
+        case NSMouseMoved:
+        case NSScrollWheel:
+            Cocoa_HandleMouseEvent(_this, theEvent);
+            break;
+        case NSKeyDown:
+        case NSKeyUp:
+        case NSFlagsChanged:
+            Cocoa_HandleKeyEvent(_this, theEvent);
+            break;
+        default:
+            break;
+    }
+
+    [super sendEvent:theEvent];
 }
 
 @end // SDLApplication
@@ -316,28 +349,6 @@ Cocoa_PumpEvents(_THIS)
             break;
         }
 
-        switch ([event type]) {
-        case NSLeftMouseDown:
-        case NSOtherMouseDown:
-        case NSRightMouseDown:
-        case NSLeftMouseUp:
-        case NSOtherMouseUp:
-        case NSRightMouseUp:
-        case NSLeftMouseDragged:
-        case NSRightMouseDragged:
-        case NSOtherMouseDragged: /* usually middle mouse dragged */
-        case NSMouseMoved:
-        case NSScrollWheel:
-            Cocoa_HandleMouseEvent(_this, event);
-            break;
-        case NSKeyDown:
-        case NSKeyUp:
-        case NSFlagsChanged:
-            Cocoa_HandleKeyEvent(_this, event);
-            break;
-        default:
-            break;
-        }
         /* Pass through to NSApp to make sure everything stays in sync */
         [NSApp sendEvent:event];
     }


### PR DESCRIPTION
Turns out this is a bug when using CEF with SDL: https://bugzilla.libsdl.org/show_bug.cgi?id=3107.
I have tested this fix and it works great for me - no more missing keystrokes in the code editor.