### PR TITLE
Fixed to get TypeDoc to run

### DIFF
--- a/Build/CIScripts/GenEditorData.js
+++ b/Build/CIScripts/GenEditorData.js
@@ -52,7 +52,7 @@ namespace('build', function() {
 
     cmds = [
       "git clone https://github.com/AtomicGameEngine/AtomicExamples " + buildDir + "AtomicExamples && rm -rf " + buildDir + "AtomicExamples/.git",
-      "cd " + jsDocFolder + " && npm install typedoc",
+      "cd " + jsDocFolder + " && npm install typedoc@0.3.12",
       "cd " + jsDocFolder + " && ./node_modules/.bin/typedoc --out out ../../../Script/TypeScript/dist/Atomic.d.ts --module commonjs --includeDeclarations --mode file --theme atomic-theme --name 'Atomic Game Engine' --readme ./Readme.md",
     ];
 

--- a/Build/Docs/gendocs.sh
+++ b/Build/Docs/gendocs.sh
@@ -2,7 +2,7 @@
 cp Readme.md ../../Artifacts/Build/JSDoc
 cp -R atomic-theme ../../Artifacts/Build/JSDoc/
 cd ../../Artifacts/Build/JSDoc
-npm install typedoc
+npm install typedoc@0.3.12
 ./node_modules/.bin/typedoc --out out ../../../Script/TypeScript/dist/Atomic.d.ts --module commonjs --includeDeclarations --mode file --theme atomic-theme --name 'Atomic Game Engine' --readme ./Readme.md
 
 cp -R out/ ../EditorData/Docs

--- a/Script/AtomicEditor/resources/ProjectTemplates.ts
+++ b/Script/AtomicEditor/resources/ProjectTemplates.ts
@@ -101,7 +101,7 @@ export function getExampleProjectTemplateDefinitions(): [ProjectTemplateDefiniti
  * @param  {string} fileTemplateType
  * @return {[FileTemplateDefinition]}
  */
-export function GetNewFileTemplateDefinitions(fileTemplateType: Editor.Templates.TemplateType) : Editor.Templates.FileTemplateDefinition[] {
+export function GetNewFileTemplateDefinitions(fileTemplateType: string) : Editor.Templates.FileTemplateDefinition[] {
     const templateDefinitions = "AtomicEditor/templates/file_template_definitions.json";
     const file = Atomic.cache.getFile(templateDefinitions);
 

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -149,7 +149,8 @@ declare module Editor.EditorEvents {
 }
 
 declare module Editor.Templates {
-    export type TemplateType = "component" | "script";
+    // Commented out until the TSDoc gets updated to the latest version of TypeScript
+    //export type TemplateType = "component" | "script";
     /**
      * New file defintion
      */
@@ -159,7 +160,7 @@ declare module Editor.Templates {
         /** description */
         desc: string;
         /** type of template */
-        templateType: TemplateType;
+        templateType: string;
         /** file extension */
         ext: string;
         /** file name/path of the source templage file to clone from.  Note, needs to be in the atomic cache */


### PR DESCRIPTION
Fixes for getting TypeDoc to run

- Backed down the TypeDoc to v0.3.12
- removed a TS 1.8.x feature from the .d.ts that the old version of TypeDoc didn't like