### PR TITLE
Expose ACE options in the userprefs.json file

### DIFF
--- a/Data/AtomicEditor/CodeEditor/Editor.html
+++ b/Data/AtomicEditor/CodeEditor/Editor.html
@@ -67,9 +67,9 @@
         });
     }
 
-    function HOST_loadPreferences(prefUrl) {
+    function HOST_preferencesChanged() {
         System.import('./source/editorCore/interop').then((module) => {
-            module.default.getInstance().loadPreferences(prefUrl);
+            module.default.getInstance().preferencesChanged();
         });
     }
 

--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -161,6 +161,7 @@ class Editor extends Atomic.ScriptObject {
      */
     setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
         Preferences.getInstance().setUserPreference(extensionName, preferenceName, value);
+        WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ProjectPreferences", JSON.stringify(Preferences.getInstance().cachedProjectPreferences, null, 2 ));
         this.sendEvent(EditorEvents.UserPreferencesChangedNotification);
     }
 
@@ -173,6 +174,7 @@ class Editor extends Atomic.ScriptObject {
      */
     setUserPreferenceGroup(settingsGroup: string, groupPreferenceValues: Object) {
         Preferences.getInstance().setUserPreferenceGroup(settingsGroup, groupPreferenceValues);
+        WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ProjectPreferences", JSON.stringify(Preferences.getInstance().cachedProjectPreferences, null, 2 ));
         this.sendEvent(EditorEvents.UserPreferencesChangedNotification);
     }
 
@@ -189,6 +191,8 @@ class Editor extends Atomic.ScriptObject {
         }
         const loaded = system.loadProject(event.path);
         if (loaded) {
+            WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ProjectPreferences", JSON.stringify(Preferences.getInstance().cachedProjectPreferences, null, 2 ));
+            WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ApplicationPreferences", JSON.stringify(Preferences.getInstance().cachedApplicationPreferences, null, 2 ));
             this.sendEvent(EditorEvents.LoadProjectNotification, event);
         }
         return loaded;

--- a/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
+++ b/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
@@ -74,22 +74,11 @@ export abstract class AbstractTextResourceEditorBuilder implements Editor.Extens
         });
 
         editor.subscribeToEvent(EditorEvents.UserPreferencesChangedNotification, (data) => {
-            this.getUserPrefs(editor);
+            const webClient = editor.webView.webClient;
+            webClient.executeJavaScript("HOST_preferencesChanged();");
         });
 
         return editor;
-    }
-
-    /**
-     * Send the url of the user prefs to the web view so that it can request it
-     */
-    getUserPrefs(editor: Editor.JSResourceEditor) {
-        let prefsPath = ToolCore.toolSystem.project.userPrefsFullPath;
-        if (Atomic.fileSystem.fileExists(prefsPath)) {
-            // Get a reference to the web client so we can call the load preferences method
-            const webClient = editor.webView.webClient;
-            webClient.executeJavaScript(`HOST_loadPreferences("atomic://${prefsPath}");`);
-        }
     }
 
     /**

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -76,15 +76,18 @@ class ServicesProvider<T extends Editor.Extensions.ServiceEventListener> impleme
 
 export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExtensions.WebViewServiceEventListener> {
 
-    private userPreferences = {};
+    private projectPreferences = {};
+    private applicationPreferences = {};
 
     /**
      * Sets the preferences for the service locator
-     * @param  {any} prefs
+     * @param  {any} projectPreferences
+     * @param  {any} applicationPreferences
      * @return {[type]}
      */
-    setPreferences(prefs : any) {
-        this.userPreferences = prefs;
+    setPreferences(projectPreferences?: any, applicationPreferences?: any) {
+        this.projectPreferences = projectPreferences || this.projectPreferences;
+        this.applicationPreferences = applicationPreferences || this.applicationPreferences;
     }
 
     /**
@@ -222,8 +225,8 @@ export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExten
     getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
     getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
     getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: any): any {
-        if (this.userPreferences) {
-            let prefs = this.userPreferences[settingsGroup];
+        if (this.projectPreferences) {
+            let prefs = this.projectPreferences[settingsGroup];
             if (prefs) {
                 return prefs[preferenceName] || defaultValue;
             }
@@ -233,5 +236,26 @@ export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExten
         return defaultValue;
     }
 
+    /**
+     * Return a preference value or the provided default from the user settings file
+     * @param  {string} settignsGroup name of the group the preference lives under
+     * @param  {string} preferenceName name of the preference to retrieve
+     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+     * @return {number|boolean|string}
+     */
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: any): any {
+        if (this.applicationPreferences) {
+            let prefs = this.applicationPreferences[settingsGroup];
+            if (prefs) {
+                return prefs[preferenceName] || defaultValue;
+            }
+        }
+
+        // if all else fails
+        return defaultValue;
+    }
 
 }

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -32,11 +32,16 @@ import ClientExtensionEventNames from "../clientExtensions/ClientExtensionEventN
  */
 export function configure(fileExt: string, filename: string) {
 
-    // set a default theme
-    editor.setTheme("ace/theme/monokai");
-
     // set a default mode
     editor.session.setMode("ace/mode/javascript");
+
+    // Grab the configured editor defaults and apply them
+    editor.setTheme(serviceLocator.clientServices.getApplicationPreference("codeEditorSettings", "theme", "ace/theme/monokai"));
+    editor.setKeyboardHandler(serviceLocator.clientServices.getApplicationPreference("codeEditorSettings", "keyboardHandler", "ace/keyboard/textinput"));
+    editor.setFontSize(serviceLocator.clientServices.getApplicationPreference("codeEditorSettings", "fontSize", 12).toString() + "px");
+    editor.setShowInvisibles(serviceLocator.clientServices.getApplicationPreference("codeEditorSettings", "showInvisibles", false));
+    editor.session.setUseSoftTabs(serviceLocator.clientServices.getApplicationPreference("codeEditorSettings", "useSoftTabs", true));
+    editor.session.setTabSize(serviceLocator.clientServices.getApplicationPreference("codeEditorSettings", "tabSize", 4));
 
     // give the language extensions the opportunity to configure the editor based upon the file type
     serviceLocator.sendEvent(ClientExtensionEventNames.ConfigureEditorEvent, {
@@ -50,7 +55,7 @@ export function configure(fileExt: string, filename: string) {
  * Returns the text in the editor instance
  * @return {string}
  */
-export function getSourceText() : string {
+export function getSourceText(): string {
     return editor.session.getValue();
 }
 
@@ -83,7 +88,7 @@ export function loadCodeIntoEditor(code: string, filename: string, fileExt: stri
  * @param  {string} newPath
  */
 export function resourceRenamed(path: string, newPath: string) {
-    let data:Editor.EditorEvents.RenameResourceEvent = {
+    let data: Editor.EditorEvents.RenameResourceEvent = {
         path: path,
         newPath: newPath
     };
@@ -95,7 +100,7 @@ export function resourceRenamed(path: string, newPath: string) {
  * @param  {string} path
  */
 export function resourceDeleted(path: string) {
-    let data:Editor.EditorEvents.DeleteResourceEvent = {
+    let data: Editor.EditorEvents.DeleteResourceEvent = {
         path: path
     };
     serviceLocator.sendEvent(ClientExtensionEventNames.ResourceDeletedEvent, data);
@@ -108,7 +113,7 @@ export function resourceDeleted(path: string) {
  * @param {string} contents
  */
 export function codeSaved(path: string, fileExt: string, contents: string) {
-    let data:Editor.EditorEvents.CodeSavedEvent = {
+    let data: Editor.EditorEvents.CodeSavedEvent = {
         filename: path,
         fileExt: fileExt,
         editor: editor,
@@ -118,10 +123,18 @@ export function codeSaved(path: string, fileExt: string, contents: string) {
 }
 
 /**
+ * Called when the editor has finished it's initial load
+ */
+export function editorLoaded() {
+    // let's grab the prefs and seed the service locator
+    serviceLocator.clientServices.setPreferences(JSON.parse(window.HOST_Preferences.ProjectPreferences), JSON.parse(window.HOST_Preferences.ApplicationPreferences));
+}
+
+/**
  * Called when new preferences are available (or initially with current prefs)
  * @param  {any} prefs
  */
-export function loadPreferences(prefs: any) {
-    serviceLocator.clientServices.setPreferences(prefs);
+export function preferencesChanged() {
+    serviceLocator.clientServices.setPreferences(JSON.parse(window.HOST_Preferences.ProjectPreferences), JSON.parse(window.HOST_Preferences.ApplicationPreferences));
     serviceLocator.sendEvent(ClientExtensionEventNames.PreferencesChangedEvent, null);
 }

--- a/Script/AtomicWebViewEditor/interop.ts
+++ b/Script/AtomicWebViewEditor/interop.ts
@@ -144,6 +144,7 @@ export default class HostInteropType {
         if (DEBUG_ALERT) {
             alert(`Attach chrome dev tools to this instance by navigating to http://localhost:${DEBUG_PORT}`);
         }
+        editorCommands.editorLoaded();
         window.atomicQueryPromise(HostInteropType.EDITOR_LOAD_COMPLETE);
     }
 
@@ -206,14 +207,8 @@ export default class HostInteropType {
      * of the prefs.
      * @param  {string} prefUrl
      */
-    loadPreferences(prefUrl: string) {
-        // load prefs
-        this.getResource(prefUrl).then((prefsJson: string) => {
-            let prefs = JSON.parse(prefsJson);
-            editorCommands.loadPreferences(prefs);
-        }).catch((e: Editor.ClientExtensions.AtomicErrorMessage) => {
-            console.log("Error loading preferences: " + e.error_message);
-        });
+    preferencesChanged() {
+        editorCommands.preferencesChanged();
     }
 
     /**

--- a/Script/AtomicWebViewEditor/typings/WindowExt.d.ts
+++ b/Script/AtomicWebViewEditor/typings/WindowExt.d.ts
@@ -44,5 +44,13 @@ interface Window {
 
     HOST_resourceRenamed: (path: string, newPath: string) => void;
     HOST_resourceDeleted: (path: string) => void;
-    HOST_loadPreferences: (path: string) => void;
+    HOST_preferencesChanged: () => void;
+
+    /**
+     * Preferences set by the host.  Each preference category is a JSON string of all the prefs
+     */
+    HOST_Preferences: {
+        ApplicationPreferences: string,
+        ProjectPreferences: string
+    };
 }

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -439,6 +439,17 @@ declare module Editor.ClientExtensions {
         getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
         getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
         getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+
+        /**
+         * Return a preference value or the provided default from the application settings file
+         * @param  {string} extensionName name of the extension the preference lives under
+         * @param  {string} preferenceName name of the preference to retrieve
+         * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+         * @return {number|boolean|string}
+         */
+        getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+        getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+        getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
     }
 
     export interface AtomicErrorMessage {

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -121,7 +121,6 @@ void JSResourceEditor::HandleWebMessage(StringHash eventType, VariantMap& eventD
     const String& EDITOR_CHANGE = "editorChange";
     const String& EDITOR_SAVE_CODE = "editorSaveCode";
     const String& EDITOR_SAVE_FILE = "editorSaveFile";
-    const String& EDITOR_GET_USER_PREFS = "editorGetUserPrefs";
 
     WebMessageHandler* handler = static_cast<WebMessageHandler*>(eventData[P_HANDLER].GetPtr());
 
@@ -158,16 +157,6 @@ void JSResourceEditor::HandleWebMessage(StringHash eventType, VariantMap& eventD
                     file.Close();
             } else {
                 LOGWARNING("Ignoring attempt to write file: " + fn);
-            }
-        }
-        else if (message == EDITOR_GET_USER_PREFS)
-        {
-            ToolSystem* tsys = GetSubsystem<ToolSystem>();
-            Project* proj = tsys->GetProject();
-            FileSystem* fileSystem = GetSubsystem<FileSystem>();
-            if (fileSystem->FileExists(proj->GetUserPrefsFullPath()))
-            {
-                webClient_->ExecuteJavaScript(ToString("HOST_loadPreferences(\"atomic://%s\");", proj->GetUserPrefsFullPath().CString()));
             }
         }
     }


### PR DESCRIPTION
This PR addresses the ability to configure the Ace editor from the application settings file.  Until there is a dedicated extensible user settings dialog, this is going to need to be hand-edited for now (I'll add an issue for creating a settings dialog)

Currently the following settings are exposed in ```userprefs.json```
```json
  "codeEditorSettings": {
    "theme": "ace/theme/monokai",
    "keyboardHandler": "ace/keyboard/textinput",
    "fontSize": 12,
    "showInvisibles": false,
    "useSoftTabs": true,
    "tabSize": 2
  }
```

I reworked the way settings are exposed to the web view and instead of having the web view request the settings through an AJAX call, the settings are placed onto the WebHost global properties.  This allows them to be available as soon as possible so that when the editor configures itself, it can get the settings.  I also modified the notification for preferences changes and just send a simple notification message that the values in the WebHost global have been updated.  This is a lot less chatty and actually feels like a cleaner implementation.

@JimMarlowe - this should give you the ACE configuration part of the skin updates you are looking at.

I contemplated having editor settings for each file type, but I think until there is dedicated UI for it, it could get too complex.