### PR TITLE
Adding extra event loop support for per frame events

### DIFF
--- a/Resources/CoreData/AtomicModules/AtomicEventLoop.js
+++ b/Resources/CoreData/AtomicModules/AtomicEventLoop.js
@@ -16,6 +16,8 @@
  *      - Modified the way that setTimeout,clearTimeout,setInterval,clearInterval are loaded into global scope
  *      - Implemented setImmediate/clearImmediate
  *
+ *  Jay Sistar - April 2016
+ *      - Added requestAnimationFrame and cancelAnimationFrame for per frame callbacks
  */
 
 /*
@@ -36,6 +38,10 @@ EventLoop = {
     nextTimerId: 1,
     minimumDelay: 1,
     maxExpirys: 10,
+
+    // per frame events
+    pfeCallbacks: [],
+    pfeCurrentTime: 0.0,
 
     // misc
     exitRequested: false
@@ -269,8 +275,49 @@ EventLoop.processImmediates = function () {
     }
 }
 
+EventLoop.processPerFrameEvents = function(eventData) {
+    this.pfeCurrentTime += eventData.timeStep;
+    var callbacks = this.pfeCallbacks;
+    this.pfeCallbacks = [];
+    callbacks.forEach(function(callback) {
+        // The second parameter isn't standard, but it's useful in Atomic.
+        callback(this.pfeCurrentTime, eventData.timeStep);
+    }.bind(this));
+}
+
 EventLoop.requestExit = function () {
     this.exitRequested = true;
+}
+
+/*
+ *  Per Frame Event API
+ *
+ *  These interface with the singleton EventLoop.
+ */
+
+/**
+ * schedules a function to be called on the next frame
+ * @method
+ * @param {function} func the Function to call
+ * @param {any} [parameters] A comma separated list of parameters to pass to func
+ * @returns {int} the id of the callback to be used in cancelAnimationFrame in order to cancel the call
+ */
+function requestAnimationFrame(step) {
+    if (typeof step !== "function") {
+        throw '"requestAnimationFrame" only accepts a function.'
+    }
+    var call_id = EventLoop.pfeCallbacks.length;
+    EventLoop.pfeCallbacks.push(step);
+    return call_id;
+}
+
+/**
+ * stops a previously queued call to requestAnimationFrame
+ * @method
+ * @param {int} call_id the id of the timer that was created via requestAnimationFrame
+ */
+function cancelAnimationFrame(call_id) {
+    EventLoop.pfeCallbacks[call_id] = function(){}; // NOP
 }
 
 /*
@@ -467,6 +514,7 @@ function throttleProcessTimers(ms) {
     var pendingOps = false;
 
     function doThrottle(eventData) {
+        EventLoop.processPerFrameEvents(eventData);
         deltaTimer += eventData.timeStep * 1000;
         if (deltaTimer > ms || pendingOps) {
             deltaTimer -= ms;
@@ -497,6 +545,8 @@ Atomic.engine.subscribeToEvent('PostUpdate', function (eventData) {
     global.clearTimeout = global.clearTimeout || clearTimeout;
     global.setImmediate = global.setImmediate || setImmediate;
     global.clearImmediate = global.clearImmediate || clearImmediate;
+    global.requestAnimationFrame = global.requestAnimationFrame || requestAnimationFrame;
+    global.cancelAnimationFrame = global.cancelAnimationFrame || cancelAnimationFrame;
 
     global.requestEventLoopExit = global.requestEventLoopExit || requestEventLoopExit;
 })(new Function('return this')());

--- a/Resources/CoreData/AtomicModules/AtomicEventLoop.js
+++ b/Resources/CoreData/AtomicModules/AtomicEventLoop.js
@@ -299,7 +299,6 @@ EventLoop.requestExit = function () {
  * schedules a function to be called on the next frame
  * @method
  * @param {function} func the Function to call
- * @param {any} [parameters] A comma separated list of parameters to pass to func
  * @returns {int} the id of the callback to be used in cancelAnimationFrame in order to cancel the call
  */
 function requestAnimationFrame(step) {


### PR DESCRIPTION
Adding requestAnimationFrame() and cancelAnimationFrame().

These offer per frame callbacks, and have an API that matches the web browser API exactly, so external tweening libraries (like GSAP) work in Atomic Game Engine without modification.

...To be perfectly honest, GSAP doesn't work out of the box. Here's a frontend script that I use:

    require("AtomicEventLoop");
    (function (globalVar) {
        if (globalVar.window === undefined) {
            globalVar.window = globalVar;
        }
        if (globalVar.global === undefined) {
            globalVar.global = globalVar;
        }
    })(new Function('return this')());
    require("GSAP/TweenLite");

This script assumes that:
1, "TweenLite.js" is in "Modules/GSAP/TweenLite.js".
2. The version of Atomic Game Engine used has this pull request.

I am going to go through the UI library soon and make another PR for the modifications to make most tweening libraries (Tween.js, GSAP, and others) work without update callback hacks necessary for some values now.

I think you could add TimelineLite/TweenMax/TimelineMax to the GSAP.js script above, but I haven't tried.