### PR TITLE
pre-set compile on save for new TypeScript projects

### DIFF
--- a/Data/AtomicEditor/ProjectTemplates/EmptyProject/TypeScript/EmptyProject.userprefs
+++ b/Data/AtomicEditor/ProjectTemplates/EmptyProject/TypeScript/EmptyProject.userprefs
@@ -1,0 +1,5 @@
+{
+  "HostTypeScriptLanguageExtension": {
+    "CompileOnSave": true
+  }
+}

--- a/Data/AtomicEditor/ProjectTemplates/Project2D/TypeScript/Project2D.userprefs
+++ b/Data/AtomicEditor/ProjectTemplates/Project2D/TypeScript/Project2D.userprefs
@@ -1,0 +1,5 @@
+{
+  "HostTypeScriptLanguageExtension": {
+    "CompileOnSave": true
+  }
+}

--- a/Data/AtomicEditor/ProjectTemplates/Project3D/TypeScript/Project3D.userprefs
+++ b/Data/AtomicEditor/ProjectTemplates/Project3D/TypeScript/Project3D.userprefs
@@ -1,0 +1,5 @@
+{
+  "HostTypeScriptLanguageExtension": {
+    "CompileOnSave": true
+  }
+}

--- a/Script/AtomicEditor/ui/modal/CreateProject.ts
+++ b/Script/AtomicEditor/ui/modal/CreateProject.ts
@@ -141,6 +141,12 @@ class CreateProject extends ModalWindow {
                     file.close();
                 }
 
+                // Look for a .userprefs file and if it exists, then rename it
+                fileResults = fileSystem.scanDir(folder, "*.userprefs", Atomic.SCAN_FILES, false);
+                if (fileResults.length === 1) {
+                    fileSystem.rename(folder + fileResults[0], folder + name + ".userprefs");
+                }
+
                 this.hide();
 
                 this.sendEvent(EditorEvents.LoadProject, { path: folder });


### PR DESCRIPTION
To make things more seamless for new TypeScript projects, auto set the Compile on Save setting.  This is so that when you get a new project, you can just edit and run without needing to toggle any settings.