### PR TITLE
Issue #691 Profiler should exclude data from profiler output

### DIFF
--- a/Resources/EditorData/AtomicEditor/resources/default_skin/skin.tb.txt
+++ b/Resources/EditorData/AtomicEditor/resources/default_skin/skin.tb.txt
@@ -15,7 +15,7 @@ defaults
 	placeholder
 		opacity 0.2
 	disabled
-		opacity 0.3
+		opacity 1
 elements
 	TBButton
 		text-color #fefefe

--- a/Resources/EditorData/AtomicEditor/resources/default_skin/skin.tb.txt
+++ b/Resources/EditorData/AtomicEditor/resources/default_skin/skin.tb.txt
@@ -15,7 +15,7 @@ defaults
 	placeholder
 		opacity 0.2
 	disabled
-		opacity 1
+		opacity 0.3
 elements
 	TBButton
 		text-color #fefefe

--- a/Source/Atomic/Graphics/Direct3D11/D3D11Graphics.h
+++ b/Source/Atomic/Graphics/Direct3D11/D3D11Graphics.h
@@ -293,6 +293,9 @@ public:
     /// Return whether Direct3D device is lost, and can not yet render. Always false on D3D11.
     bool IsDeviceLost() const { return false; }
 
+    /// Return number of True primitives drawn this frame.
+    unsigned GetSinglePassPrimitives() const { return numSinglePassPrimitives_; }
+
     /// Return number of primitives drawn this frame.
     unsigned GetNumPrimitives() const { return numPrimitives_; }
 
@@ -510,7 +513,13 @@ public:
     IntVector2 GetMonitorResolution(int monitorId) const;
     // ATOMIC END
 
+    int GetNumPasses() { return numPasses_; }
+    void ResetNumPasses() { numPasses_ = 0; }
+    void IncNumPasses() { numPasses_++; }
+
 private:
+    int numPasses_;
+
     /// Create the application window.
     bool OpenWindow(int width, int height, bool resizable, bool borderless);
     /// Create the application window icon.
@@ -576,6 +585,8 @@ private:
     bool sRGBSupport_;
     /// sRGB conversion on write support flag.
     bool sRGBWriteSupport_;
+    ///Number of true primitives
+    unsigned numSinglePassPrimitives_;
     /// Number of primitives this frame.
     unsigned numPrimitives_;
     /// Number of batches this frame.

--- a/Source/Atomic/Graphics/Direct3D9/D3D9Graphics.cpp
+++ b/Source/Atomic/Graphics/Direct3D9/D3D9Graphics.cpp
@@ -261,6 +261,7 @@ Graphics::Graphics(Context* context) :
     instancingSupport_(false),
     sRGBSupport_(false),
     sRGBWriteSupport_(false),
+    numSinglePassPrimitives_(0),
     numPrimitives_(0),
     numBatches_(0),
     maxScratchBufferRequest_(0),
@@ -814,6 +815,7 @@ bool Graphics::BeginFrame()
     for (unsigned i = 0; i < MAX_TEXTURE_UNITS; ++i)
         SetTexture(i, 0);
 
+    numSinglePassPrimitives_ = 0;
     numPrimitives_ = 0;
     numBatches_ = 0;
 
@@ -935,6 +937,8 @@ void Graphics::Draw(PrimitiveType type, unsigned indexStart, unsigned indexCount
     impl_->device_->DrawIndexedPrimitive(d3dPrimitiveType, 0, minVertex, vertexCount, indexStart, primitiveCount);
 
     numPrimitives_ += primitiveCount;
+    if (GetNumPasses() == 1)
+        numSinglePassPrimitives_ += primitiveCount;
     ++numBatches_;
 }
 
@@ -963,6 +967,7 @@ void Graphics::DrawInstanced(PrimitiveType type, unsigned indexStart, unsigned i
     impl_->device_->DrawIndexedPrimitive(d3dPrimitiveType, 0, minVertex, vertexCount, indexStart, primitiveCount);
 
     numPrimitives_ += instanceCount * primitiveCount;
+    numSinglePassPrimitives_ += instanceCount * primitiveCount;
     ++numBatches_;
 }
 

--- a/Source/Atomic/Graphics/Direct3D9/D3D9Graphics.h
+++ b/Source/Atomic/Graphics/Direct3D9/D3D9Graphics.h
@@ -288,6 +288,9 @@ public:
     /// Return whether Direct3D device is lost, and can not yet render. This happens during fullscreen resolution switching.
     bool IsDeviceLost() const { return deviceLost_; }
 
+    /// Return number of True primitives drawn this frame.
+    unsigned GetSinglePassPrimitives() const { return numSinglePassPrimitives_; }
+
     /// Return number of primitives drawn this frame.
     unsigned GetNumPrimitives() const { return numPrimitives_; }
 
@@ -503,7 +506,13 @@ public:
     IntVector2 GetMonitorResolution(int monitorId) const;
     // ATOMIC END
 
+    int GetNumPasses() { return numPasses_; }
+    void SetNumPasses() { numPasses_ = 0; }
+    void AddPasses() { numPasses_++; }
+
 private:
+    int numPasses_;
+
     /// Set vertex buffer stream frequency.
     void SetStreamFrequency(unsigned index, unsigned frequency);
     /// Reset stream frequencies.
@@ -579,6 +588,8 @@ private:
     bool sRGBSupport_;
     /// sRGB conversion on write support flag.
     bool sRGBWriteSupport_;
+    ///Number of true primitives
+    unsigned numSinglePassPrimitives_;
     /// Number of primitives this frame.
     unsigned numPrimitives_;
     /// Number of batches this frame.

--- a/Source/Atomic/Graphics/Direct3D9/D3D9Graphics.h
+++ b/Source/Atomic/Graphics/Direct3D9/D3D9Graphics.h
@@ -507,8 +507,8 @@ public:
     // ATOMIC END
 
     int GetNumPasses() { return numPasses_; }
-    void SetNumPasses() { numPasses_ = 0; }
-    void AddPasses() { numPasses_++; }
+    void ResetNumPasses() { numPasses_ = 0; }
+    void IncNumPasses() { numPasses_++; }
 
 private:
     int numPasses_;

--- a/Source/Atomic/Graphics/OpenGL/OGLGraphics.h
+++ b/Source/Atomic/Graphics/OpenGL/OGLGraphics.h
@@ -294,6 +294,9 @@ public:
     /// Return whether device is lost, and can not yet render.
     bool IsDeviceLost() const;
 
+    /// Return number of True primitives drawn this frame.
+    unsigned GetSinglePassPrimitives() const { return numSinglePassPrimitives_; }
+
     /// Return number of primitives drawn this frame.
     unsigned GetNumPrimitives() const { return numPrimitives_; }
 
@@ -535,7 +538,13 @@ public:
     IntVector2 GetMonitorResolution(int monitorId) const;
     // ATOMIC END
 
+    int GetNumPasses() { return numPasses_; }
+    void ResetNumPasses() { numPasses_ = 0; }
+    void IncNumPasses() { numPasses_++; }
+
 private:
+    int numPasses_;
+
     /// Create the application window icon.
     void CreateWindowIcon();
     /// Check supported rendering features.
@@ -613,6 +622,8 @@ private:
     bool sRGBSupport_;
     /// sRGB conversion on write support flag.
     bool sRGBWriteSupport_;
+    ///Number of true primitives
+    unsigned numSinglePassPrimitives_;
     /// Number of primitives this frame.
     unsigned numPrimitives_;
     /// Number of batches this frame.

--- a/Source/Atomic/Graphics/Renderer.cpp
+++ b/Source/Atomic/Graphics/Renderer.cpp
@@ -672,6 +672,7 @@ void Renderer::Render()
         graphics_->ResetRenderTargets();
         graphics_->Clear(CLEAR_COLOR | CLEAR_DEPTH | CLEAR_STENCIL, defaultZone_->GetFogColor());
 
+        numSinglePassPrimitives_ = 0;
         numPrimitives_ = 0;
         numBatches_ = 0;
     }
@@ -703,6 +704,7 @@ void Renderer::Render()
         }
 
         // Copy the number of batches & primitives from Graphics so that we can account for 3D geometry only
+        numSinglePassPrimitives_ = graphics_->GetSinglePassPrimitives();
         numPrimitives_ = graphics_->GetNumPrimitives();
         numBatches_ = graphics_->GetNumBatches();
     }

--- a/Source/Atomic/Graphics/Renderer.h
+++ b/Source/Atomic/Graphics/Renderer.h
@@ -275,6 +275,9 @@ public:
     /// Return number of views rendered.
     unsigned GetNumViews() const { return views_.Size(); }
 
+    /// Return number of true primitives rendered.
+    unsigned GetSinglePassPrimitives() { return numSinglePassPrimitives_; }
+
     /// Return number of primitives rendered.
     unsigned GetNumPrimitives() const { return numPrimitives_; }
 
@@ -484,6 +487,8 @@ private:
     unsigned numOcclusionBuffers_;
     /// Number of temporary shadow cameras in use.
     unsigned numShadowCameras_;
+    /// Number of True primitives (3D geometry only.)
+    unsigned numSinglePassPrimitives_;
     /// Number of primitives (3D geometry only.)
     unsigned numPrimitives_;
     /// Number of batches (3D geometry only.)

--- a/Source/Atomic/Graphics/View.cpp
+++ b/Source/Atomic/Graphics/View.cpp
@@ -1551,12 +1551,12 @@ void View::ExecuteRenderPathCommands()
 
                     SetRenderTargets(command);
 
-                    graphics_->SetNumPasses();
+                    graphics_->ResetNumPasses();
 
                     for (Vector<LightBatchQueue>::Iterator i = lightQueues_.Begin(); i != lightQueues_.End(); ++i)
                     {
 
-                        graphics_->AddPasses();
+                        graphics_->IncNumPasses();
 
                         // If reusing shadowmaps, render each of them before the lit batches
                         if (renderer_->GetReuseShadowMaps() && i->shadowMap_)
@@ -2918,7 +2918,7 @@ void View::RenderShadowMap(const LightBatchQueue& queue)
         const ShadowBatchQueue& shadowQueue = queue.shadowSplits_[i];
         if (!shadowQueue.shadowBatches_.IsEmpty())
         {
-            graphics_->AddPasses();
+            graphics_->IncNumPasses();
             graphics_->SetViewport(shadowQueue.shadowViewport_);
             shadowQueue.shadowBatches_.Draw(this, false, false, true);
         }

--- a/Source/Atomic/Graphics/View.cpp
+++ b/Source/Atomic/Graphics/View.cpp
@@ -1551,8 +1551,13 @@ void View::ExecuteRenderPathCommands()
 
                     SetRenderTargets(command);
 
+                    graphics_->SetNumPasses();
+
                     for (Vector<LightBatchQueue>::Iterator i = lightQueues_.Begin(); i != lightQueues_.End(); ++i)
                     {
+
+                        graphics_->AddPasses();
+
                         // If reusing shadowmaps, render each of them before the lit batches
                         if (renderer_->GetReuseShadowMaps() && i->shadowMap_)
                         {
@@ -2913,6 +2918,7 @@ void View::RenderShadowMap(const LightBatchQueue& queue)
         const ShadowBatchQueue& shadowQueue = queue.shadowSplits_[i];
         if (!shadowQueue.shadowBatches_.IsEmpty())
         {
+            graphics_->AddPasses();
             graphics_->SetViewport(shadowQueue.shadowViewport_);
             shadowQueue.shadowBatches_.Draw(this, false, false, true);
         }

--- a/Source/Atomic/UI/SystemUI/DebugHud.cpp
+++ b/Source/Atomic/UI/SystemUI/DebugHud.cpp
@@ -66,7 +66,7 @@ DebugHud::DebugHud(Context* context) :
     fpsTimeSinceUpdate_(FPS_UPDATE_INTERVAL),
     fpsFramesSinceUpdate_(0),
     fps_(0),
-    isSceneOpen_(false),
+    sceneOpen_(false),
     showSceneHud_(false)
 {
     SystemUI* ui = GetSubsystem<SystemUI>();
@@ -108,7 +108,7 @@ void DebugHud::Update(float timeStep)
         return;
 
     UI* ui = GetSubsystem<UI>();
-    if (GetIsSceneOpen())
+    if (GetSceneOpen())
     {
         ui->ShowDebugHud(false);
     }
@@ -123,7 +123,7 @@ void DebugHud::Update(float timeStep)
         uiRoot->AddChild(profilerText_);
     }
 
-    if (statsText_->IsVisible() || GetIsSceneOpen())
+    if (statsText_->IsVisible() || GetSceneOpen())
     {
         fpsTimeSinceUpdate_ += timeStep;
         ++fpsFramesSinceUpdate_;
@@ -175,7 +175,7 @@ void DebugHud::Update(float timeStep)
         statsString_ = stats;
     }
 
-    if (modeText_->IsVisible() || GetIsSceneOpen())
+    if (modeText_->IsVisible() || GetSceneOpen())
     {
         String mode;
         mode.AppendWithFormat("Tex:%s Mat:%s Spec:%s Shadows:%s Size:%i Quality:%s Occlusion:%s Instancing:%s API:%s",
@@ -200,7 +200,7 @@ void DebugHud::Update(float timeStep)
         {
             profilerTimer_.Reset();
 
-            if (profilerText_->IsVisible() || GetIsSceneOpen())
+            if (profilerText_->IsVisible() || GetSceneOpen())
             {
                 String profilerOutput = profiler->GetData(false, false, profilerMaxDepth_);
                 profilerText_->SetText(profilerOutput);

--- a/Source/Atomic/UI/SystemUI/DebugHud.cpp
+++ b/Source/Atomic/UI/SystemUI/DebugHud.cpp
@@ -30,6 +30,7 @@
 #include "Text.h"
 #include "SystemUI.h"
 #include "DebugHud.h"
+#include "UI/UI.h"
 
 #include "../../DebugNew.h"
 
@@ -60,11 +61,13 @@ DebugHud::DebugHud(Context* context) :
     Object(context),
     profilerMaxDepth_(M_MAX_UNSIGNED),
     profilerInterval_(1000),
-    useRendererStats_(false),
+    useRendererStats_(true),
     mode_(DEBUGHUD_SHOW_NONE),
     fpsTimeSinceUpdate_(FPS_UPDATE_INTERVAL),
     fpsFramesSinceUpdate_(0),
-    fps_(0)
+    fps_(0),
+    isSceneOpen_(false),
+    showSceneHud_(false)
 {
     SystemUI* ui = GetSubsystem<SystemUI>();
     UIElement* uiRoot = ui->GetRoot();
@@ -104,6 +107,12 @@ void DebugHud::Update(float timeStep)
     if (!renderer || !graphics)
         return;
 
+    UI* ui = GetSubsystem<UI>();
+    if (GetIsSceneOpen())
+    {
+        ui->ShowDebugHud(false);
+    }
+
     // Ensure UI-elements are not detached
     if (!statsText_->GetParent())
     {
@@ -114,7 +123,7 @@ void DebugHud::Update(float timeStep)
         uiRoot->AddChild(profilerText_);
     }
 
-    if (statsText_->IsVisible())
+    if (statsText_->IsVisible() || GetIsSceneOpen())
     {
         fpsTimeSinceUpdate_ += timeStep;
         ++fpsFramesSinceUpdate_;
@@ -125,22 +134,30 @@ void DebugHud::Update(float timeStep)
             fpsTimeSinceUpdate_ = 0;
         }
 
-        unsigned primitives, batches;
+        unsigned primitives, batches, singlePassPrimitives, editorPrimitives;
         if (!useRendererStats_)
         {
             primitives = graphics->GetNumPrimitives();
             batches = graphics->GetNumBatches();
+
+            singlePassPrimitives = renderer->GetSinglePassPrimitives();
+            editorPrimitives = graphics->GetNumPrimitives() - renderer->GetNumPrimitives();
         }
         else
         {
             primitives = renderer->GetNumPrimitives();
             batches = renderer->GetNumBatches();
+
+            singlePassPrimitives = renderer->GetSinglePassPrimitives();
+            editorPrimitives = graphics->GetNumPrimitives() - renderer->GetNumPrimitives();
         }
 
         String stats;
-        stats.AppendWithFormat("FPS %d\nTriangles %u\nBatches %u\nViews %u\nLights %u\nShadowmaps %u\nOccluders %u",
+        stats.AppendWithFormat("FPS %d\nTriangles (All passes) %u\nTriangles (Single pass) %u\nTriangles (Editor) %u\nBatches %u\nViews %u\nLights %u\nShadowmaps %u\nOccluders %u",
             fps_,
             primitives,
+            singlePassPrimitives,
+            editorPrimitives,
             batches,
             renderer->GetNumViews(),
             renderer->GetNumLights(true),
@@ -155,9 +172,10 @@ void DebugHud::Update(float timeStep)
         }
 
         statsText_->SetText(stats);
+        statsString_ = stats;
     }
 
-    if (modeText_->IsVisible())
+    if (modeText_->IsVisible() || GetIsSceneOpen())
     {
         String mode;
         mode.AppendWithFormat("Tex:%s Mat:%s Spec:%s Shadows:%s Size:%i Quality:%s Occlusion:%s Instancing:%s API:%s",
@@ -172,6 +190,7 @@ void DebugHud::Update(float timeStep)
             graphics->GetApiName().CString());
 
         modeText_->SetText(mode);
+        modeString_ = mode;
     }
 
     Profiler* profiler = GetSubsystem<Profiler>();
@@ -181,10 +200,11 @@ void DebugHud::Update(float timeStep)
         {
             profilerTimer_.Reset();
 
-            if (profilerText_->IsVisible())
+            if (profilerText_->IsVisible() || GetIsSceneOpen())
             {
                 String profilerOutput = profiler->GetData(false, false, profilerMaxDepth_);
                 profilerText_->SetText(profilerOutput);
+                profilerString_ = profilerOutput;
             }
 
             profiler->BeginInterval();
@@ -293,6 +313,11 @@ bool DebugHud::ResetAppStats(const String& label)
 void DebugHud::ClearAppStats()
 {
     appStats_.Clear();
+}
+
+void DebugHud::ToggleSceneHud()
+{
+    SetShowSceneHud(!GetShowSceneHud());
 }
 
 void DebugHud::HandlePostUpdate(StringHash eventType, VariantMap& eventData)

--- a/Source/Atomic/UI/SystemUI/DebugHud.h
+++ b/Source/Atomic/UI/SystemUI/DebugHud.h
@@ -106,8 +106,8 @@ public:
     /// Clear all application-specific stats.
     void ClearAppStats();
 
-    bool GetIsSceneOpen() { return isSceneOpen_; }
-    void SetIsSceneOpen(bool isOpen) { isSceneOpen_ = isOpen; }
+    bool GetSceneOpen() { return sceneOpen_; }
+    void SetSceneOpen(bool isOpen) { sceneOpen_ = isOpen; }
 
     String GetStatsString() { return statsString_; }
     String GetModeString() { return modeString_; }
@@ -150,7 +150,7 @@ private:
     String modeString_;
     String profilerString_;
 
-    bool isSceneOpen_;
+    bool sceneOpen_;
     bool showSceneHud_;
 };
 

--- a/Source/Atomic/UI/SystemUI/DebugHud.h
+++ b/Source/Atomic/UI/SystemUI/DebugHud.h
@@ -106,6 +106,17 @@ public:
     /// Clear all application-specific stats.
     void ClearAppStats();
 
+    bool GetIsSceneOpen() { return isSceneOpen_; }
+    void SetIsSceneOpen(bool isOpen) { isSceneOpen_ = isOpen; }
+
+    String GetStatsString() { return statsString_; }
+    String GetModeString() { return modeString_; }
+    String GetProfilerString() { return profilerString_; }
+
+    void ToggleSceneHud();
+    bool GetShowSceneHud() { return showSceneHud_; }
+    void SetShowSceneHud(bool showSceneHud) { showSceneHud_ = showSceneHud; }
+
 private:
     /// Handle logic post-update event. The HUD texts are updated here.
     void HandlePostUpdate(StringHash eventType, VariantMap& eventData);
@@ -134,6 +145,13 @@ private:
     float fpsFramesSinceUpdate_;
     /// Calculated fps
     unsigned fps_;
+
+    String statsString_;
+    String modeString_;
+    String profilerString_;
+
+    bool isSceneOpen_;
+    bool showSceneHud_;
 };
 
 }

--- a/Source/Atomic/UI/UI.cpp
+++ b/Source/Atomic/UI/UI.cpp
@@ -858,7 +858,7 @@ void UI::ToggleDebugHud()
     if (!hud)
         return;
 
-    if (!hud->GetIsSceneOpen())
+    if (!hud->GetSceneOpen())
         hud->ToggleAll();
     else
         hud->ToggleSceneHud();

--- a/Source/Atomic/UI/UI.cpp
+++ b/Source/Atomic/UI/UI.cpp
@@ -858,7 +858,10 @@ void UI::ToggleDebugHud()
     if (!hud)
         return;
 
-    hud->ToggleAll();
+    if (!hud->GetIsSceneOpen())
+        hud->ToggleAll();
+    else
+        hud->ToggleSceneHud();
 }
 
 void UI::ShowConsole(bool value)

--- a/Source/Atomic/UI/UIWidget.cpp
+++ b/Source/Atomic/UI/UIWidget.cpp
@@ -637,6 +637,22 @@ UI_WIDGET_STATE UIWidget::GetStateRaw()
 
 }
 
+void UIWidget::SetOpacity(float opacity)
+{
+    if (!widget_)
+        return;
+
+    widget_->SetOpacity(opacity);
+}
+
+float UIWidget::GetOpacity()
+{
+    if (!widget_)
+        return 0.f;
+
+    return widget_->GetOpacity();
+}
+
 UIView* UIWidget::GetView()
 {
     if (!widget_)

--- a/Source/Atomic/UI/UIWidget.h
+++ b/Source/Atomic/UI/UIWidget.h
@@ -204,7 +204,6 @@ class UIWidget : public Object, public tb::TBWidgetDelegate
     void SetFocus();
     bool GetFocus();
 
-
     /// Set focus to first widget which accepts it
     void SetFocusRecursive();
     void OnFocusChanged(bool focused);
@@ -217,6 +216,9 @@ class UIWidget : public Object, public tb::TBWidgetDelegate
 
     void SetStateRaw(UI_WIDGET_STATE state);
     UI_WIDGET_STATE GetStateRaw();
+
+    void SetOpacity(float opacity);
+    float GetOpacity();
 
     void Invalidate();
     void Die();

--- a/Source/AtomicEditor/Editors/ResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/ResourceEditor.cpp
@@ -156,6 +156,7 @@ ResourceEditor::ResourceEditor(Context* context, const String& fullpath, UITabCo
 
     profilerContentWidget_ = new UIWidget(context_);
     profilerContentWidget_->SetGravity(UI_GRAVITY_ALL);
+    profilerContentWidget_->GetInternalWidget()->SetDisabledOpacity(1.0f);
 
     statsText_ = new UIEditField(context_);
     statsText_->SetGravity(UI_GRAVITY_LEFT);

--- a/Source/AtomicEditor/Editors/ResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/ResourceEditor.cpp
@@ -154,6 +154,33 @@ ResourceEditor::ResourceEditor(Context* context, const String& fullpath, UITabCo
     rootContentWidget_->SetGravity(UI_GRAVITY_ALL);
     container_->GetContentRoot()->AddChild(rootContentWidget_);
 
+    profilerContentWidget_ = new UIWidget(context_);
+    profilerContentWidget_->SetGravity(UI_GRAVITY_ALL);
+
+    statsText_ = new UIEditField(context_);
+    statsText_->SetGravity(UI_GRAVITY_LEFT);
+    statsText_->SetSize(250, 200);
+    statsText_->SetTextAlign(UI_TEXT_ALIGN_LEFT);
+    statsText_->SetMultiline(true);
+    statsText_->SetSkinBg("0");
+
+    modeText_ = new UIEditField(context_);
+    modeText_->SetGravity(UI_GRAVITY_BOTTOM);
+    modeText_->SetSize(700, 20);
+    modeText_->SetTextAlign(UI_TEXT_ALIGN_LEFT);
+    modeText_->SetSkinBg("0");
+
+    profilerText_ = new UIEditField(context_);
+    profilerText_->SetGravity(UI_GRAVITY_RIGHT);
+    profilerText_->SetSize(500, 550);
+    profilerText_->SetTextAlign(UI_TEXT_ALIGN_LEFT);
+    profilerText_->SetMultiline(true);
+    profilerText_->SetSkinBg("0");
+
+    profilerContentWidget_->AddChild(statsText_);
+    profilerContentWidget_->AddChild(modeText_);
+    profilerContentWidget_->AddChild(profilerText_);
+
     SubscribeToEvent(E_FILECHANGED, HANDLER(ResourceEditor, HandleFileChanged));
     SubscribeToEvent(E_RENAMERESOURCENOTIFICATION, HANDLER(ResourceEditor, HandleRenameResourceNotification));
     

--- a/Source/AtomicEditor/Editors/ResourceEditor.h
+++ b/Source/AtomicEditor/Editors/ResourceEditor.h
@@ -25,6 +25,7 @@
 #include <Atomic/Core/Object.h>
 
 #include <Atomic/UI/UIButton.h>
+#include <Atomic/UI/UIEditField.h>
 #include <Atomic/UI/UITabContainer.h>
 
 using namespace Atomic;
@@ -88,6 +89,11 @@ protected:
     SharedPtr<UITabContainer> container_;
     SharedPtr<UIWidget> rootContentWidget_;
     SharedPtr<UIButton> button_;
+    SharedPtr<UIWidget> profilerContentWidget_;
+
+    SharedPtr<UIEditField> statsText_;
+    SharedPtr<UIEditField> modeText_;
+    SharedPtr<UIEditField> profilerText_;
 
 private:
 

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
@@ -105,6 +105,7 @@ SceneEditor3D::SceneEditor3D(Context* context, const String &fullpath, UITabCont
     sceneView_->SetGravity(UI_GRAVITY_ALL);
 
     rootContentWidget_->AddChild(sceneView_);
+    rootContentWidget_->AddChild(profilerContentWidget_);
 
     gizmo3D_ = new Gizmo3D(context_);
     gizmo3D_->SetView(sceneView_);
@@ -120,6 +121,12 @@ SceneEditor3D::SceneEditor3D(Context* context, const String &fullpath, UITabCont
     // future size changes will be handled automatically
     IntRect rect = container_->GetContentRoot()->GetRect();
     rootContentWidget_->SetSize(rect.Width(), rect.Height());
+
+    int profilerWidth = rect.Width() - profilerText_->GetRect().Width();
+    int profilerHeight = rect.Height() - modeText_->GetRect().Height();
+
+    profilerContentWidget_->SetSize(profilerWidth, profilerHeight);
+    profilerContentWidget_->Disable();
 
     SubscribeToEvent(E_PROJECTUSERPREFSAVED, HANDLER(SceneEditor3D, HandleUserPrefSaved));
 
@@ -217,6 +224,20 @@ void SceneEditor3D::HandleUpdate(StringHash eventType, VariantMap& eventData)
 {
     if (!cubemapRenderCount_)
         gizmo3D_->Update();
+
+    if (debugHud_->GetShowSceneHud())
+    {
+        debugHud_->SetIsSceneOpen(true);
+        statsText_->SetText(debugHud_->GetStatsString());
+        modeText_->SetText(debugHud_->GetModeString());
+        profilerText_->SetText(debugHud_->GetProfilerString());
+    }
+    else
+    {
+        statsText_->SetText("");
+        modeText_->SetText("");
+        profilerText_->SetText("");
+    }
 }
 
 void SceneEditor3D::HandlePlayStarted(StringHash eventType, VariantMap& eventData)
@@ -255,6 +276,8 @@ void SceneEditor3D::Close(bool navigateToAvailableResource)
         sceneImporter_->GetAsset()->Save();
         sceneImporter_ = nullptr;
     }
+
+    debugHud_->SetIsSceneOpen(false);
 
     ResourceEditor::Close(navigateToAvailableResource);
 }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.cpp
@@ -71,6 +71,8 @@ SceneEditor3D::SceneEditor3D(Context* context, const String &fullpath, UITabCont
     Project* project = tsystem->GetProject();
     userPrefs_ = project->GetUserPrefs();
 
+    debugHud_ = GetSubsystem<SystemUI::DebugHud>();
+
     ResourceCache* cache = GetSubsystem<ResourceCache>();
 
     scene_ = new Scene(context_);
@@ -227,7 +229,7 @@ void SceneEditor3D::HandleUpdate(StringHash eventType, VariantMap& eventData)
 
     if (debugHud_->GetShowSceneHud())
     {
-        debugHud_->SetIsSceneOpen(true);
+        debugHud_->SetSceneOpen(true);
         statsText_->SetText(debugHud_->GetStatsString());
         modeText_->SetText(debugHud_->GetModeString());
         profilerText_->SetText(debugHud_->GetProfilerString());
@@ -277,7 +279,7 @@ void SceneEditor3D::Close(bool navigateToAvailableResource)
         sceneImporter_ = nullptr;
     }
 
-    debugHud_->SetIsSceneOpen(false);
+    debugHud_->SetSceneOpen(false);
 
     ResourceEditor::Close(navigateToAvailableResource);
 }

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.h
@@ -122,7 +122,7 @@ private:
 
     SharedPtr<Scene> scene_;
 
-    SystemUI::DebugHud* debugHud_ = GetSubsystem<SystemUI::DebugHud>();
+    SystemUI::DebugHud* debugHud_;
 
     // TODO: multiple views
     SharedPtr<SceneView3D> sceneView_;

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneEditor3D.h
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <Atomic/UI/SystemUI/SystemUI.h>
+#include <Atomic/UI/SystemUI/DebugHud.h>
+
 #include <TurboBadger/tb_widgets_common.h>
 
 #include "../ResourceEditor.h"
@@ -118,6 +121,8 @@ private:
     void UpdateGizmoSnapSettings();
 
     SharedPtr<Scene> scene_;
+
+    SystemUI::DebugHud* debugHud_ = GetSubsystem<SystemUI::DebugHud>();
 
     // TODO: multiple views
     SharedPtr<SceneView3D> sceneView_;

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
@@ -482,6 +482,9 @@ void SceneView3D::HandleUpdate(StringHash eventType, VariantMap& eventData)
 
     Enable();
 
+    SystemUI::DebugHud* debugHud = GetSubsystem<SystemUI::DebugHud>();
+    debugHud->SetIsSceneOpen(true);
+
     // Timestep parameter is same no matter what event is being listened to
     float timeStep = eventData[Update::P_TIMESTEP].GetFloat();
 

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
@@ -483,7 +483,7 @@ void SceneView3D::HandleUpdate(StringHash eventType, VariantMap& eventData)
     Enable();
 
     SystemUI::DebugHud* debugHud = GetSubsystem<SystemUI::DebugHud>();
-    debugHud->SetIsSceneOpen(true);
+    debugHud->SetSceneOpen(true);
 
     // Timestep parameter is same no matter what event is being listened to
     float timeStep = eventData[Update::P_TIMESTEP].GetFloat();

--- a/Source/ThirdParty/TurboBadger/tb_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.cpp
@@ -66,6 +66,7 @@ TBWidget::PaintProps::PaintProps()
 TBWidget::TBWidget()
     : m_parent(nullptr)
     , m_opacity(1.f)
+    , m_disabledOpacity(-1.0f)
     , m_state(WIDGET_STATE_NONE)
     , m_gravity(WIDGET_GRAVITY_DEFAULT)
     , m_layout_params(nullptr)
@@ -256,6 +257,17 @@ void TBWidget::SetOpacity(float opacity)
     if (opacity == 0) // Invalidate after setting opacity 0 will do nothing.
         Invalidate();
     m_opacity = opacity;
+    Invalidate();
+}
+
+void TBWidget::SetDisabledOpacity(float opacity)
+{
+    opacity = Clamp(opacity, -1.f, 1.f);
+    if (m_disabledOpacity == opacity)
+        return;
+    if (opacity == 0) // Invalidate after setting opacity 0 will do nothing.
+        Invalidate();
+    m_disabledOpacity = opacity;
     Invalidate();
 }
 
@@ -1161,7 +1173,10 @@ float TBWidget::CalculateOpacityInternal(WIDGET_STATE state, TBSkinElement *skin
     if (skin_element)
         opacity *= skin_element->opacity;
     if (state & WIDGET_STATE_DISABLED)
-        opacity *= g_tb_skin->GetDefaultDisabledOpacity();
+        if (m_disabledOpacity < 0.0f)
+            opacity *= g_tb_skin->GetDefaultDisabledOpacity();
+        else
+            opacity *= m_disabledOpacity;
     return opacity;
 }
 

--- a/Source/ThirdParty/TurboBadger/tb_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.h
@@ -461,6 +461,12 @@ public:
     void SetOpacity(float opacity);
     float GetOpacity() const { return m_opacity; }
 
+    /** Set opacity for this widget and its children from 0.0 - 1.0 when in WIDGET_STATE_DISABLED.
+    If disabled opacity is < 0, default skin opacity will be used.
+    If opacity is 0 (invisible), the widget won't receive any input. */
+    void SetDisabledOpacity(float opacity);
+    float GetDisabledOpacity() const { return m_disabledOpacity; }
+
     /** Set visibility for this widget and its children.
         If visibility is not WIDGET_VISIBILITY_VISIBLE, the widget won't receive any input. */
     void SetVisibilility(WIDGET_VISIBILITY vis);
@@ -1020,6 +1026,7 @@ private:
     TBWidgetValueConnection m_connection; ///< TBWidget value connection
     TBLinkListOf<TBWidgetListener> m_listeners;	///< List of listeners
     float m_opacity;				///< Opacity 0-1. See SetOpacity.
+    float m_disabledOpacity;		///< Opacity 0-1. See SetDisabledOpacity.
     WIDGET_STATE m_state;			///< The widget state (excluding any auto states)
     WIDGET_GRAVITY m_gravity;		///< The layout gravity setting.
     TBFontDescription m_font_desc;	///< The font description.

--- a/Source/ThirdParty/TurboBadger/tb_widgets_reader.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_widgets_reader.cpp
@@ -42,6 +42,8 @@ void TBWidget::OnInflate(const INFLATE_INFO &info)
 
     SetOpacity(info.node->GetValueFloat("opacity", GetOpacity()));
 
+    SetDisabledOpacity(info.node->GetValueFloat("disabledOpacity", GetDisabledOpacity()));
+
     if (const char *text = info.node->GetValueString("text", nullptr))
         SetText(text);
 

--- a/Source/ThirdParty/TurboBadger/tb_widgets_reader.h
+++ b/Source/ThirdParty/TurboBadger/tb_widgets_reader.h
@@ -103,33 +103,34 @@ public:
     Each factory may have its own set of properties, but a set of generic
     properties is always supported on all widgets. Those are:
 
-    Resource name:		TBWidget property:			Values:
+    Resource name:		TBWidget property:				Values:
 
-    id					TBWidget::m_id				TBID (string or int)
-    group-id			TBWidget::m_group_id		TBID (string or int)
-    value				TBWidget::SetValue			integer
-    data				TBWidget::m_data			integer
-    is-group-root		TBWidget::SetIsGroupRoot	boolean
-    is-focusable		TBWidget::SetIsFocusable	boolean
-    want-long-click		TBWidget::SetWantLongClick	boolean
-    ignore-input		TBWidget::SetIgnoreInput	boolean
-    opacity				TBWidget::SetOpacity		float (0 - 1)
-    text				TBWidget::SetText			string
-    connection			TBWidget::Connect			string
-    axis				TBWidget::SetAxis			x or y
-    gravity				TBWidget::SetGravity		string (combination of left, top, right, bottom, or all)
-    visibility			TBWidget::SetVisibility		string (visible, invisible, gone)
-    state				TBWidget::SetState			string (disabled)
-    skin				TBWidget::SetSkinBg			TBID (string or int)
-    rect				TBWidget::SetRect			4 integers (x, y, width, height)
-    lp>width			TBWidget::SetLayoutParams	dimension
-    lp>min-width		TBWidget::SetLayoutParams	dimension
-    lp>max-width		TBWidget::SetLayoutParams	dimension
-    lp>pref-width		TBWidget::SetLayoutParams	dimension
-    lp>height			TBWidget::SetLayoutParams	dimension
-    lp>min-height		TBWidget::SetLayoutParams	dimension
-    lp>max-height		TBWidget::SetLayoutParams	dimension
-    lp>pref-height		TBWidget::SetLayoutParams	dimension
+    id					TBWidget::m_id					TBID (string or int)
+    group-id			TBWidget::m_group_id			TBID (string or int)
+    value				TBWidget::SetValue				integer
+    data				TBWidget::m_data				integer
+    is-group-root		TBWidget::SetIsGroupRoot		boolean
+    is-focusable		TBWidget::SetIsFocusable		boolean
+    want-long-click		TBWidget::SetWantLongClick		boolean
+    ignore-input		TBWidget::SetIgnoreInput		boolean
+    opacity				TBWidget::SetOpacity			float (0 - 1)
+    disabledOpacity		TBWidget::SetDisabledOpacity	float (0 - 1)
+    text				TBWidget::SetText				string
+    connection			TBWidget::Connect				string
+    axis				TBWidget::SetAxis				x or y
+    gravity				TBWidget::SetGravity			string (combination of left, top, right, bottom, or all)
+    visibility			TBWidget::SetVisibility			string (visible, invisible, gone)
+    state				TBWidget::SetState				string (disabled)
+    skin				TBWidget::SetSkinBg				TBID (string or int)
+    rect				TBWidget::SetRect				4 integers (x, y, width, height)
+    lp>width			TBWidget::SetLayoutParams		dimension
+    lp>min-width		TBWidget::SetLayoutParams		dimension
+    lp>max-width		TBWidget::SetLayoutParams		dimension
+    lp>pref-width		TBWidget::SetLayoutParams		dimension
+    lp>height			TBWidget::SetLayoutParams		dimension
+    lp>min-height		TBWidget::SetLayoutParams		dimension
+    lp>max-height		TBWidget::SetLayoutParams		dimension
+    lp>pref-height		TBWidget::SetLayoutParams		dimension
     autofocus			The TBWidget will be focused automatically the first time its TBWindow is activated.
     font>name			Font name
     font>size			Font size


### PR DESCRIPTION
Divided the triangles into categories "All pass", "Single pass" and "Editor" (D3D9Graphics.cpp & h, DebugHud.cpp & h, Renderer.cpp & h, View.cpp)

Created a profiler widget to be added to the scene that lets you view the information easier when a scene is open (DebugHud.cpp & h, ResourceEditor.cpp & h, SceneEditor3D.cpp & h, SceneView.cpp, skin.tb.txt, UI.cpp)