### PR TITLE
Turbo badger editor settings

### DIFF
--- a/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
@@ -25,6 +25,7 @@ import * as ClientExtensionServices from "./ClientExtensionServices";
 // Initialize and configure the extensions
 import tsExtension from "./languageExtensions/typescript/TypescriptLanguageExtension";
 import jsExtension from "./languageExtensions/javascript/JavascriptLanguageExtension";
+import tbExtension from "./languageExtensions/turbobadger/TurboBadgerLanguageExtension";
 
 /**
  * Generic service locator of editor services that may be injected by either a plugin
@@ -87,3 +88,4 @@ export default serviceLocator;
 // Load up all the internal services
 serviceLocator.loadService(new tsExtension());
 serviceLocator.loadService(new jsExtension());
+serviceLocator.loadService(new tbExtension());

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2014-2016 THUNDERBEAST GAMES LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+/**
+ * Resource extension that handles configuring the editor for Javascript
+ */
+export default class TurboBadgerLanguageExtension implements Editor.ClientExtensions.WebViewService {
+    name: string = "ClientTurboBadgerLanguageExtension";
+    description: string = "TurboBadger language services for the editor.";
+
+    private serviceLocator: Editor.ClientExtensions.ClientServiceLocator;
+
+    /**
+    * Initialize the language service
+     * @param  {Editor.ClientExtensions.ClientServiceLocator} serviceLocator
+     */
+    initialize(serviceLocator: Editor.ClientExtensions.ClientServiceLocator) {
+        // initialize the language service
+        this.serviceLocator = serviceLocator;
+    }
+
+    /**
+     * Determines if the file name/path provided is something we care about
+     * @param  {string} path
+     * @return {boolean}
+     */
+    private isValidFiletype(path: string): boolean {
+        return path.toLowerCase().endsWith(".tb.txt") || path.toLowerCase().endsWith(".tb");
+    }
+
+    /**
+     * Called when the editor needs to be configured for a particular file
+     * @param  {Editor.EditorEvents.EditorFileEvent} ev
+     */
+    configureEditor(ev: Editor.EditorEvents.EditorFileEvent) {
+        if (this.isValidFiletype(ev.filename)) {
+            let editor = <AceAjax.Editor>ev.editor;
+            editor.session.setMode("ace/mode/properties");
+
+            editor.setOptions({
+                enableBasicAutocompletion: true,
+                enableLiveAutocompletion: true,
+                useSoftTabs: false,
+                showInvisibles: true
+            });
+        }
+    }
+}

--- a/Script/AtomicWebViewEditor/tsconfig.json
+++ b/Script/AtomicWebViewEditor/tsconfig.json
@@ -21,6 +21,7 @@
         "./clientExtensions/ClientExtensionEventNames.ts",
         "./clientExtensions/ClientExtensionServices.ts",
         "./clientExtensions/languageExtensions/javascript/JavascriptLanguageExtension.ts",
+        "./clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts",
         "./clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts",
         "./clientExtensions/languageExtensions/typescript/workerprocess/TypescriptLanguageService.ts",
         "./clientExtensions/languageExtensions/typescript/workerprocess/TypescriptLanguageServiceWebWorker.ts",


### PR DESCRIPTION
added new language handler for turbobadger files in the webview editor.  Turns off soft tabs and shows whitespace as well as using the "properties" language highlighter.  This works for files with *.tb.txt and *.tb file extensions.