### PR TITLE
fix for compiling with gcc 6.1.1 on Arch Linux

### DIFF
--- a/Source/ThirdParty/TurboBadger/thirdparty/stb_image.h
+++ b/Source/ThirdParty/TurboBadger/thirdparty/stb_image.h
@@ -354,7 +354,9 @@ STBIDEF void stbi_install_YCbCr_to_RGB(stbi_YCbCr_to_RGB_run func);
 #ifndef STBI_NO_STDIO
 #include <stdio.h>
 #endif
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include <stdlib.h>
+#undef _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include <string.h>
 #ifndef STBI_ASSERT
 #include <assert.h>


### PR DESCRIPTION
Tested with Ubuntu  GCC 5.3 and has no effect in older compilers