### PR TITLE
remove unused dependency on ATL

### DIFF
--- a/Source/ThirdParty/nativefiledialog/nfd_win.cpp
+++ b/Source/ThirdParty/nativefiledialog/nfd_win.cpp
@@ -13,7 +13,8 @@
 #include <wchar.h>
 #include <stdio.h>
 #include <assert.h>
-#include <atlbase.h>
+//ATOMIC: Removed reference to ATL
+//#include <atlbase.h>
 #include <windows.h>
 #include <ShObjIdl.h>
 


### PR DESCRIPTION
This should make building with VC++ Build Tools and mingw easier.