### PR TITLE
Exposing a few properties that are great for tweening on UIWidget.

### DIFF
--- a/Source/Atomic/UI/UIFontDescription.cpp
+++ b/Source/Atomic/UI/UIFontDescription.cpp
@@ -43,6 +43,11 @@ UIFontDescription::~UIFontDescription()
 
 }
 
+int UIFontDescription::GetSize()
+{
+    return desc_.GetSize();
+}
+
 void UIFontDescription::SetId(const String& id)
 {
     desc_.SetID(TBIDC(id.CString()));

--- a/Source/Atomic/UI/UIFontDescription.h
+++ b/Source/Atomic/UI/UIFontDescription.h
@@ -36,6 +36,8 @@ public:
     UIFontDescription(Context* context);
     virtual ~UIFontDescription();
 
+    int GetSize();
+
     void SetId(const String& id);
     void SetSize(int size);
 

--- a/Source/Atomic/UI/UIWidget.cpp
+++ b/Source/Atomic/UI/UIWidget.cpp
@@ -437,16 +437,24 @@ void UIWidget::SetFontId(const String& fontId)
     widget_->SetFontDescription(fd);
 }
 
-void UIWidget::SetFontId(tb::uint32 fontId)
+void UIWidget::SetFontIdHash(unsigned fontIdHash)
 {
     if (!widget_)
         return;
 
     tb::TBFontDescription fd(widget_->GetFontDescription());
-    fd.SetID(fontId);
+    fd.SetID(fontIdHash);
     widget_->SetFontDescription(fd);
 }
 
+unsigned UIWidget::GetFontIdHash()
+{
+    if (!widget_)
+        return 0;
+
+    tb::TBFontDescription fd(widget_->GetFontDescription());
+    return fd.GetID();
+}
 
 void UIWidget::SetFontSize(int size)
 {

--- a/Source/Atomic/UI/UIWidget.cpp
+++ b/Source/Atomic/UI/UIWidget.cpp
@@ -437,23 +437,17 @@ void UIWidget::SetFontId(const String& fontId)
     widget_->SetFontDescription(fd);
 }
 
-void UIWidget::SetFontIdHash(unsigned fontIdHash)
+String UIWidget::GetFontId()
 {
     if (!widget_)
-        return;
+        return "";
 
     tb::TBFontDescription fd(widget_->GetFontDescription());
-    fd.SetID(fontIdHash);
-    widget_->SetFontDescription(fd);
-}
-
-unsigned UIWidget::GetFontIdHash()
-{
-    if (!widget_)
-        return 0;
-
-    tb::TBFontDescription fd(widget_->GetFontDescription());
-    return fd.GetID();
+    if (!g_font_manager->HasFontFace(fd))
+    {
+        return "";
+    }
+    return g_font_manager->GetFontInfo(fd.GetID())->GetName();
 }
 
 void UIWidget::SetFontSize(int size)

--- a/Source/Atomic/UI/UIWidget.cpp
+++ b/Source/Atomic/UI/UIWidget.cpp
@@ -427,6 +427,315 @@ void UIWidget::SetFontDescription(UIFontDescription* fd)
 
 }
 
+void UIWidget::SetFontId(const String& fontId)
+{
+    if (!widget_)
+        return;
+
+    tb::TBFontDescription fd(widget_->GetFontDescription());
+    fd.SetID(fontId.CString());
+    widget_->SetFontDescription(fd);
+}
+
+void UIWidget::SetFontId(tb::uint32 fontId)
+{
+    if (!widget_)
+        return;
+
+    tb::TBFontDescription fd(widget_->GetFontDescription());
+    fd.SetID(fontId);
+    widget_->SetFontDescription(fd);
+}
+
+
+void UIWidget::SetFontSize(int size)
+{
+    if (!widget_)
+        return;
+
+    tb::TBFontDescription fd(widget_->GetFontDescription());
+    fd.SetSize(size);
+    widget_->SetFontDescription(fd);
+}
+
+int UIWidget::GetFontSize()
+{
+    if (!widget_)
+        return 0;
+
+    tb::TBFontDescription fd(widget_->GetFontDescription());
+    return fd.GetSize();
+}
+
+void UIWidget::SetLayoutWidth(int width)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.SetWidth(width);
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutWidth()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->pref_w;
+}
+
+void UIWidget::SetLayoutHeight(int height)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.SetHeight(height);
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutHeight()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->pref_h;
+}
+
+void UIWidget::SetLayoutPrefWidth(int width)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.pref_w = width;
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutPrefWidth()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->pref_w;
+}
+
+void UIWidget::SetLayoutPrefHeight(int height)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.pref_h = height;
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutPrefHeight()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->pref_h;
+}
+
+void UIWidget::SetLayoutMinWidth(int width)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.min_w = width;
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutMinWidth()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->min_w;
+}
+
+void UIWidget::SetLayoutMinHeight(int height)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.min_h = height;
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutMinHeight()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->min_h;
+}
+
+void UIWidget::SetLayoutMaxWidth(int width)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.max_w = width;
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutMaxWidth()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->max_w;
+}
+
+void UIWidget::SetLayoutMaxHeight(int height)
+{
+    if (!widget_)
+        return;
+
+    tb::LayoutParams lp;
+
+    const tb::LayoutParams *oldLp(widget_->GetLayoutParams());
+    if (oldLp)
+        lp = *oldLp;
+
+    lp.max_h = height;
+    widget_->SetLayoutParams(lp);
+}
+
+int UIWidget::GetLayoutMaxHeight()
+{
+    if (!widget_)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    const tb::LayoutParams *lp(widget_->GetLayoutParams());
+    if (!lp)
+        return tb::LayoutParams::UNSPECIFIED;
+
+    return lp->max_h;
+}
+
+void UIWidget::SetOpacity(float opacity)
+{
+    if (!widget_)
+        return;
+
+    widget_->SetOpacity(opacity);
+}
+
+float UIWidget::GetOpacity()
+{
+    if (!widget_)
+        return -0.0f;
+
+    return widget_->GetOpacity();
+}
+
+void UIWidget::SetAutoOpacity(float autoOpacity)
+{
+    if (!widget_)
+        return;
+
+    if (autoOpacity == 0.0f)
+    {
+        widget_->SetOpacity(autoOpacity);
+        widget_->SetVisibilility(tb::WIDGET_VISIBILITY_INVISIBLE);
+    }
+    else
+    {
+        widget_->SetVisibilility(tb::WIDGET_VISIBILITY_VISIBLE);
+        widget_->SetOpacity(autoOpacity);
+    }
+}
+
+float UIWidget::GetAutoOpacity()
+{
+    if (!widget_)
+        return -0.0f;
+
+    float autoOpacity(widget_->GetOpacity());
+
+    if (autoOpacity == 0.0f)
+    {
+        if (widget_->GetVisibility() == tb::WIDGET_VISIBILITY_VISIBLE)
+            return 0.0001f; // Don't say that it's completly invisible.
+    }
+    else
+    {
+        if (widget_->GetVisibility() != tb::WIDGET_VISIBILITY_VISIBLE)
+            return 0.0f; // Say it's invisible.
+    }
+    return autoOpacity;
+}
+
 void UIWidget::DeleteAllChildren()
 {
     if (!widget_)

--- a/Source/Atomic/UI/UIWidget.h
+++ b/Source/Atomic/UI/UIWidget.h
@@ -275,7 +275,8 @@ class UIWidget : public Object, public tb::TBWidgetDelegate
 
     // Font Description
     void SetFontId(const String& fontId);
-    void SetFontId(tb::uint32 fontId);
+    void SetFontIdHash(unsigned fontIdHash);
+    unsigned GetFontIdHash();
     void SetFontSize(int size);
     int GetFontSize();
 

--- a/Source/Atomic/UI/UIWidget.h
+++ b/Source/Atomic/UI/UIWidget.h
@@ -164,7 +164,7 @@ class UIWidget : public Object, public tb::TBWidgetDelegate
 
     public:
 
-        UIWidget(Context* context, bool createWidget = true);
+    UIWidget(Context* context, bool createWidget = true);
     virtual ~UIWidget();
 
     bool Load(const String& filename);
@@ -272,6 +272,46 @@ class UIWidget : public Object, public tb::TBWidgetDelegate
 
     void Enable();
     void Disable();
+
+    // Font Description
+    void SetFontId(const String& fontId);
+    void SetFontId(tb::uint32 fontId);
+    void SetFontSize(int size);
+    int GetFontSize();
+
+    // Rect
+    void SetX(int x) { IntRect r(GetRect()); r.right_ = x + r.Width(); r.left_ = x; SetRect(r); }
+    int GetX() { return GetRect().left_; }
+    void SetY(int y) { IntRect r(GetRect()); r.bottom_ = y + r.Height(); r.top_ = y; SetRect(r); }
+    int GetY() { return GetRect().top_; }
+    void SetWidth(int width) { IntRect r(GetRect()); r.right_ = r.left_ + width; SetRect(r); }
+    int GetWidth() { return GetRect().Width(); }
+    void SetHeight(int height) { IntRect r(GetRect()); r.bottom_ = r.top_ + height; SetRect(r); }
+    int GetHeight() { return GetRect().Height(); }
+
+    // Layout Params
+    void SetLayoutWidth(int width);
+    int GetLayoutWidth();
+    void SetLayoutHeight(int height);
+    int GetLayoutHeight();
+    void SetLayoutPrefWidth(int width);
+    int GetLayoutPrefWidth();
+    void SetLayoutPrefHeight(int height);
+    int GetLayoutPrefHeight();
+    void SetLayoutMinWidth(int width);
+    int GetLayoutMinWidth();
+    void SetLayoutMinHeight(int height);
+    int GetLayoutMinHeight();
+    void SetLayoutMaxWidth(int width);
+    int GetLayoutMaxWidth();
+    void SetLayoutMaxHeight(int height);
+    int GetLayoutMaxHeight();
+
+    // Opacity and AutoOpacity (AutoOpacity sets visibility as well based on opacity being 0.0 or non-0.0).
+    void SetOpacity(float opacity);
+    float GetOpacity();
+    void SetAutoOpacity(float autoOpacity);
+    float GetAutoOpacity();
 
 protected:
 

--- a/Source/Atomic/UI/UIWidget.h
+++ b/Source/Atomic/UI/UIWidget.h
@@ -24,6 +24,7 @@
 
 #include <ThirdParty/TurboBadger/tb_widgets.h>
 #include <ThirdParty/TurboBadger/tb_widgets_common.h>
+#include <ThirdParty/TurboBadger/tb_font_renderer.h>
 
 #include "../Core/Object.h"
 
@@ -275,8 +276,7 @@ class UIWidget : public Object, public tb::TBWidgetDelegate
 
     // Font Description
     void SetFontId(const String& fontId);
-    void SetFontIdHash(unsigned fontIdHash);
-    unsigned GetFontIdHash();
+    String GetFontId();
     void SetFontSize(int size);
     int GetFontSize();
 


### PR DESCRIPTION
I'll have to make an example soon to show how these properties are useful. I do expose opacity here, but not color, which would be useful. It seems that text color might be exposed, but not a filtered (diffuse-style) color that affects the whole widget as opacity does.

Here's my test file, just so you can see how these might be used:

    'atomic component';

    require("GSAP");

    var particleEmitter;
    var buttons = [];

    function createButton(self, peffectName) {
        var button = new Atomic.UIButton();
        button.fontId = "Vera";
        button.fontSize = 30;
        button.text = peffectName;
        button.gravity = Atomic.UI_GRAVITY_RIGHT;
        button.layoutWidth = 350;
        button.layoutHeight = 50;
        button.opacity = 0.50;
        button.tl = new TimelineLite();
        button.tl.to(button, 0.25, {fontSize: 40, layoutWidth: 370, opacity: 1.0});
        button.tl.stop();
        buttons.push(button);
        button.onClick = function() {
            particleEmitter.effect = Atomic.cache.getResource("ParticleEffect", "Particles/" + peffectName + ".peffect");
            buttons.forEach(function(button) {
                button.tl.reverse();
            });
            button.tl.play();
        }
        var current = particleEmitter.effect.name.match(/^Particles\/(.*)\.peffect$/)[1];
        if (peffectName === current) {
            button.tl.progress(1.0);
        }
        return button;
    }
    
    //UI component
    exports.component = function(self) {
        var UI = Atomic.getUI();

        particleEmitter = self.getComponent("ParticleEmitter");

        self.uiView = new Atomic.UIView();

        var layout = new Atomic.UILayout();
        layout.rect = self.uiView.rect;
        layout.axis = Atomic.UI_AXIS_Y;
        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION_GRAVITY;
        self.uiView.addChild(layout);

        layout.addChild(createButton(self, "Disco"));
        layout.addChild(createButton(self, "Fire"));
        layout.addChild(createButton(self, "Smoke"));
        layout.addChild(createButton(self, "SmokeStack"));
        layout.addChild(createButton(self, "SnowExplosion"));
    };

It's based on the ParticleEmitter3D example. I'm not doing anything special with the particles; I'm only tweening the button properties. Each button is given a timeline, and it tweens the font size, width (layout based width, since it's in a layout), and opacity when it's selected, so unselected buttons are translucent, have a smaller font size, and a smaller width, while the selected button is fully opaque, has a slightly larger font size, and a slightly larger width. Those 3 properties are tweened on a button press.

Here's a (unfortunately unanimated) screenshot:
![image](https://cloud.githubusercontent.com/assets/413028/14854655/8c62a05a-0c5e-11e6-81a5-8c3c1b68a51b.png)
