### PR TITLE
Expose fontFamily to the monaco editor prefs

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -293,6 +293,7 @@ interface WindowData {
 interface MonacoEditorSettings {
     theme: string;
     fontSize: number;
+    fontFamily: string;
     showInvisibles: boolean;
     useSoftTabs: boolean;
     tabSize: number;
@@ -343,6 +344,7 @@ class PreferencesFormat {
         this.codeEditor = {
             theme: "vs-dark",
             fontSize: 12,
+            fontFamily: "",
             showInvisibles: false,
             useSoftTabs: true,
             tabSize: 4

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -37,7 +37,8 @@ export function configure(fileExt: string, filename: string) {
         theme: serviceLocator.clientServices.getApplicationPreference("codeEditor", "theme", "vs-dark"),
         renderWhitespace: serviceLocator.clientServices.getApplicationPreference("codeEditor", "showInvisibles", false),
         mouseWheelScrollSensitivity: 2,
-        fontSize: serviceLocator.clientServices.getApplicationPreference("codeEditor", "fontSize", 12)
+        fontSize: serviceLocator.clientServices.getApplicationPreference("codeEditor", "fontSize", 12),
+        fontFamily: serviceLocator.clientServices.getApplicationPreference("codeEditor", "fontFamily", "")
     });
 
     // give the language extensions the opportunity to configure the editor based upon the file type

--- a/Script/AtomicWebViewEditor/tsconfig.json
+++ b/Script/AtomicWebViewEditor/tsconfig.json
@@ -12,7 +12,8 @@
     "filesGlob": [
         "./**/*.ts",
         "../TypeScript/*.ts",
-        "!../TypeScript/dist/*.ts"
+        "!../TypeScript/dist/*.ts",
+        "!../TypeScript/AtomicNET.d.ts"
     ],
     "atom": {
         "rewriteTsconfig": true

--- a/Script/tsconfig.json
+++ b/Script/tsconfig.json
@@ -15,7 +15,8 @@
         "./ToolCore/**/*.ts",
         "./AtomicEditor/**/*.ts",
         "./TypeScript/**/*.ts",
-        "!./TypeScript/dist/*.ts"
+        "!./TypeScript/dist/*.ts",
+        "!./TypeScript/AtomicNET.d.ts"
     ],
     "atom": {
         "rewriteTsconfig": true


### PR DESCRIPTION
@JoshEngebretson , I've quickly exposed ```fontFamily``` to the monaco prefs.  Also, the AtomicNET.d.ts automatically gets added back in by the Atom editor if it exists, so I added a negative glob so this doesn't happen anymore.