### PR TITLE
Refine .gitignore for Script/TpeScript to only exclude non-Work d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ Data/AtomicEditor/Deployment/Web/AtomicPlayer.html.mem
 Data/AtomicEditor/Deployment/IOS/AtomicPlayer.app/AtomicPlayer
 node_modules/*
 /.project
-Script/TypeScript/*
-!Script/TypeScript/AtomicWork.d.ts
+Script/TypeScript/**/*.d.ts
+!Script/TypeScript/**/*Work.d.ts
 Script/Haxe/*


### PR DESCRIPTION
One of our branches ended up missing tsconfig.json after a git clean -xdf because of this