### PR TITLE
Project based custom editors

### DIFF
--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -400,17 +400,33 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
     }
 
     /**
- * Disaplays a resource slection window
- * @param  {string} windowText
- * @param  {string} importerType
- * @param  {string} resourceType
- * @param  {function} callback
- * @param  {any} retObject
- * @param  {any} args
- */
+     * Displays a resource slection window
+     * @param  {string} windowText
+     * @param  {string} importerType
+     * @param  {string} resourceType
+     * @param  {function} callback
+     * @param  {any} retObject
+     * @param  {any} args
+     */
     showResourceSelection(windowText: string, importerType: string, resourceType: string, callback: (retObject: any, args: any) => void, args: any = undefined) {
 
         this.modalOps.showResourceSelection(windowText, importerType, resourceType, callback);
+    }
+
+    /**
+     * Will register a custom editor for a particular file type.
+     * @param  {Editor.Extensions.ResourceEditorBuilder} editorBuilder
+     */
+    registerCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder) {
+        this.mainFrame.resourceframe.resourceEditorProvider.registerCustomEditor(editorBuilder);
+    }
+
+    /**
+     * Will unregister a previously registered editor builder
+     * @param  {Editor.Extensions.ResourceEditorBuilder} editorBuilder
+     */
+    unregisterCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder) {
+        this.mainFrame.resourceframe.resourceEditorProvider.unregisterCustomEditor(editorBuilder);
     }
 
     /**

--- a/Script/AtomicEditor/ui/ResourceEditorProvider.ts
+++ b/Script/AtomicEditor/ui/ResourceEditorProvider.ts
@@ -49,8 +49,20 @@ export default class ResourceEditorProvider {
      * Register a custom editor.  These editors will override editors in the standard editor list if
      * they both resolve the ```canHandleResource``` call.
      */
-    registerCustomEditor(editorBuilder) {
+    registerCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder) {
         this.customEditorRegistry.push(editorBuilder);
+    }
+
+    /**
+     * Will unregister a previously registered editor builder
+     * @param  {Editor.Extensions.ResourceEditorBuilder} editorBuilder
+     */
+    unregisterCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder) {
+        var index = this.customEditorRegistry.indexOf(editorBuilder, 0);
+        console.log(`custom editor len: ${this.customEditorRegistry.length}`);
+        if (index > -1) {
+            this.customEditorRegistry.splice(index, 1);
+        }
     }
 
     /**
@@ -58,6 +70,7 @@ export default class ResourceEditorProvider {
      */
     getEditor(resourcePath: string, tabContainer) {
         let editorBuilder: Editor.Extensions.ResourceEditorBuilder;
+        console.log(`custom editor len: ${this.customEditorRegistry.length}`);
         this.customEditorRegistry.forEach((builder) => {
             if (builder.canHandleResource(resourcePath)) {
                 editorBuilder = builder;

--- a/Script/AtomicEditor/ui/ResourceEditorProvider.ts
+++ b/Script/AtomicEditor/ui/ResourceEditorProvider.ts
@@ -59,7 +59,6 @@ export default class ResourceEditorProvider {
      */
     unregisterCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder) {
         var index = this.customEditorRegistry.indexOf(editorBuilder, 0);
-        console.log(`custom editor len: ${this.customEditorRegistry.length}`);
         if (index > -1) {
             this.customEditorRegistry.splice(index, 1);
         }
@@ -70,7 +69,6 @@ export default class ResourceEditorProvider {
      */
     getEditor(resourcePath: string, tabContainer) {
         let editorBuilder: Editor.Extensions.ResourceEditorBuilder;
-        console.log(`custom editor len: ${this.customEditorRegistry.length}`);
         this.customEditorRegistry.forEach((builder) => {
             if (builder.canHandleResource(resourcePath)) {
                 editorBuilder = builder;

--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -152,7 +152,6 @@ class ResourceFrame extends ScriptWidget {
     }
 
     handleCloseResource(ev: EditorEvents.EditorCloseResourceEvent) {
-        console.log('close: ' + ev.editor.fullPath);
         this.wasClosed = false;
         var editor = ev.editor;
         var navigate = ev.navigateToAvailableResource;

--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -152,6 +152,7 @@ class ResourceFrame extends ScriptWidget {
     }
 
     handleCloseResource(ev: EditorEvents.EditorCloseResourceEvent) {
+        console.log('close: ' + ev.editor.fullPath);
         this.wasClosed = false;
         var editor = ev.editor;
         var navigate = ev.navigateToAvailableResource;
@@ -259,7 +260,9 @@ class ResourceFrame extends ScriptWidget {
     handleProjectUnloaded(data) {
 
       for (var i in this.editors) {
-           this.sendEvent(EditorEvents.EditorResourceClose, { editor: this.editors[i], navigateToAvailableResource: false });
+          var editor = this.editors[i];
+           this.sendEvent(EditorEvents.EditorResourceClose, { editor: editor, navigateToAvailableResource: false });
+           editor.close();
       }
 
     }

--- a/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
+++ b/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
@@ -35,9 +35,24 @@ export abstract class AbstractTextResourceEditorBuilder implements Editor.Extens
         return path.substring(path.toLowerCase().indexOf(RESOURCES_MARKER));
     }
 
-    getEditor(resourceFrame: Atomic.UIWidget, resourcePath: string, tabContainer: Atomic.UITabContainer): Editor.ResourceEditor {
+    /**
+     * Returns the URL to load into the web view.  Override this to return a custom url
+     * @return {string}
+     */
+    getEditorUrl(): string {
+/*
+        Reference -- delete when working in osx and windows
+        #ifdef ATOMIC_PLATFORM_OSX
+            String url = "file://" + codeEditorDir;
+        #else
+            String url = "file:///" + codeEditorDir;
+        #endif
+*/
+        return `atomic://${ToolCore.toolEnvironment.toolDataDir}CodeEditor/Editor.html`;
+    }
 
-        const editor = new Editor.JSResourceEditor(resourcePath, tabContainer);
+    getEditor(resourceFrame: Atomic.UIWidget, resourcePath: string, tabContainer: Atomic.UITabContainer): Editor.ResourceEditor {
+        const editor = new Editor.JSResourceEditor(resourcePath, tabContainer, this.getEditorUrl());
 
         // one time subscriptions waiting for the web view to finish loading.  This event
         // actually hits the editor instance before we can hook it, so listen to it on the

--- a/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
+++ b/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
@@ -40,14 +40,6 @@ export abstract class AbstractTextResourceEditorBuilder implements Editor.Extens
      * @return {string}
      */
     getEditorUrl(): string {
-/*
-        Reference -- delete when working in osx and windows
-        #ifdef ATOMIC_PLATFORM_OSX
-            String url = "file://" + codeEditorDir;
-        #else
-            String url = "file:///" + codeEditorDir;
-        #endif
-*/
         return `atomic://${ToolCore.toolEnvironment.toolDataDir}CodeEditor/Editor.html`;
     }
 

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -323,6 +323,17 @@ declare module Editor.HostExtensions {
         showModalError(windowText: string, message: string);
         showResourceSelection(windowText: string, importerType: string, resourceType: string, callback: (retObject: any, args: any) => void, args?: any);
 
+        /**
+         * Register a custom editor.  These editors will override editors in the standard editor list if
+         * they both resolve the ```canHandleResource``` call.
+         */
+        registerCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder);
+
+        /**
+         * Will unregister a previously registered editor builder
+         * @param  {Editor.Extensions.ResourceEditorBuilder} editorBuilder
+         */
+        unregisterCustomEditor(editorBuilder: Editor.Extensions.ResourceEditorBuilder);
     }
 }
 

--- a/Source/AtomicEditor/Editors/JSResourceEditor.h
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.h
@@ -43,7 +43,7 @@ class JSResourceEditor: public ResourceEditor
 
 public:
 
-    JSResourceEditor(Context* context, const String& fullpath, UITabContainer* container);
+    JSResourceEditor(Context* context, const String& fullpath, UITabContainer* container, const String& editorUrl);
 
     virtual ~JSResourceEditor();
 
@@ -74,7 +74,7 @@ private:
     void HandleRenameResourceNotification(StringHash eventType, VariantMap& eventData);
     void HandleDeleteResourceNotification(StringHash eventType, VariantMap& eventData);
     void HandleProjectUnloadedNotification(StringHash eventType, VariantMap& eventData);
-    
+
     SharedPtr<UIWebView> webView_;
     WeakPtr<WebClient> webClient_;
     WeakPtr<WebMessageHandler> messageHandler_;


### PR DESCRIPTION
This PR opens up the ability to create custom editors inside the projects, opening up the door to creating web based code generators (ie, create a visual editor for conversation trees that saves out as javascript).  Some fixes are also included in this
- fixes an issue where if you close a project, the editors weren't closing so if you opened another project the editors would show up
- fixes an issue where the web view was not able to successfully send up a block of code and a filename to save it as (this will be critical to the TypeScript compilation ability)