### PR TITLE
fix for editor crash on start in Linux

### DIFF
--- a/Source/AtomicWebView/WebBrowserHost.cpp
+++ b/Source/AtomicWebView/WebBrowserHost.cpp
@@ -129,8 +129,8 @@ WebBrowserHost::WebBrowserHost(Context* context) : Object (context)
     // these include "--enable-media-stream", "--enable-usermedia-screen-capturing", "--off-screen-rendering-enabled", "--transparent-painting-enabled"
 
 #ifdef ATOMIC_PLATFORM_LINUX
-    static const char* _argv[3] = { "AtomicWebView", "--disable-setuid-sandbox" };
-    CefMainArgs args(3, (char**) &_argv);
+    static const char* _argv[2] = { "AtomicWebView", "--disable-setuid-sandbox" };
+    CefMainArgs args(2, (char**) &_argv);
 #else
     CefMainArgs args;
 #endif


### PR DESCRIPTION
changed the array size to '2' to reflect actual size