### PR TITLE
Refactoring the extension interface names to make more sense

### DIFF
--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -249,7 +249,6 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
      * @type {boolean} return true if handled
      */
     menuItemClicked(refId: string): boolean {
-
         // run through and find any services that can handle this.
         let holdResult = false;
         this.registeredServices.forEach((service) => {
@@ -272,26 +271,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
      * @param  {Atomic.UIWidget} topLevelWindow The top level window that will be receiving these events
      */
     subscribeToEvents(eventDispatcher: Editor.Extensions.EventDispatcher) {
-        // Placeholder
+        // Placeholder for when UI events published by the editor need to be listened for
         //eventDispatcher.subscribeToEvent(EditorEvents.SaveResourceNotification, (ev) => this.doSomeUiMessage(ev));
-    }
-
-    /**
-     * Called after a resource has been saved
-     * @param  {Editor.EditorEvents.SaveResourceEvent} ev
-     */
-    doSomeUiMessage(ev: Editor.EditorEvents.SaveResourceEvent) {
-        // PLACEHOLDER
-        // run through and find any services that can handle this.
-        this.registeredServices.forEach((service) => {
-            // try {
-            //     // Verify that the service contains the appropriate methods and that it can save
-            //     if (service.save) {
-            //         service.save(ev);
-            //     }
-            // } catch (e) {
-            //    EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
-            // }
-        });
     }
 }

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -27,7 +27,7 @@ import ModalOps = require("../ui/modal/ModalOps");
 /**
  * Generic registry for storing Editor Extension Services
  */
-export class ServiceRegistry<T extends Editor.Extensions.EditorService> implements Editor.Extensions.ServiceRegistry<T> {
+export class ServicesProvider<T extends Editor.Extensions.ServiceEventListener> implements Editor.Extensions.ServicesProvider<T> {
     registeredServices: T[] = [];
 
     /**
@@ -57,7 +57,7 @@ export interface ServiceEventSubscriber {
 /**
  * Registry for service extensions that are concerned about project events
  */
-export class ProjectServiceRegistry extends ServiceRegistry<Editor.HostExtensions.ProjectService> implements Editor.HostExtensions.ProjectServiceRegistry {
+export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensions.ProjectServicesEventListener> implements Editor.HostExtensions.ProjectServicesProvider {
     constructor() {
         super();
     }
@@ -127,7 +127,7 @@ export class ProjectServiceRegistry extends ServiceRegistry<Editor.HostExtension
 /**
  * Registry for service extensions that are concerned about Resources
  */
-export class ResourceServiceRegistry extends ServiceRegistry<Editor.HostExtensions.ResourceService> implements Editor.HostExtensions.ResourceServiceRegistry {
+export class ResourceServicesProvider extends ServicesProvider<Editor.HostExtensions.ResourceServicesEventListener> implements Editor.HostExtensions.ResourceServicesProvider {
     constructor() {
         super();
     }
@@ -199,7 +199,7 @@ export class ResourceServiceRegistry extends ServiceRegistry<Editor.HostExtensio
  * Registry for service extensions that are concerned about and need access to parts of the editor user interface
  * Note: we may want to move this out into it's own file since it has a bunch of editor dependencies
  */
-export class UIServiceRegistry extends ServiceRegistry<Editor.HostExtensions.UIService> implements Editor.HostExtensions.UIServiceRegistry {
+export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.UIServicesEventListener> implements Editor.HostExtensions.UIServicesProvider {
     constructor() {
         super();
     }

--- a/Script/AtomicEditor/hostExtensions/ServiceLocator.ts
+++ b/Script/AtomicEditor/hostExtensions/ServiceLocator.ts
@@ -32,16 +32,16 @@ import TypescriptLanguageExtension from "./languageExtensions/TypscriptLanguageE
 export class ServiceLocatorType implements Editor.HostExtensions.HostServiceLocator {
 
     constructor() {
-        this.resourceServices = new HostExtensionServices.ResourceServiceRegistry();
-        this.projectServices = new HostExtensionServices.ProjectServiceRegistry();
-        this.uiServices = new HostExtensionServices.UIServiceRegistry();
+        this.resourceServices = new HostExtensionServices.ResourceServicesProvider();
+        this.projectServices = new HostExtensionServices.ProjectServicesProvider();
+        this.uiServices = new HostExtensionServices.UIServicesProvider();
     }
 
     private eventDispatcher: Atomic.UIWidget = null;
 
-    resourceServices: HostExtensionServices.ResourceServiceRegistry;
-    projectServices: HostExtensionServices.ProjectServiceRegistry;
-    uiServices: HostExtensionServices.UIServiceRegistry;
+    resourceServices: HostExtensionServices.ResourceServicesProvider;
+    projectServices: HostExtensionServices.ProjectServicesProvider;
+    uiServices: HostExtensionServices.UIServicesProvider;
 
     loadService(service: Editor.HostExtensions.HostEditorService) {
         try {

--- a/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
+++ b/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
@@ -27,7 +27,7 @@ import * as EditorEvents from "../../editor/EditorEvents";
 /**
  * Resource extension that supports the web view typescript extension
  */
-export default class ProjectBasedExtensionLoader implements Editor.HostExtensions.ProjectService {
+export default class ProjectBasedExtensionLoader implements Editor.HostExtensions.ProjectServicesEventListener {
     name: string = "ProjectBasedExtensionLoader";
     description: string = "This service supports loading extensions that reside in the project under {ProjectRoot}/Editor and named '*.Service.js'.";
 
@@ -44,14 +44,14 @@ export default class ProjectBasedExtensionLoader implements Editor.HostExtension
      * Inject this language service into the registry
      * @return {[type]}             True if successful
      */
-    initialize(serviceRegistry: Editor.HostExtensions.HostServiceLocator) {
+    initialize(serviceLocator: Editor.HostExtensions.HostServiceLocator) {
 
         // Let's rewrite the mod search
         this.rewriteModSearch();
 
         // We care project events
-        serviceRegistry.projectServices.register(this);
-        this.serviceRegistry = serviceRegistry;
+        serviceLocator.projectServices.register(this);
+        this.serviceRegistry = serviceLocator;
     }
 
     /**

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
@@ -25,7 +25,7 @@ import * as EditorEvents from "../../editor/EditorEvents";
 /**
  * Resource extension that supports the web view typescript extension
  */
-export default class TypescriptLanguageExtension implements Editor.HostExtensions.ResourceService, Editor.HostExtensions.ProjectService {
+export default class TypescriptLanguageExtension implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener {
     name: string = "HostTypeScriptLanguageExtension";
     description: string = "This service supports the typscript webview extension.";
 
@@ -107,11 +107,11 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
      * Inject this language service into the registry
      * @return {[type]}             True if successful
      */
-    initialize(serviceRegistry: Editor.HostExtensions.HostServiceLocator) {
+    initialize(serviceLocator: Editor.HostExtensions.HostServiceLocator) {
         // We care about both resource events as well as project events
-        serviceRegistry.resourceServices.register(this);
-        serviceRegistry.projectServices.register(this);
-        this.serviceRegistry = serviceRegistry;
+        serviceLocator.resourceServices.register(this);
+        serviceLocator.projectServices.register(this);
+        this.serviceRegistry = serviceLocator;
     }
 
     /**

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -54,7 +54,7 @@ export class EventDispatcher implements Editor.Extensions.EventDispatcher {
 /**
  * Generic registry for storing Editor Extension Services
  */
-class ServiceRegistry<T extends Editor.Extensions.EditorService> implements Editor.Extensions.ServiceRegistry<T> {
+class ServiceRegistry<T extends Editor.Extensions.ServiceEventListener> implements Editor.Extensions.ServicesProvider<T> {
     registeredServices: T[] = [];
 
     /**

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -146,7 +146,7 @@ declare module Editor.Extensions {
     /**
      * Base interface for any editor services.
      */
-    export interface EditorService {
+    export interface EditorServiceExtension {
         /**
          * Unique name of this service
          * @type {string}
@@ -160,6 +160,12 @@ declare module Editor.Extensions {
         description: string;
 
     }
+
+    /**
+     * Base Service Event Listener.  Attach descendents of these to an EditorServiceExtension
+     * to hook service events
+     */
+    export interface ServiceEventListener extends EditorServiceExtension { }
 
     interface EventDispatcher {
         /**
@@ -186,13 +192,13 @@ declare module Editor.Extensions {
          * Loads a service into a service registry
          * @param  {EditorService} service
          */
-        loadService(service: EditorService): void;
+        loadService(service: EditorServiceExtension): void;
     }
 
     /**
      * Service registry interface for registering services
      */
-    export interface ServiceRegistry<T extends EditorService> {
+    export interface ServicesProvider<T extends ServiceEventListener> {
         registeredServices: T[];
 
         /**
@@ -221,40 +227,39 @@ declare module Editor.HostExtensions {
      * or by the editor itself.
      */
     export interface HostServiceLocator extends Editor.Extensions.ServiceLoader {
-        resourceServices: ResourceServiceRegistry;
-        projectServices: ProjectServiceRegistry;
-        uiServices: UIServiceRegistry;
+        resourceServices: ResourceServicesProvider;
+        projectServices: ProjectServicesProvider;
+        uiServices: UIServicesProvider;
     }
 
-    export interface HostEditorService extends Editor.Extensions.EditorService {
+    export interface HostEditorService extends Editor.Extensions.EditorServiceExtension {
         /**
          * Called by the service locator at load time
          */
-        initialize(serviceLocator: Editor.Extensions.ServiceLoader);
+        initialize(serviceLocator: HostServiceLocator);
     }
 
-    export interface ResourceService extends Editor.Extensions.EditorService {
+    export interface ResourceServicesEventListener extends Editor.Extensions.ServiceEventListener {
         save?(ev: EditorEvents.SaveResourceEvent);
         delete?(ev: EditorEvents.DeleteResourceEvent);
         rename?(ev: EditorEvents.RenameResourceEvent);
     }
-    export interface ResourceServiceRegistry extends Editor.Extensions.ServiceRegistry<ResourceService> { }
+    export interface ResourceServicesProvider extends Editor.Extensions.ServicesProvider<ResourceServicesEventListener> { }
 
-    export interface ProjectService extends Editor.Extensions.EditorService {
+    export interface ProjectServicesEventListener extends Editor.Extensions.ServiceEventListener {
         projectUnloaded?();
         projectLoaded?(ev: EditorEvents.LoadProjectEvent);
         playerStarted?();
     }
-    export interface ProjectServiceRegistry extends Editor.Extensions.ServiceRegistry<ProjectService> { }
+    export interface ProjectServicesProvider extends Editor.Extensions.ServicesProvider<ProjectServicesEventListener> { }
 
-    export interface UIService extends Editor.Extensions.EditorService {
+    export interface UIServicesEventListener extends Editor.Extensions.ServiceEventListener {
         menuItemClicked?(refId: string): boolean;
     }
-    export interface UIServiceRegistry extends Editor.Extensions.ServiceRegistry<UIService> {
+    export interface UIServicesProvider extends Editor.Extensions.ServicesProvider<UIServicesEventListener> {
         createPluginMenuItemSource(id: string, items: any): Atomic.UIMenuItemSource;
         removePluginMenuItemSource(id: string);
         showModalWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow;
-        menuItemClicked(refId: string): boolean;
     }
 }
 
@@ -271,14 +276,14 @@ declare module Editor.ClientExtensions {
         getHostInterop(): HostInterop;
     }
 
-    export interface ClientEditorService extends Editor.Extensions.EditorService {
+    export interface ClientEditorService extends Editor.Extensions.EditorServiceExtension {
         /**
          * Called by the service locator at load time
          */
         initialize(serviceLocator: ClientServiceLocator);
     }
 
-    export interface WebViewService extends Editor.Extensions.EditorService {
+    export interface WebViewService extends Editor.Extensions.EditorServiceExtension {
         configureEditor?(ev: EditorEvents.EditorFileEvent);
         codeLoaded?(ev: EditorEvents.CodeLoadedEvent);
         save?(ev: EditorEvents.CodeSavedEvent);

--- a/Script/tsconfig.json
+++ b/Script/tsconfig.json
@@ -76,6 +76,7 @@
         "./AtomicEditor/ui/modal/build/platforms/WebSettingsWidget.ts",
         "./AtomicEditor/ui/modal/build/platforms/WindowsSettingsWidget.ts",
         "./AtomicEditor/ui/modal/CreateProject.ts",
+        "./AtomicEditor/ui/modal/ExtensionWindow.ts",
         "./AtomicEditor/ui/modal/license/ActivationSuccessWindow.ts",
         "./AtomicEditor/ui/modal/license/ActivationWindow.ts",
         "./AtomicEditor/ui/modal/license/EULAWindow.ts",


### PR DESCRIPTION
This PR attempts to make the extension interfaces make more sense.  The concept is that you have ServiceProviders that provide functionality that an extension can request, and ServiceListeners which the extension implements so that it can respond to service events coming from the editor.

The following name changes were made:
```
ServiceRegistry<T> -> ServicesProvider<T>
ProjectServiceRegistry -> ProjectServicesProvider
ResourceServiceRegistry -> ResourceServicesProvider
UIServiceRegistry -> UIServicesProvider
ProjectService -> ProjectServicesEventListener
ResourceService -> ResourceServicesEventListener
UIService -> UIServicesEventListener
```

This now changes the way to implement an extension from:
```
export default class Extension implements Editor.HostExtensions.ResourceService, Editor.HostExtensions.ProjectService
```

to
```
export default class Extension implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener 
```