### PR TITLE
Linux only ForceGL2 based in gfxlib version

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -161,6 +161,10 @@ class Preferences {
         return this._prefs.editorBuildData;
     }
 
+    get editorFeature(): EditorFeature {
+        return this._prefs.editorFeature;
+    }
+
     static getInstance(): Preferences {
         return Preferences.instance;
     }
@@ -311,6 +315,9 @@ interface EditorBuildData {
     lastEditorBuildSHA: string;
 }
 
+interface EditorFeature {
+    versionPatch : string;
+}
 
 class PreferencesFormat {
 
@@ -362,6 +369,10 @@ class PreferencesFormat {
             lastEditorBuildSHA: "Unversioned Build"
         };
 
+        this.editorFeature = {
+            versionPatch : ""
+        };
+
     }
 
     /**
@@ -402,6 +413,11 @@ class PreferencesFormat {
             updatedMissingDefaults = true;
         }
 
+        if (!prefs.editorFeature) {
+            prefs.editorFeature = this.editorFeature;
+            updatedMissingDefaults = true;
+        }
+
         return updatedMissingDefaults;
     }
 
@@ -411,6 +427,7 @@ class PreferencesFormat {
     codeEditor: MonacoEditorSettings;
     uiData: UserInterfaceData;
     editorBuildData: EditorBuildData;
+    editorFeature : EditorFeature;
 }
 
 export = Preferences;

--- a/Source/Atomic/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Atomic/Graphics/OpenGL/OGLGraphics.cpp
@@ -234,10 +234,11 @@ Graphics::Graphics(Context* context_) :
     shaderExtension_(".glsl"),
     orientations_("LandscapeLeft LandscapeRight"),
 #ifndef GL_ES_VERSION_2_0
-    apiName_("GL2")
+    apiName_("GL2"),
 #else
-    apiName_("GLES2")
+    apiName_("GLES2"),
 #endif
+    versionPatch_()
 {
     SetTextureUnitMappings();
     ResetCachedState();
@@ -2864,6 +2865,37 @@ void Graphics::CheckFeatureSupport()
         #ifdef EMSCRIPTEN
         dummyColorFormat_ = GetRGBAFormat();
 #endif
+    }
+#endif
+
+#if defined(__linux__)
+
+    String driverx( (const char*)glGetString(GL_VERSION) );
+    LOGINFOF("Graphics Driver : %s", driverx.CString() );
+    Vector<String>tokens = driverx.Split (' ');
+    unsigned ii = 0;
+    if (tokens.Size() > 2) // must have enough tokens to work with
+    {
+        // Size() - 2 is the manufacturer, "Mesa" is the target
+        if ( tokens[ tokens.Size()-2].Compare ( "Mesa", false ) == 0 )
+        {
+            // Size() - 1  is the version number, convert to long, can be n | n.n | n.n.n
+            Vector<String>versionx = tokens[tokens.Size()-1].Split ('.');
+            int majver = 0;
+            int minver = 0;
+            int pointver = 0;
+            if ( tokens.Size() > 1 ) majver = atoi(versionx[0].CString());
+            if ( tokens.Size() > 2 ) minver = atoi(versionx[1].CString());
+            if ( tokens.Size() > 3 ) pointver = atoi(versionx[2].CString());
+    
+            int allver = (majver * 10000) + (minver * 1000) + pointver;
+
+            if ( allver < 101004 ) // Mesa drivers less than this version cause linux display artifacts
+            {                      // a semicolon separated list of workarounds.
+                versionPatch_.Append("ForceGL2;");
+                LOGINFOF ( "This Graphics driver version requires ForceGL2 to be set for proper performance." );
+            }
+        }
     }
 #endif
 }

--- a/Source/Atomic/Graphics/OpenGL/OGLGraphics.h
+++ b/Source/Atomic/Graphics/OpenGL/OGLGraphics.h
@@ -252,6 +252,9 @@ public:
     /// Return graphics API name.
     const String& GetApiName() const { return apiName_; }
 
+    /// Return current driver version patch information 
+    const String& GetVersionPatch() const { return versionPatch_; }
+
     /// Return window position.
     IntVector2 GetWindowPosition() const;
 
@@ -723,6 +726,8 @@ private:
     String orientations_;
     /// Graphics API name.
     String apiName_;
+    /// String to report driver version problems
+    String versionPatch_;
 
     /// Pixel perfect UV offset.
     static const Vector2 pixelUVOffset;

--- a/Source/AtomicEditor/Application/AEPlayerApp.cpp
+++ b/Source/AtomicEditor/Application/AEPlayerApp.cpp
@@ -243,6 +243,11 @@ void AEPlayerApplication::ReadCommandLineArguments()
             {
                 engineParameters_["WindowMaximized"] = true;
             }
+            else if (argument == "--ForceGL2")
+            {
+                engineParameters_["ForceGL2"] = true;
+                LOGINFOF ( "This Graphics driver version is setting ForceGL2 for proper performance." );
+            }
         }
     }
 }

--- a/Source/AtomicEditor/EditorMode/AEEditorMode.cpp
+++ b/Source/AtomicEditor/EditorMode/AEEditorMode.cpp
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+#include <Atomic/Graphics/Graphics.h>
+
 #include <Atomic/IO/Log.h>
 
 #include <Atomic/IPC/IPC.h>
@@ -124,6 +126,17 @@ bool EditorMode::PlayProject(String addArgs, bool debug)
     ToolEnvironment* env = GetSubsystem<ToolEnvironment>();
     ToolSystem* tsystem = GetSubsystem<ToolSystem>();
 
+    bool FGL2 = false;
+
+#ifdef ATOMIC_PLATFORM_LINUX
+
+    Graphics* graphics = GetSubsystem<Graphics>();
+    String patchVersion = graphics->GetVersionPatch(); // this method is only valid for OGL graphics
+    if ( patchVersion.Contains( "ForceGL2" ) )
+        FGL2 = true;
+
+#endif
+
     const String& editorBinary = env->GetEditorBinary();
 
     Project* project = tsystem->GetProject();
@@ -151,6 +164,9 @@ bool EditorMode::PlayProject(String addArgs, bool debug)
 
     if (debug)
         vargs.Insert(0, "--debug");
+
+    if( FGL2 )
+        vargs.Insert(0, "--ForceGL2");
 
     if (addArgs.Length() > 0)
         vargs.Insert(0, addArgs.Split(' '));


### PR DESCRIPTION
This PR fixes a common problem with the Linux Editor and player. Depending on a specific Mesa library version, a 3d scene, like ToonTown, becomes a flashing mess when viewed.  Urho3D has the same issue.  As a first impression, it's bad, real bad. The solution is to detect and compare mesa lib versions, and if the linux distro is afflicted, set a value in tool.prefs, to account for this problem.  There are complications, the detection code only runs after the graphics are initialized, and the flag you need to set to make the flashing stop can only be set before the graphics are initialized. So there is a one execution lag to starting the fix in the editor, this is reported in the log. The editor player is passed the flag thru the command line, so that is transparent to the user. 
   For the linux standalone player, the user will have to change the Settings/Engine.json file manually to set the ForceGL2 flag, there is no way to do that automatically, since the user has to know that they need the Settings directory.
   This processing is automatic, so the user does not have to do anything, whether they have the problem or not. If they upgrade their Mesa Libs to a version that does not have the problem, it will fix itself, with the one execution lag.