### PR TITLE
Referenced typescript dependencies in generated definition files

### DIFF
--- a/Source/ToolCore/JSBind/JSBPackage.cpp
+++ b/Source/ToolCore/JSBind/JSBPackage.cpp
@@ -195,6 +195,7 @@ bool JSBPackage::Load(const String& packageFolder)
                 return false;
             }
 
+            dependencies_.Push(depPackage);
         }
 
     }

--- a/Source/ToolCore/JSBind/JSBPackage.h
+++ b/Source/ToolCore/JSBind/JSBPackage.h
@@ -62,6 +62,8 @@ public:
 
     JSBClass* GetClass(const String& name);
 
+    const Vector<SharedPtr<JSBPackage> >& GetDependencies() const { return dependencies_; }
+
     PODVector<JSBClass*>& GetAllClasses() { return allClasses_; }
     void RegisterClass(JSBClass* cls) {allClasses_.Push(cls); }
 

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -100,6 +100,13 @@ void JSBTypeScript::Begin()
     {
         source_ += "/// <reference path=\"Atomic.d.ts\" />\n\n";
     }
+    const Vector<SharedPtr<JSBPackage> >& dependencies = package_->GetDependencies();
+    for (unsigned i = 0; i < dependencies.Size(); i++)
+    {
+        String dependencyName = dependencies[i]->GetName();
+        if (dependencyName != "Atomic")
+            source_ += "/// <reference path=\"" + dependencyName + ".d.ts\" />\n\n";
+    }
 
     source_ += "declare module "+ package_->GetName() + " {\n\n";
 }


### PR DESCRIPTION
Generated .d.ts files were missing references to dependencies, causing ts files that used them to fail to compile.