### PR TITLE
TypeScript enhancements

### DIFF
--- a/Data/AtomicEditor/ProjectTemplates/Project2D/TypeScript/Resources/Components/Star.js
+++ b/Data/AtomicEditor/ProjectTemplates/Project2D/TypeScript/Resources/Components/Star.js
@@ -28,4 +28,4 @@ var Star = (function (_super) {
     };
     return Star;
 })(Atomic.JSComponent);
-module.exports = Star;
+exports.default = Star;

--- a/Data/AtomicEditor/ProjectTemplates/Project2D/TypeScript/Resources/Components/Star.ts
+++ b/Data/AtomicEditor/ProjectTemplates/Project2D/TypeScript/Resources/Components/Star.ts
@@ -3,7 +3,7 @@
 /**
  * Component that will rotate a node at a configurable speed.
  */
-class Star extends Atomic.JSComponent {
+export default class Star extends Atomic.JSComponent {
 
     /**
      * Fields witihin the inspectorFields object will be exposed to the editor
@@ -28,5 +28,3 @@ class Star extends Atomic.JSComponent {
 
     }
 }
-
-export = Star;

--- a/Data/AtomicEditor/ProjectTemplates/Project3D/TypeScript/Resources/Components/Spinner.js
+++ b/Data/AtomicEditor/ProjectTemplates/Project3D/TypeScript/Resources/Components/Spinner.js
@@ -28,4 +28,4 @@ var Spinner = (function (_super) {
     };
     return Spinner;
 })(Atomic.JSComponent);
-module.exports = Spinner;
+exports.default = Spinner;

--- a/Data/AtomicEditor/ProjectTemplates/Project3D/TypeScript/Resources/Components/Spinner.ts
+++ b/Data/AtomicEditor/ProjectTemplates/Project3D/TypeScript/Resources/Components/Spinner.ts
@@ -3,7 +3,7 @@
 /**
  * Component that will rotate a node at a configurable speed.
  */
-class Spinner extends Atomic.JSComponent {
+export default class Spinner extends Atomic.JSComponent {
 
     /**
      * Fields witihin the inspectorFields object will be exposed to the editor
@@ -28,5 +28,3 @@ class Spinner extends Atomic.JSComponent {
 
     }
 }
-
-export = Spinner;

--- a/Resources/EditorData/AtomicEditor/templates/template_ts_component.ts
+++ b/Resources/EditorData/AtomicEditor/templates/template_ts_component.ts
@@ -3,7 +3,7 @@
 /**
  * A new component
  */
-class Component extends Atomic.JSComponent {
+export default class Component extends Atomic.JSComponent {
 
     /**
      * Fields witihin the inspectorFields object will be exposed to the editor
@@ -26,5 +26,3 @@ class Component extends Atomic.JSComponent {
 
     }
 }
-
-export = Component;

--- a/Script/Packages/Atomic/Resource.json
+++ b/Script/Packages/Atomic/Resource.json
@@ -7,5 +7,12 @@
 			"GetPixel": ["int", "int"],
 			"SetSize": ["int", "int", "int", "unsigned"]
 		}
+	},
+	"typescript_decl" : {
+		"ResourceCache" : [
+			"getResource<T extends Resource>(type: string, name: string, sendEventOnFailure?: boolean): T;",
+			"getTempResource<T extends Resource>(type: string, name: string, sendEventOnFailure?: boolean): T;",
+	        "getExistingResource<T extends Resource>(type: string, name: string): T;"
+		]
 	}
 }

--- a/Script/Packages/Atomic/UI.json
+++ b/Script/Packages/Atomic/UI.json
@@ -16,6 +16,12 @@
 
 		"UIButton" : [
 			"onClick: () => void;"
+		],
+		"UI": [
+		    "getWidgetAt<T extends UIWidget>(x: number, y: number, include_children: boolean): T;"
+		],
+		"UIWidget": [
+		    "getWidget<T extends UIWidget>(id: string): T;"
 		]
 	}
 

--- a/Source/AtomicJS/Javascript/JSComponent.cpp
+++ b/Source/AtomicJS/Javascript/JSComponent.cpp
@@ -280,12 +280,21 @@ void JSComponent::InitInstance(bool hasArgs, int argIdx)
             return;
         }
 
-        duk_get_prop_string(ctx, -1, "component");
+        // Check for "default" constructor which is used by TypeScript and ES2015
+        duk_get_prop_string(ctx, -1, "default");
 
         if (!duk_is_function(ctx, -1))
         {
-            duk_set_top(ctx, top);
-            return;
+            duk_pop(ctx);
+
+            // If "default" doesn't exist, look for component
+            duk_get_prop_string(ctx, -1, "component");
+
+            if (!duk_is_function(ctx, -1))
+            {
+                duk_set_top(ctx, top);
+                return;
+            }
         }
 
         // call with self


### PR DESCRIPTION
This PR adds some additional overloads to make some APIs work better as generics so that the resulting return value is auto-cast to the right type.  Namely:
```
ResourceCache.getResource<T>
ResourceCache.getTempResource<T>
ResourceCache.getExistingResource<T>
UI.getWidgetAt<T>
UIWidget.getWidget<T>
```

The other thing this PR does is allow for ```export default <classname>``` which is used in ```ES6``` and ```TypeScript``` which closes #845.  The project templates have been updated to use ```export default``` for the ```TypeScript``` projects as this is a cleaner and more preferable way of doing things.

@JoshEngebretson can you double check the C++ changes?  They work, but I'm still getting my bearings in C++ and there could be a better way of handling that.