### PR TITLE
Add a parameter to genvs2015 task to enable/disable ATOMIC_DEV_BUILD

### DIFF
--- a/Build/Scripts/BuildWindows.js
+++ b/Build/Scripts/BuildWindows.js
@@ -69,7 +69,9 @@ namespace('build', function() {
   // Generate a Visual Studio 2015 solution
   task('genvs2015', {
     async: true
-  }, function() {
+  }, function(devBuild) {
+    if (devBuild === undefined)
+      devBuild = 1;
 
     var slnRoot = path.resolve(atomicRoot, "") + "-VS2015\\";
 
@@ -81,7 +83,7 @@ namespace('build', function() {
 
     var cmds = [];
 
-    cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot);
+    cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot + " " + devBuild);
 
     jake.exec(cmds, function() {
 

--- a/Build/Scripts/Windows/GenerateVS2015.bat
+++ b/Build/Scripts/Windows/GenerateVS2015.bat
@@ -1,3 +1,3 @@
 call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
-cmake %1 -DATOMIC_DEV_BUILD=1 -G "Visual Studio 14 2015 Win64"
+cmake %1 -DATOMIC_DEV_BUILD=%2 -G "Visual Studio 14 2015 Win64"
 


### PR DESCRIPTION
This allows building the VS2015 solution without it having ATOMIC_DEV_BUILD set to 1. In our case this is useful for generating the solution for custom non-dev builds for artists. Will still default to 1.