### PR TITLE
User preferences system for extensions

### DIFF
--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -161,6 +161,18 @@ class Editor extends Atomic.ScriptObject {
         this.sendEvent(EditorEvents.UserPreferencesChangedNotification);
     }
 
+    /**
+     * Sets a group of user preference values in the user settings file located in the project.  Elements in the
+     * group will merge in with existing group preferences.  Use this method if setting a bunch of settings
+     * at once.
+     * @param  {string} settingsGroup name of the group the preference lives under
+     * @param  {string} groupPreferenceValues an object literal containing all of the preferences for the group.
+     */
+    setUserPreferenceGroup(settingsGroup: string, groupPreferenceValues: Object) {
+        Preferences.getInstance().setUserPreferenceGroup(settingsGroup, groupPreferenceValues);
+        this.sendEvent(EditorEvents.UserPreferencesChangedNotification);
+    }
+
     handleEditorLoadProject(event: EditorEvents.LoadProjectEvent): boolean {
 
         var system = ToolCore.getToolSystem();

--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -145,7 +145,10 @@ class Editor extends Atomic.ScriptObject {
      * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
      * @return {number|boolean|string}
      */
-    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: any): any {
         return Preferences.getInstance().getUserPreference(extensionName, preferenceName, defaultValue);
     }
 

--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -55,7 +55,7 @@ class Editor extends Atomic.ScriptObject {
 
         this.editorLicense = new EditorLicense();
 
-        EditorUI.initialize();
+        EditorUI.initialize(this);
 
         this.playMode = new PlayMode();
 
@@ -136,6 +136,29 @@ class Editor extends Atomic.ScriptObject {
         Preferences.getInstance().saveEditorWindowData(editorWindowData);
 
         return true;
+    }
+
+    /**
+     * Return a preference value or the provided default from the user settings file
+     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} preferenceName name of the preference to retrieve
+     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+     * @return {number|boolean|string}
+     */
+    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
+        return Preferences.getInstance().getUserPreference(extensionName, preferenceName, defaultValue);
+    }
+
+
+    /**
+     * Sets a user preference value in the user settings file
+     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} preferenceName name of the preference to set
+     * @param  {number | boolean | string} value value to set
+     */
+    setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
+        Preferences.getInstance().setUserPreference(extensionName, preferenceName, value);
+        this.sendEvent(EditorEvents.UserPreferencesChangedNotification);
     }
 
     handleEditorLoadProject(event: EditorEvents.LoadProjectEvent): boolean {

--- a/Script/AtomicEditor/editor/EditorEvents.ts
+++ b/Script/AtomicEditor/editor/EditorEvents.ts
@@ -157,3 +157,5 @@ export const RemoveCurrentAssetAssigned = "RemoveCurrentAssetAssigned";
 export interface RemoveCurrentAssetAssignedEvent {
 
 }
+
+export const UserPreferencesChangedNotification  = "UserPreferencesChangedNotification";

--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -31,7 +31,7 @@ class Preferences {
     private static instance: Preferences;
     private _prefs: PreferencesFormat;
 
-    private cachedProjectjPreferences: Object = null;
+    private cachedProjectPreferences: Object = null;
 
     constructor() {
         this.fileSystem = Atomic.getFileSystem();
@@ -155,24 +155,27 @@ class Preferences {
      * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
      * @return {number|boolean|string}
      */
-    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: any): any {
 
         // Cache the settings so we don't keep going out to the file
-        if (this.cachedProjectjPreferences == null) {
+        if (this.cachedProjectPreferences == null) {
             const prefsFileLoc = ToolCore.toolSystem.project.userPrefsFullPath;
             if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
                 let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
                 try {
                     let prefs = JSON.parse(prefsFile.readText());
-                    this.cachedProjectjPreferences = prefs;
+                    this.cachedProjectPreferences = prefs;
                 } finally {
                     prefsFile.close();
                 }
             }
         }
 
-        if (this.cachedProjectjPreferences && this.cachedProjectjPreferences[settingsGroup]) {
-            return this.cachedProjectjPreferences[settingsGroup][preferenceName] || defaultValue;
+        if (this.cachedProjectPreferences && this.cachedProjectPreferences[settingsGroup]) {
+            return this.cachedProjectPreferences[settingsGroup][preferenceName] || defaultValue;
         }
 
         // if all else fails
@@ -211,7 +214,7 @@ class Preferences {
         }
 
         // Cache the update
-        this.cachedProjectjPreferences = prefs;
+        this.cachedProjectPreferences = prefs;
     }
 
 
@@ -250,7 +253,7 @@ class Preferences {
         }
 
         // Cache the update
-        this.cachedProjectjPreferences = prefs;
+        this.cachedProjectPreferences = prefs;
     }
 }
 

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -147,6 +147,17 @@ export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensi
     setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
         EditorUI.getEditor().setUserPreference(extensionName, preferenceName, value);
     }
+
+    /**
+     * Sets a group of user preference values in the user settings file located in the project.  Elements in the
+     * group will merge in with existing group preferences.  Use this method if setting a bunch of settings
+     * at once.
+     * @param  {string} extensionName name of the group the preference lives under
+     * @param  {string} groupPreferenceValues an object literal containing all of the preferences for the group.
+     */
+    setUserPreferenceGroup(extensionName: string, groupPreferenceValues: Object) {
+        EditorUI.getEditor().setUserPreferenceGroup(extensionName, groupPreferenceValues);
+    }
 }
 
 /**

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -123,6 +123,66 @@ export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensi
             }
         });
     }
+
+    /**
+     * Return a preference value or the provided default from the user settings file
+     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} preferenceName name of the preference to retrieve
+     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+     * @return {number|boolean|string}
+     */
+    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
+        const prefsFileLoc = ToolCore.toolSystem.project.userPrefsFullPath;
+        if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
+            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
+            try {
+                let prefs = JSON.parse(prefsFile.readText());
+                let extensionPrefs = prefs["extensions"];
+                if (extensionPrefs && extensionPrefs[extensionName]) {
+                    return extensionPrefs[extensionName][preferenceName] || defaultValue;
+                }
+            } finally {
+                prefsFile.close();
+            }
+        }
+
+        // if all else fails
+        return defaultValue;
+    }
+
+
+    /**
+     * Sets a user preference value in the user settings file
+     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} preferenceName name of the preference to set
+     * @param  {number | boolean | string} value value to set
+     */
+    setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
+
+        const prefsFileLoc = ToolCore.toolSystem.project.userPrefsFullPath;
+        let prefs = {};
+
+        if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
+            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
+            try {
+                prefs = JSON.parse(prefsFile.readText());
+            } finally {
+                prefsFile.close();
+            }
+        }
+
+        prefs["extensions"] = prefs["extensions"] || {};
+        prefs["extensions"][extensionName] = prefs["extensions"][extensionName] || {};
+        prefs["extensions"][extensionName][preferenceName] = value;
+
+        let saveFile = new Atomic.File(prefsFileLoc, Atomic.FILE_WRITE);
+        try {
+            saveFile.writeString(JSON.stringify(prefs, null, "  "));
+        } finally {
+            saveFile.flush();
+            saveFile.close();
+        }
+    }
 }
 
 /**
@@ -196,7 +256,7 @@ export class ResourceServicesProvider extends ServicesProvider<Editor.HostExtens
     }
 
     /**
-     * Create New Material 
+     * Create New Material
      * @param  {string} resourcePath
      * @param  {string} materialName
      * @param  {boolean} reportError
@@ -391,7 +451,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
                     }
                 }
             } catch (e) {
-               EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
+                EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
             }
         });
     }
@@ -403,7 +463,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
      * @type {boolean} return true if handled
      */
     hierarchyContextItemClicked(node: Atomic.Node, refid: string): boolean {
-        if (!node) 
+        if (!node)
             return false;
 
         // run through and find any services that can handle this.
@@ -416,7 +476,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
                     }
                 }
             } catch (e) {
-               EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
+                EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
             }
         });
     }
@@ -442,7 +502,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
                     }
                 }
             } catch (e) {
-               EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
+                EditorUI.showModalError("Extension Error", `Error detected in extension ${service.name}:\n${e}\n\n ${e.stack}`);
             }
         });
     }

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -25,6 +25,8 @@ import * as EditorUI from "../ui/EditorUI";
 import MainFrame = require("../ui/frames/MainFrame");
 import ModalOps = require("../ui/modal/ModalOps");
 import ResourceOps = require("../resources/ResourceOps");
+import Editor = require("../editor/Editor");
+
 /**
  * Generic registry for storing Editor Extension Services
  */
@@ -132,22 +134,7 @@ export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensi
      * @return {number|boolean|string}
      */
     getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
-        const prefsFileLoc = ToolCore.toolSystem.project.userPrefsFullPath;
-        if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
-            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
-            try {
-                let prefs = JSON.parse(prefsFile.readText());
-                let extensionPrefs = prefs["extensions"];
-                if (extensionPrefs && extensionPrefs[extensionName]) {
-                    return extensionPrefs[extensionName][preferenceName] || defaultValue;
-                }
-            } finally {
-                prefsFile.close();
-            }
-        }
-
-        // if all else fails
-        return defaultValue;
+        return EditorUI.getEditor().getUserPreference(extensionName, preferenceName);
     }
 
 
@@ -158,30 +145,7 @@ export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensi
      * @param  {number | boolean | string} value value to set
      */
     setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
-
-        const prefsFileLoc = ToolCore.toolSystem.project.userPrefsFullPath;
-        let prefs = {};
-
-        if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
-            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
-            try {
-                prefs = JSON.parse(prefsFile.readText());
-            } finally {
-                prefsFile.close();
-            }
-        }
-
-        prefs["extensions"] = prefs["extensions"] || {};
-        prefs["extensions"][extensionName] = prefs["extensions"][extensionName] || {};
-        prefs["extensions"][extensionName][preferenceName] = value;
-
-        let saveFile = new Atomic.File(prefsFileLoc, Atomic.FILE_WRITE);
-        try {
-            saveFile.writeString(JSON.stringify(prefs, null, "  "));
-        } finally {
-            saveFile.flush();
-            saveFile.close();
-        }
+        EditorUI.getEditor().setUserPreference(extensionName, preferenceName, value);
     }
 }
 

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -133,8 +133,11 @@ export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensi
      * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
      * @return {number|boolean|string}
      */
-    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
-        return EditorUI.getEditor().getUserPreference(extensionName, preferenceName);
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+    getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: any): any {
+        return EditorUI.getEditor().getUserPreference(extensionName, preferenceName, defaultValue);
     }
 
 

--- a/Script/AtomicEditor/ui/EditorUI.ts
+++ b/Script/AtomicEditor/ui/EditorUI.ts
@@ -25,6 +25,7 @@ import MainFrame = require("./frames/MainFrame");
 import ModalOps = require("./modal/ModalOps");
 import Shortcuts = require("./Shortcuts");
 import ServiceLocator from "../hostExtensions/ServiceLocator";
+import Editor = require("editor/Editor");
 
 // this is designed with public get functions to solve
 // circular dependency issues in TS
@@ -47,8 +48,12 @@ export function getShortcuts():Shortcuts {
   return editorUI.shortcuts;
 }
 
-export function initialize() {
-  editorUI = new EditorUI();
+export function initialize(editor: Editor) {
+  editorUI = new EditorUI(editor);
+}
+
+export function getEditor(): Editor {
+    return editorUI.editor;
 }
 
 export function shutdown() {
@@ -68,10 +73,9 @@ export function getCurrentResourceEditor():Editor.ResourceEditor {
     return getMainFrame().resourceframe.currentResourceEditor;
 }
 
-
 class EditorUI extends Atomic.ScriptObject {
 
-  constructor() {
+  constructor(editor: Editor) {
 
     super();
 
@@ -82,6 +86,8 @@ class EditorUI extends Atomic.ScriptObject {
     this.mainframe = new MainFrame();
 
     this.view.addChild(this.mainframe);
+
+    this.editor = editor;
 
     this.subscribeToEvent("ScreenMode", (ev:Atomic.ScreenModeEvent) => {
 
@@ -97,7 +103,7 @@ class EditorUI extends Atomic.ScriptObject {
 
     // Hook the service locator into the event system and give it the ui objects it needs
     ServiceLocator.uiServices.init(
-      this.mainframe, 
+      this.mainframe,
       this.modalOps);
     ServiceLocator.subscribeToEvents(this.mainframe);
 
@@ -115,5 +121,6 @@ class EditorUI extends Atomic.ScriptObject {
   mainframe: MainFrame;
   modalOps: ModalOps;
   shortcuts: Shortcuts;
+  editor: Editor;
 
 }

--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -100,14 +100,7 @@ class ResourceFrame extends ScriptWidget {
 
         if (ext == ".js" || ext == ".txt" || ext == ".json" || ext == ".ts") {
 
-             let jseditor = new Editor.JSResourceEditor(path, this.tabcontainer);
-
-             jseditor.subscribeToEvent(EditorEvents.UserPreferencesChangedNotification, (data) => {
-                 // We can get the webclient here now, though this might not be a great place to set this up                 
-                 let webClient = jseditor.webView.webClient;
-             });
-
-             editor = jseditor;
+             editor = new Editor.JSResourceEditor(path, this.tabcontainer);
 
         } else if (ext == ".scene") {
 
@@ -233,6 +226,23 @@ class ResourceFrame extends ScriptWidget {
         }
     }
 
+    handleUserPreferencesChanged() {
+        let prefsPath = ToolCore.toolSystem.project.userPrefsFullPath;
+        if (Atomic.fileSystem.fileExists(prefsPath)) {
+            for (let editorKey in this.editors) {
+                let editor = this.editors[editorKey];
+                if (editor.typeName == "JSResourceEditor") {
+                    let jsEditor = <Editor.JSResourceEditor>editor;
+
+                    // Get a reference to the web client so we can call the load preferences method
+                    let webClient = jsEditor.webView.webClient;
+
+                    webClient.executeJavaScript(`HOST_loadPreferences("atomic://${prefsPath}");`);
+                }
+            }
+        }
+    }
+
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
         if (ev.type == Atomic.UI_EVENT_TYPE_TAB_CHANGED && ev.target == this.tabcontainer) {
@@ -305,6 +315,7 @@ class ResourceFrame extends ScriptWidget {
         this.subscribeToEvent(EditorEvents.EditorResourceClose, (ev: EditorEvents.EditorCloseResourceEvent) => this.handleCloseResource(ev));
         this.subscribeToEvent(EditorEvents.RenameResourceNotification, (ev: EditorEvents.RenameResourceEvent) => this.handleRenameResource(ev));
         this.subscribeToEvent(EditorEvents.DeleteResourceNotification, (data) => this.handleDeleteResource(data));
+        this.subscribeToEvent(EditorEvents.UserPreferencesChangedNotification, (data) => this.handleUserPreferencesChanged());
 
         this.subscribeToEvent(UIEvents.ResourceEditorChanged, (data) => this.handleResourceEditorChanged(data));
 

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionEventNames.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionEventNames.ts
@@ -30,4 +30,5 @@ export default class ClientExtensionEventNames {
     static ResourceRenamedEvent = "ResourceRenamedEvent";
     static ResourceDeletedEvent = "ResourceDeletedEvent";
     static ProjectUnloadedEvent = "ProjectUnloadedEvent";
+    static PreferencesChangedEvent = "PreferencesChangedEvent";
 }

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -86,6 +86,7 @@ export class ExtensionServiceRegistry extends ServiceRegistry<Editor.ClientExten
         eventDispatcher.subscribeToEvent(ClientExtensionEventNames.ProjectUnloadedEvent, (ev) => this.projectUnloaded());
         eventDispatcher.subscribeToEvent(ClientExtensionEventNames.ResourceDeletedEvent, (ev) => this.deleteResource(ev));
         eventDispatcher.subscribeToEvent(ClientExtensionEventNames.CodeSavedEvent, (ev) => this.saveCode(ev));
+        eventDispatcher.subscribeToEvent(ClientExtensionEventNames.PreferencesChangedEvent, (ev) => this.preferencesChanged());
     }
 
     /**
@@ -189,4 +190,23 @@ export class ExtensionServiceRegistry extends ServiceRegistry<Editor.ClientExten
             }
         });
     }
+
+    /**
+     * Called when prefeerences changes
+     * @param  {Editor.EditorEvents.PreferencesChangedEvent} ev
+     */
+    preferencesChanged() {
+        this.registeredServices.forEach((service) => {
+            // Notify services that the project has been unloaded
+            try {
+                if (service.preferencesChanged) {
+                    service.preferencesChanged();
+                }
+            } catch (e) {
+                alert(`Extension Error:\n Error detected in extension ${service.name}\n \n ${e.stack}`);
+            }
+        });
+    }
+
+
 }

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -231,16 +231,16 @@ export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExten
 
     /**
      * Return a preference value or the provided default from the user settings file
-     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} gorupName name of the group the preference lives under
      * @param  {string} preferenceName name of the preference to retrieve
      * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
      * @return {number|boolean|string}
      */
-    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
+    getUserPreference(groupName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
         if (this.userPreferences) {
-            let extensionPrefs = this.userPreferences["extensions"];
-            if (extensionPrefs && extensionPrefs[extensionName]) {
-                return extensionPrefs[extensionName][preferenceName] || defaultValue;
+            let prefs = this.userPreferences[groupName];
+            if (prefs) {
+                return prefs[groupName][preferenceName] || defaultValue;
             }
         }
 

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -204,7 +204,7 @@ export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExten
     }
 
     /**
-     * Called when prefeerences changes
+     * Called when preferences changes
      * @param  {Editor.EditorEvents.PreferencesChangedEvent} ev
      */
     preferencesChanged() {

--- a/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
@@ -19,7 +19,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
-import HostInteropType from "../interop";
 import * as ClientExtensionServices from "./ClientExtensionServices";
 
 // Initialize and configure the extensions
@@ -34,26 +33,15 @@ import tbExtension from "./languageExtensions/turbobadger/TurboBadgerLanguageExt
 export class ClientServiceLocatorType implements Editor.ClientExtensions.ClientServiceLocator {
 
     constructor() {
-        this.services = new ClientExtensionServices.ExtensionServiceRegistry();
-        this.services.subscribeToEvents(this);
+        this.clientServices = new ClientExtensionServices.WebViewServicesProvider();
+        this.clientServices.subscribeToEvents(this);
     }
 
-    private services: ClientExtensionServices.ExtensionServiceRegistry;
     private eventDispatcher: Editor.Extensions.EventDispatcher = new ClientExtensionServices.EventDispatcher();
-    private userPreferences = {};
-    
-    /**
-     * Sets the preferences for the service locator
-     * @param  {any} prefs
-     * @return {[type]}
-     */
-    setPreferences(prefs : any) {
-        this.userPreferences = prefs;
-    }
 
+    clientServices: ClientExtensionServices.WebViewServicesProvider;
     loadService(service: Editor.ClientExtensions.ClientEditorService) {
         try {
-            this.services.register(service);
             service.initialize(this);
         } catch (e) {
             alert(`Extension Error:\n Error detected in extension ${service.name}\n \n ${e.stack}`);
@@ -82,35 +70,6 @@ export class ClientServiceLocatorType implements Editor.ClientExtensions.ClientS
         }
     }
 
-    /** Methods available to extensions **/
-
-    /**
-     * Returns the Host Interop module
-     * @return {Editor.ClientExtensions.HostInterop}
-     */
-    getHostInterop(): Editor.ClientExtensions.HostInterop {
-        return HostInteropType.getInstance();
-    }
-
-
-    /**
-     * Return a preference value or the provided default from the user settings file
-     * @param  {string} extensionName name of the extension the preference lives under
-     * @param  {string} preferenceName name of the preference to retrieve
-     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
-     * @return {number|boolean|string}
-     */
-    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
-        if (this.userPreferences) {
-            let extensionPrefs = this.userPreferences["extensions"];
-            if (extensionPrefs && extensionPrefs[extensionName]) {
-                return extensionPrefs[extensionName][preferenceName] || defaultValue;
-            }
-        }
-
-        // if all else fails
-        return defaultValue;
-    }
 }
 
 // Singleton service locator that can be referenced

--- a/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
@@ -40,13 +40,15 @@ export class ClientServiceLocatorType implements Editor.ClientExtensions.ClientS
 
     private services: ClientExtensionServices.ExtensionServiceRegistry;
     private eventDispatcher: Editor.Extensions.EventDispatcher = new ClientExtensionServices.EventDispatcher();
-
+    private userPreferences = {};
+    
     /**
-     * Returns the Host Interop module
-     * @return {Editor.ClientExtensions.HostInterop}
+     * Sets the preferences for the service locator
+     * @param  {any} prefs
+     * @return {[type]}
      */
-    getHostInterop(): Editor.ClientExtensions.HostInterop {
-        return HostInteropType.getInstance();
+    setPreferences(prefs : any) {
+        this.userPreferences = prefs;
     }
 
     loadService(service: Editor.ClientExtensions.ClientEditorService) {
@@ -78,6 +80,36 @@ export class ClientServiceLocatorType implements Editor.ClientExtensions.ClientS
         if (this.eventDispatcher) {
             this.eventDispatcher.subscribeToEvent(eventType, callback);
         }
+    }
+
+    /** Methods available to extensions **/
+
+    /**
+     * Returns the Host Interop module
+     * @return {Editor.ClientExtensions.HostInterop}
+     */
+    getHostInterop(): Editor.ClientExtensions.HostInterop {
+        return HostInteropType.getInstance();
+    }
+
+
+    /**
+     * Return a preference value or the provided default from the user settings file
+     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} preferenceName name of the preference to retrieve
+     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+     * @return {number|boolean|string}
+     */
+    getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string {
+        if (this.userPreferences) {
+            let extensionPrefs = this.userPreferences["extensions"];
+            if (extensionPrefs && extensionPrefs[extensionName]) {
+                return extensionPrefs[extensionName][preferenceName] || defaultValue;
+            }
+        }
+
+        // if all else fails
+        return defaultValue;
     }
 }
 

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/javascript/JavascriptLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/javascript/JavascriptLanguageExtension.ts
@@ -23,7 +23,7 @@
 /**
  * Resource extension that handles configuring the editor for Javascript
  */
-export default class JavascriptLanguageExtension implements Editor.ClientExtensions.WebViewService {
+export default class JavascriptLanguageExtension implements Editor.ClientExtensions.WebViewServiceEventListener {
     name: string = "ClientJavascriptLanguageExtension";
     description: string = "Javascript language services for the editor.";
 
@@ -36,6 +36,7 @@ export default class JavascriptLanguageExtension implements Editor.ClientExtensi
     initialize(serviceLocator: Editor.ClientExtensions.ClientServiceLocator) {
         // initialize the language service
         this.serviceLocator = serviceLocator;
+        serviceLocator.clientServices.register(this);
     }
 
     /**

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts
@@ -23,7 +23,7 @@
 /**
  * Resource extension that handles configuring the editor for Javascript
  */
-export default class TurboBadgerLanguageExtension implements Editor.ClientExtensions.WebViewService {
+export default class TurboBadgerLanguageExtension implements Editor.ClientExtensions.WebViewServiceEventListener {
     name: string = "ClientTurboBadgerLanguageExtension";
     description: string = "TurboBadger language services for the editor.";
 
@@ -36,6 +36,7 @@ export default class TurboBadgerLanguageExtension implements Editor.ClientExtens
     initialize(serviceLocator: Editor.ClientExtensions.ClientServiceLocator) {
         // initialize the language service
         this.serviceLocator = serviceLocator;
+        serviceLocator.clientServices.register(this);
     }
 
     /**

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
@@ -300,4 +300,12 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
             this.worker.port.postMessage(message);
         }
     }
+
+    /**
+     * Called when the user preferences have been changed (or initially loaded)
+     * @return {[type]}
+     */
+    preferencesChanged() {
+        // nothing to do yet
+    }
 }

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
@@ -28,7 +28,7 @@ import ClientExtensionEventNames from "../../ClientExtensionEventNames";
 /**
  * Resource extension that handles compiling or transpling typescript on file save.
  */
-export default class TypescriptLanguageExtension implements Editor.ClientExtensions.WebViewService {
+export default class TypescriptLanguageExtension implements Editor.ClientExtensions.WebViewServiceEventListener {
     name: string = "ClientTypescriptLanguageExtension";
     description: string = "This extension handles typescript language features such as completion, compilation, etc.";
 
@@ -57,6 +57,7 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
     initialize(serviceLocator: Editor.ClientExtensions.ClientServiceLocator) {
         // initialize the language service
         this.serviceLocator = serviceLocator;
+        serviceLocator.clientServices.register(this);
     }
 
     /**
@@ -306,6 +307,7 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
      * @return {[type]}
      */
     preferencesChanged() {
-        // nothing to do yet
+        // Stub function for now
+        this.serviceLocator.clientServices.getUserPreference("TypescriptLanguageExtension", "CompileOnSave", true);
     }
 }

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -123,3 +123,12 @@ export function codeSaved(path: string, fileExt: string, contents: string) {
     };
     serviceLocator.sendEvent(ClientExtensionEventNames.CodeSavedEvent, data);
 }
+
+/**
+ * Called when new preferences are available (or initially with current prefs)
+ * @param  {any} prefs
+ */
+export function loadPreferences(prefs: any) {
+    serviceLocator.setPreferences(prefs);
+    serviceLocator.sendEvent(ClientExtensionEventNames.PreferencesChangedEvent, null);
+}

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -129,6 +129,6 @@ export function codeSaved(path: string, fileExt: string, contents: string) {
  * @param  {any} prefs
  */
 export function loadPreferences(prefs: any) {
-    serviceLocator.setPreferences(prefs);
+    serviceLocator.clientServices.setPreferences(prefs);
     serviceLocator.sendEvent(ClientExtensionEventNames.PreferencesChangedEvent, null);
 }

--- a/Script/AtomicWebViewEditor/typings/WindowExt.d.ts
+++ b/Script/AtomicWebViewEditor/typings/WindowExt.d.ts
@@ -31,4 +31,5 @@ interface Window {
     HOST_projectUnloaded: () => void;
     HOST_resourceRenamed: (path: string, newPath: string) => void;
     HOST_resourceDeleted: (path: string) => void;
+    HOST_loadPreferences: (path: string) => void;
 }

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -318,6 +318,39 @@ declare module Editor.ClientExtensions {
      * or by the editor itself.
      */
     export interface ClientServiceLocator extends Editor.Extensions.ServiceLoader {
+        /**
+         * Exposed services
+         * @type {WebViewServicesProvider}
+         */
+        clientServices: WebViewServicesProvider;
+    }
+
+    export interface ClientEditorService extends Editor.Extensions.EditorServiceExtension {
+        /**
+         * Called by the service locator at load time
+         */
+        initialize(serviceLocator: ClientServiceLocator);
+    }
+
+    export interface WebViewServiceEventListener extends Editor.Extensions.EditorServiceExtension {
+        configureEditor?(ev: EditorEvents.EditorFileEvent);
+        codeLoaded?(ev: EditorEvents.CodeLoadedEvent);
+        save?(ev: EditorEvents.CodeSavedEvent);
+        delete?(ev: EditorEvents.DeleteResourceEvent);
+        rename?(ev: EditorEvents.RenameResourceEvent);
+        projectUnloaded?();
+        preferencesChanged?();
+    }
+
+    /**
+     * Available methods exposed to client services
+     */
+    export interface WebViewServicesProvider extends Editor.Extensions.ServicesProvider<WebViewServiceEventListener> {
+
+        /**
+         * Get a reference to the interop to talk to the host
+         * @return {HostInterop}
+         */
         getHostInterop(): HostInterop;
 
         /**
@@ -328,23 +361,6 @@ declare module Editor.ClientExtensions {
          * @return {number|boolean|string}
          */
         getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string;
-    }
-
-    export interface ClientEditorService extends Editor.Extensions.EditorServiceExtension {
-        /**
-         * Called by the service locator at load time
-         */
-        initialize(serviceLocator: ClientServiceLocator);
-    }
-
-    export interface WebViewService extends Editor.Extensions.EditorServiceExtension {
-        configureEditor?(ev: EditorEvents.EditorFileEvent);
-        codeLoaded?(ev: EditorEvents.CodeLoadedEvent);
-        save?(ev: EditorEvents.CodeSavedEvent);
-        delete?(ev: EditorEvents.DeleteResourceEvent);
-        rename?(ev: EditorEvents.RenameResourceEvent);
-        projectUnloaded?();
-        preferencesChanged?();
     }
 
     export interface AtomicErrorMessage {

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -140,6 +140,12 @@ declare module Editor.EditorEvents {
         serializable: Atomic.Serializable;
 
     }
+
+    export interface PreferencesChangedEvent {
+
+        preferences: any;
+
+    }
 }
 
 declare module Editor.Extensions {
@@ -313,6 +319,15 @@ declare module Editor.ClientExtensions {
      */
     export interface ClientServiceLocator extends Editor.Extensions.ServiceLoader {
         getHostInterop(): HostInterop;
+
+        /**
+         * Return a preference value or the provided default from the user settings file
+         * @param  {string} extensionName name of the extension the preference lives under
+         * @param  {string} preferenceName name of the preference to retrieve
+         * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+         * @return {number|boolean|string}
+         */
+        getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string;
     }
 
     export interface ClientEditorService extends Editor.Extensions.EditorServiceExtension {
@@ -329,6 +344,7 @@ declare module Editor.ClientExtensions {
         delete?(ev: EditorEvents.DeleteResourceEvent);
         rename?(ev: EditorEvents.RenameResourceEvent);
         projectUnloaded?();
+        preferencesChanged?();
     }
 
     export interface AtomicErrorMessage {

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -256,7 +256,25 @@ declare module Editor.HostExtensions {
         projectLoaded?(ev: EditorEvents.LoadProjectEvent);
         playerStarted?();
     }
-    export interface ProjectServicesProvider extends Editor.Extensions.ServicesProvider<ProjectServicesEventListener> { }
+    export interface ProjectServicesProvider extends Editor.Extensions.ServicesProvider<ProjectServicesEventListener> {
+
+        /**
+         * Return a preference value or the provided default from the user settings file
+         * @param  {string} extensionName name of the extension the preference lives under
+         * @param  {string} preferenceName name of the preference to retrieve
+         * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+         * @return {number|boolean|string}
+         */
+        getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string;
+
+        /**
+         * Sets a user preference value in the user settings file
+         * @param  {string} extensionName name of the extension the preference lives under
+         * @param  {string} preferenceName name of the preference to set
+         * @param  {number | boolean | string} value value to set
+         */
+        setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string);
+    }
 
     export interface SceneServicesEventListener extends Editor.Extensions.ServiceEventListener {
         activeSceneEditorChanged?(ev: EditorEvents.ActiveSceneEditorChangeEvent);

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -271,7 +271,9 @@ declare module Editor.HostExtensions {
          * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
          * @return {number|boolean|string}
          */
-        getUserPreference(extensionName: string, preferenceName: string, defaultValue?: number | boolean | string): number | boolean | string;
+        getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+        getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+        getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
 
         /**
          * Sets a user preference value in the user settings file

--- a/Source/Atomic/Resource/ResourceEvents.h
+++ b/Source/Atomic/Resource/ResourceEvents.h
@@ -95,6 +95,11 @@ EVENT(E_PROJECTUNLOADEDNOTIFICATION, ProjecUnloadedNotification)
 {
 }
     
+/// User Preferences Changed
+EVENT(E_USERPREFERENCESCHANGEDNOTIFICAITON, UserPreferencesChangedNotification)
+{
+}
+    
 
 /// Language changed.
 EVENT(E_CHANGELANGUAGE, ChangeLanguage)

--- a/Source/Atomic/Resource/ResourceEvents.h
+++ b/Source/Atomic/Resource/ResourceEvents.h
@@ -74,7 +74,7 @@ EVENT(E_RESOURCEBACKGROUNDLOADED, ResourceBackgroundLoaded)
     PARAM(P_SUCCESS, Success);                      // bool
     PARAM(P_RESOURCE, Resource);                    // Resource pointer
 }
-    
+
 /// Resource was renamed
 EVENT(E_RENAMERESOURCENOTIFICATION, RenameResourceNotification)
 {
@@ -95,12 +95,6 @@ EVENT(E_PROJECTUNLOADEDNOTIFICATION, ProjecUnloadedNotification)
 {
 }
     
-/// User Preferences Changed
-EVENT(E_USERPREFERENCESCHANGEDNOTIFICAITON, UserPreferencesChangedNotification)
-{
-}
-    
-
 /// Language changed.
 EVENT(E_CHANGELANGUAGE, ChangeLanguage)
 {

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -90,7 +90,6 @@ JSResourceEditor ::JSResourceEditor(Context* context, const String &fullpath, UI
     SubscribeToEvent(E_RENAMERESOURCENOTIFICATION, HANDLER(JSResourceEditor, HandleRenameResourceNotification));
     SubscribeToEvent(E_DELETERESOURCENOTIFICATION, HANDLER(JSResourceEditor, HandleDeleteResourceNotification));
     SubscribeToEvent(E_PROJECTUNLOADEDNOTIFICATION, HANDLER(JSResourceEditor, HandleProjectUnloadedNotification));
-    SubscribeToEvent(E_USERPREFERENCESCHANGEDNOTIFICAITON, HANDLER(JSResourceEditor, HandleUserPreferencesChangedNotification));
 
     c->AddChild(webView_->GetInternalWidget());
 
@@ -138,17 +137,6 @@ void JSResourceEditor::HandleProjectUnloadedNotification(StringHash eventType, V
     webClient_->ExecuteJavaScript("HOST_projectUnloaded();");
 }
 
-void JSResourceEditor::HandleUserPreferencesChangedNotification(StringHash eventType, VariantMap& eventData)
-{
-    ToolSystem* tsys = GetSubsystem<ToolSystem>();
-    Project* proj = tsys->GetProject();
-    FileSystem* fileSystem = GetSubsystem<FileSystem>();
-    if (fileSystem->FileExists(proj->GetUserPrefsFullPath()))
-    {
-        webClient_->ExecuteJavaScript(ToString("HOST_loadPreferences(\"atomic://%s\");", proj->GetUserPrefsFullPath().CString()));
-    }
-}
-    
 void JSResourceEditor::HandleWebViewLoadEnd(StringHash eventType, VariantMap& eventData)
 {
     // need to wait until we get an editor load complete message since we could

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -90,6 +90,7 @@ JSResourceEditor ::JSResourceEditor(Context* context, const String &fullpath, UI
     SubscribeToEvent(E_RENAMERESOURCENOTIFICATION, HANDLER(JSResourceEditor, HandleRenameResourceNotification));
     SubscribeToEvent(E_DELETERESOURCENOTIFICATION, HANDLER(JSResourceEditor, HandleDeleteResourceNotification));
     SubscribeToEvent(E_PROJECTUNLOADEDNOTIFICATION, HANDLER(JSResourceEditor, HandleProjectUnloadedNotification));
+    SubscribeToEvent(E_USERPREFERENCESCHANGEDNOTIFICAITON, HANDLER(JSResourceEditor, HandleUserPreferencesChangedNotification));
 
     c->AddChild(webView_->GetInternalWidget());
 
@@ -137,6 +138,17 @@ void JSResourceEditor::HandleProjectUnloadedNotification(StringHash eventType, V
     webClient_->ExecuteJavaScript("HOST_projectUnloaded();");
 }
 
+void JSResourceEditor::HandleUserPreferencesChangedNotification(StringHash eventType, VariantMap& eventData)
+{
+    ToolSystem* tsys = GetSubsystem<ToolSystem>();
+    Project* proj = tsys->GetProject();
+    FileSystem* fileSystem = GetSubsystem<FileSystem>();
+    if (fileSystem->FileExists(proj->GetUserPrefsFullPath()))
+    {
+        webClient_->ExecuteJavaScript(ToString("HOST_loadPreferences(\"atomic://%s\");", proj->GetUserPrefsFullPath().CString()));
+    }
+}
+    
 void JSResourceEditor::HandleWebViewLoadEnd(StringHash eventType, VariantMap& eventData)
 {
     // need to wait until we get an editor load complete message since we could

--- a/Source/AtomicEditor/Editors/JSResourceEditor.h
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.h
@@ -74,7 +74,6 @@ private:
     void HandleRenameResourceNotification(StringHash eventType, VariantMap& eventData);
     void HandleDeleteResourceNotification(StringHash eventType, VariantMap& eventData);
     void HandleProjectUnloadedNotification(StringHash eventType, VariantMap& eventData);
-    void HandleUserPreferencesChangedNotification(StringHash eventType, VariantMap& eventData);
     
     SharedPtr<UIWebView> webView_;
     WeakPtr<WebClient> webClient_;

--- a/Source/AtomicEditor/Editors/JSResourceEditor.h
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.h
@@ -71,6 +71,7 @@ private:
     void HandleRenameResourceNotification(StringHash eventType, VariantMap& eventData);
     void HandleDeleteResourceNotification(StringHash eventType, VariantMap& eventData);
     void HandleProjectUnloadedNotification(StringHash eventType, VariantMap& eventData);
+    void HandleUserPreferencesChangedNotification(StringHash eventType, VariantMap& eventData);
     
     SharedPtr<UIWebView> webView_;
     WeakPtr<WebClient> webClient_;

--- a/Source/ToolCore/Project/ProjectUserPrefs.cpp
+++ b/Source/ToolCore/Project/ProjectUserPrefs.cpp
@@ -136,8 +136,16 @@ bool ProjectUserPrefs::Load(const String& path)
 
 void ProjectUserPrefs::Save(const String& path)
 {
-
     SharedPtr<JSONFile> jsonFile(new JSONFile(context_));
+
+    // Load existing prefs file if it exists and just update editor settings.  The
+    // file may contain other settings we are not aware of so we shouldn't overwrite those
+    SharedPtr<File> oldFile(new File(context_, path));
+    if (oldFile->IsOpen())
+    {
+        bool result = jsonFile->Load(*oldFile);
+        oldFile->Close();
+    }
 
     JSONValue& root = jsonFile->GetRoot();
 


### PR DESCRIPTION
This PR adds the ability for host extensions to store and retrieve preferences from the project user preferences file.  These preferences are also propagated to the web client so that editor extensions can retrieve the settings.  Additionally, whenever preferences are changed from the host, a preference change event is sent to the web client so the web client can respond appropriately.

The other changes here are some lint whitespace changes and also refactoring of the webview client extension names and structure to more closely match the changes made the host extension naming done in a previous PR.

I did have a question on the user preference file.  I'm using: 
```
ToolCore.toolSystem.project.userPrefsFullPath 
```
to store the preferences in and this points to a file called ```projectname.userpreferences```.  It appears that the Snap Settings dialog stores settings in a different file called ```UserPrefs.json``` .  Should't those also be stored in the ```projectname.userpreferences``` file?  

I updated the routine that saves the Snap Settings to not overwrite the file, but to retain any extraneous settings that may also be in there and just update with the known settings, so switching over to the ```projectname.userpreferences``` file should be seamless if that's the way you would like to go.  Either that or have ```ToolCore.toolsSystem.project.userPrefsFullPath``` point to the ```UserPrefs.json``` file.

I'm going to be using this to coordinate some settings in the TypeScript extension, but thought I would break out just the user settings piece into it's own PR so it's easier to digest.
