### PR TITLE
Added Import Materials option to ModelImporter and Inspector

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/ModelInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/ModelInspector.ts
@@ -46,6 +46,7 @@ class ModelInspector extends InspectorWidget {
         this.importer.scale = Number(this.scaleEdit.text);
 
         this.importer.importAnimations = this.importAnimationBox.value ? true : false;
+        this.importer.setImportMaterials(this.importMaterials.value ? true : false);
 
         for (var i = 0; i < this.importer.animationCount; i++) {
 
@@ -102,6 +103,9 @@ class ModelInspector extends InspectorWidget {
 
         this.scaleEdit = InspectorUtils.createAttrEditField("Scale", modelLayout);
         this.scaleEdit.text = this.importer.scale.toString();
+
+        this.importMaterials = this.createAttrCheckBox("Import Materials", modelLayout);
+        this.importMaterials.value = this.importer.getImportMaterials() ? 1 : 0;
 
         // Animations Section
         var animationLayout = this.createSection(rootLayout, "Animation", 1);
@@ -192,6 +196,7 @@ class ModelInspector extends InspectorWidget {
 
     // animation
     importAnimationBox: Atomic.UICheckBox;
+    importMaterials: Atomic.UICheckBox;
     importAnimationArray: ArrayEditWidget;
     animationInfoLayout: Atomic.UILayout;
 

--- a/Source/ToolCore/Assets/ModelImporter.cpp
+++ b/Source/ToolCore/Assets/ModelImporter.cpp
@@ -58,9 +58,11 @@ ModelImporter::~ModelImporter()
 void ModelImporter::SetDefaults()
 {
     AssetImporter::SetDefaults();
+    SharedPtr<OpenAssetImporter> importer(new OpenAssetImporter(context_));
 
     scale_ = 1.0;
     importAnimations_ = false;
+    importMaterials_ = importer->GetImportMaterialsDefault();
     animationInfo_.Clear();
 
 }
@@ -77,6 +79,7 @@ bool ModelImporter::ImportModel()
     importer->SetScale(scale_);
     importer->SetExportAnimations(false);
     importer->SetImportNode(importNode_);
+    importer->SetImportMaterials(importMaterials_);
 
     if (importer->Load(asset_->GetPath()))
     {
@@ -91,6 +94,13 @@ bool ModelImporter::ImportModel()
 
     return false;
 }
+
+/*void ModelImporter::SetImportMaterials(bool importMat)
+{
+    LOGDEBUGF("Importing Materials of: %s", asset_->GetPath().CString());
+    SharedPtr<OpenAssetImporter> importer(new OpenAssetImporter(context_));
+    importer->SetImportMaterials(importMat);
+}*/
 
 bool ModelImporter::ImportAnimation(const String& filename, const String& name, float startTime, float endTime)
 {
@@ -257,6 +267,7 @@ bool ModelImporter::Import()
                 ImportAnimations();
             }
 
+            SetImportMaterials(importMaterials_);
         }
     }
 
@@ -339,6 +350,15 @@ bool ModelImporter::LoadSettingsInternal(JSONValue& jsonRoot)
     if (import.Get("importAnimations").IsBool())
         importAnimations_ = import.Get("importAnimations").GetBool();
 
+    if (import.Get("importMaterials").IsBool())
+    {
+        importMaterials_ = import.Get("importMaterials").GetBool();
+    }
+    else
+    {
+
+    }
+
     if (import.Get("animInfo").IsArray())
     {
         JSONArray animInfo = import.Get("animInfo").GetArray();
@@ -368,6 +388,7 @@ bool ModelImporter::SaveSettingsInternal(JSONValue& jsonRoot)
     JSONValue save;
     save.Set("scale", scale_);
     save.Set("importAnimations", importAnimations_);
+    save.Set("importMaterials", importMaterials_);
 
     JSONArray animInfo;
 

--- a/Source/ToolCore/Assets/ModelImporter.h
+++ b/Source/ToolCore/Assets/ModelImporter.h
@@ -81,6 +81,8 @@ public:
 
     bool GetImportAnimations() { return importAnimations_; }
     void SetImportAnimations(bool importAnimations) { importAnimations_ = importAnimations; }
+    bool GetImportMaterials() { return importMaterials_; }
+    void SetImportMaterials(bool importMat) { importMaterials_ = importMat; };
 
     unsigned GetAnimationCount();
     void SetAnimationCount(unsigned count);
@@ -108,6 +110,7 @@ protected:
 
     double scale_;
     bool importAnimations_;
+    bool importMaterials_;
     Vector<SharedPtr<AnimationImportInfo>> animationInfo_;
 
     SharedPtr<Node> importNode_;

--- a/Source/ToolCore/Import/ImportConfig.cpp
+++ b/Source/ToolCore/Import/ImportConfig.cpp
@@ -58,8 +58,6 @@ bool ImportConfig::LoadModelImporterConfig(const JSONValue& jModelImporterConfig
             valueMap_["aiProcess_ImproveCacheLocality"] = GetBoolValue(jvalue, true);
         else if (key == "fixInFacingNormals")
             valueMap_["aiProcess_FixInfacingNormals"] = GetBoolValue(jvalue, true);
-        else if (key == "fixInfacingNormals")
-            valueMap_["aiProcess_FixInfacingNormals"] = GetBoolValue(jvalue, true);
         else if (key == "findInvalidData")
             valueMap_["aiProcess_FindInvalidData"] = GetBoolValue(jvalue, true);
         else if (key == "genUVCoords")
@@ -68,6 +66,8 @@ bool ImportConfig::LoadModelImporterConfig(const JSONValue& jModelImporterConfig
             valueMap_["aiProcess_FindInstances"] = GetBoolValue(jvalue, true);
         else if (key == "optimizeMeshes")
             valueMap_["aiProcess_OptimizeMeshes"] = GetBoolValue(jvalue, true);
+        else if (key == "importMaterials")
+            valueMap_["ImportMaterials"] = GetBoolValue(jvalue, true);
     }
 
     return true;

--- a/Source/ToolCore/Import/OpenAssetImporter.cpp
+++ b/Source/ToolCore/Import/OpenAssetImporter.cpp
@@ -53,6 +53,8 @@ OpenAssetImporter::OpenAssetImporter(Context* context) : Object(context) ,
     scene_(0),
     rootNode_(0),
     useSubdirs_(true),
+    importMaterials_(true),
+    importMaterialsDefault_(true),
     localIDs_(false),
     saveBinary_(false),
     createZone_(true),
@@ -902,6 +904,8 @@ void OpenAssetImporter::SetOveriddenFlags(VariantMap& aiFlagParameters)
             ApplyFlag(aiProcess_FindInstances, itr->second_.GetBool());
         else if (itr->first_ == "aiProcess_OptimizeMeshes")
             ApplyFlag(aiProcess_OptimizeMeshes, itr->second_.GetBool());
+        else if (itr->first_ == "ImportMaterials")
+            importMaterialsDefault_ = itr->second_.GetBool();
 
         itr++;
     }
@@ -1184,13 +1188,17 @@ bool OpenAssetImporter::BuildAndSaveAnimations(OutModel* model, const String &an
 // Materials
 void OpenAssetImporter::ExportMaterials(HashSet<String>& usedTextures)
 {
-    if (useSubdirs_)
+    if (importMaterials_ )
     {
-        context_->GetSubsystem<FileSystem>()->CreateDir(sourceAssetPath_ + "Materials");
+        if (useSubdirs_)
+        {
+            context_->GetSubsystem<FileSystem>()->CreateDir(sourceAssetPath_ + "Materials");
+        }
+
+        for (unsigned i = 0; i < scene_->mNumMaterials; ++i)
+            BuildAndSaveMaterial(scene_->mMaterials[i], usedTextures);
     }
 
-    for (unsigned i = 0; i < scene_->mNumMaterials; ++i)
-        BuildAndSaveMaterial(scene_->mMaterials[i], usedTextures);
 }
 
 bool OpenAssetImporter::BuildAndSaveMaterial(aiMaterial* material, HashSet<String>& usedTextures)

--- a/Source/ToolCore/Import/OpenAssetImporter.h
+++ b/Source/ToolCore/Import/OpenAssetImporter.h
@@ -60,8 +60,10 @@ public:
     void SetEndTime(float endTime) { endTime_ = endTime; }
     void SetScale(float scale) { scale_ = scale; }
     void SetExportAnimations(bool exportAnimations) { noAnimations_ = !exportAnimations; }
-
+    void SetImportMaterials(bool importMaterials) { importMaterials_ = importMaterials; }
     void SetVerboseLog(bool verboseLog) { verboseLog_ = verboseLog; }
+
+    bool GetImportMaterialsDefault() { return importMaterialsDefault_; }
 
     const Vector<AnimationInfo>& GetAnimationInfos() { return animationInfos_; }
 
@@ -106,6 +108,8 @@ private:
     String resourcePath_;
     String outPath_;
     bool useSubdirs_;
+    bool importMaterials_;
+    bool importMaterialsDefault_;
     bool localIDs_;
     bool saveBinary_;
     bool createZone_;


### PR DESCRIPTION
Added a config flag to "ImportMaterials"  in Settings\Import.json to disable/enable auto generating materials on model import. (Enabled by default)
Also added a check box to the model inspector allowing the user to enable/disable whether that model should generate or regenerate materials on apply or import.