### PR TITLE
Ease of use fixes for some TS Bindings

### DIFF
--- a/Script/Packages/Atomic/Core.json
+++ b/Script/Packages/Atomic/Core.json
@@ -19,8 +19,8 @@
 
 		"Object" : [
 			"sendEvent(eventType:string, data?:Object);",
-			"subscribeToEvent(eventType:string, callback:(data:any)=>void);",
-			"subscribeToEvent(sender:AObject, eventType:string, callback:(data:any)=>void);"
+			"subscribeToEvent(eventType:string, callback:(data:any) => void);",
+			"subscribeToEvent(sender:AObject, eventType:string, callback:(data: any) => void);"
 		]
 	},
 	"haxe_decl" : {

--- a/Script/Packages/Atomic/Scene.json
+++ b/Script/Packages/Atomic/Scene.json
@@ -42,7 +42,8 @@
 			"getComponent<T extends Atomic.Component>(type: string): T;",
 			"getChildAtIndex(index:number):Node;",
 			"createJSComponent(name:string, args?:{});",
-			"getJSComponent(name:string, recursive?:boolean):JSComponent;",
+			"getJSComponent(name:string, recursive?:boolean): JSComponent;",
+			"getJSComponent<T extends Atomic.JSComponent>(name:string, recursive?:boolean): T;",
 			"createChildPrefab(childName:string, prefabPath:string):Node;",
 			"loadPrefab(prefabPath:string):boolean;",
 			"createComponent<T extends Atomic.Component>(type: string, mode?: CreateMode, id?: number): T;",
@@ -52,7 +53,7 @@
 			"getMainCamera():Camera;"
 		],
 		"Component": [
-		    "getComponent<T extends Atomic.Component>(type: string):T;"
+		    "getComponent<T extends Atomic.Component>(type: string): T;"
 		]
 	},
 	"haxe_decl" : {

--- a/Script/Packages/Atomic/Scene.json
+++ b/Script/Packages/Atomic/Scene.json
@@ -39,14 +39,20 @@
 			"getChildrenWithName(name:string, recursive?:boolean):Node[];",
 			"getChildrenWithComponent(componentType:string, recursive?:boolean):Node[];",
 			"getComponents(componentType?:string, recursive?:boolean):Component[];",
+			"getComponent<T extends Atomic.Component>(type: string): T;",
 			"getChildAtIndex(index:number):Node;",
 			"createJSComponent(name:string, args?:{});",
 			"getJSComponent(name:string, recursive?:boolean):JSComponent;",
 			"createChildPrefab(childName:string, prefabPath:string):Node;",
-			"loadPrefab(prefabPath:string):boolean;"
+			"loadPrefab(prefabPath:string):boolean;",
+			"createComponent<T extends Atomic.Component>(type: string, mode?: CreateMode, id?: number): T;",
+			"getOrCreateComponent<T extends Atomic.Component>(type: string, mode?: CreateMode, id?: number): T;"
 		],
 		"Scene" : [
 			"getMainCamera():Camera;"
+		],
+		"Component": [
+		    "getComponent<T extends Atomic.Component>(type: string):T;"
 		]
 	},
 	"haxe_decl" : {


### PR DESCRIPTION
While building some examples, I made some hand modifications to atomic.d.ts.  This incorporates them into the official script bindings as well as fixes some linting issues with the generated bindings.

Currently, getting a strongly typed component from a node requires you to cast the result:
``` typescript
let node = <Atomic.Sprite2D>this.node.getComponent("Sprite2D");
```

This change adds the following signature overload in addition to the current signature:
```typescript
let node = this.node.getComponent<Atomic.Sprite2D>("Sprite2D");
```
What this does is auto-casts the result to the component and ensures that the generic type being cast in is actually a descendent of Atomic.Component.  The same goes for ```Node.getJSComponent```, ```Node.createComponent```, ```Node.getOrCreateComponent```, and ```Component.getComponent```

Without this check, the TypeScript compiler would not catch such mis-uses as:
```typescript
let node = <string> this.node.getComponent("Sprite2D");
```