### PR TITLE
Added Max Size setting to Texture Importer

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/TextureInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/TextureInspector.ts
@@ -24,10 +24,12 @@ import ScriptWidget = require("ui/ScriptWidget");
 import UIEvents = require("ui/UIEvents");
 import EditorUI = require("ui/EditorUI");
 import EditorEvents = require("editor/EditorEvents");
+import InspectorWidget = require("./InspectorWidget");
+import InspectorUtils = require("./InspectorUtils");
 
 import TextureSelector = require("./TextureSelector");
 
-class TextureInspector extends ScriptWidget {
+class TextureInspector extends InspectorWidget {
 
     constructor() {
 
@@ -35,6 +37,12 @@ class TextureInspector extends ScriptWidget {
 
         this.fd.id = "Vera";
         this.fd.size = 11;
+
+    }
+
+    handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
+
+        return false;
 
     }
 
@@ -103,6 +111,7 @@ class TextureInspector extends ScriptWidget {
 
         this.texture = texture;
         this.asset = asset;
+        this.importer = <ToolCore.TextureImporter>asset.importer;
 
         var mlp = new Atomic.UILayoutParams();
         mlp.width = 310;
@@ -153,6 +162,19 @@ class TextureInspector extends ScriptWidget {
 
         attrsVerticalLayout.addChild(nameLayout);
 
+        var maxSizeLayout = new Atomic.UILayout();
+        maxSizeLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+
+        //COMPRESSION SIZE
+        var maxSize = InspectorUtils.createAttrName("Max Size");
+        this.populateCompressionSizeList();
+
+        maxSizeLayout.addChild(maxSize);
+        maxSizeLayout.addChild(this.compressionSize);
+
+        attrsVerticalLayout.addChild(maxSizeLayout);
+        attrsVerticalLayout.addChild(this.createApplyButton());
+
         textureSection.contentRoot.addChild(attrsVerticalLayout);
 
         textureLayout.addChild(this.createTextureSection());
@@ -161,13 +183,50 @@ class TextureInspector extends ScriptWidget {
 
     }
 
+    onApply()
+    {
+
+        this.importer.setCompressedImageSize(Number(this.compressionSize.text));
+        this.asset.import();
+        this.asset.save();
+
+    }
+
+    populateCompressionSizeList()
+    {
+        this.compressionSize = new Atomic.UISelectDropdown();
+        this.compressionSizeSource = new Atomic.UISelectItemSource();
+
+        for (var i = 0; i < this.compressionSizes.length; i ++)
+        {
+            var size = new Atomic.UISelectItem();
+            size.setString(this.compressionSizes[i].toString());           
+            this.compressionSizeSource.addItem(size);
+        }
+
+        this.compressionSize.setSource(this.compressionSizeSource);
+
+        if (this.importer.getCompressedImageSize() != 0)
+        {
+            this.compressionSize.setText(this.importer.getCompressedImageSize().toString());
+        }
+        else
+        {
+            this.compressionSize.setText("NONE");
+        }
+    }
+
     texture: Atomic.Texture2D;
 
     techniqueButton: Atomic.UIButton;
     material: Atomic.Material;
     asset: ToolCore.Asset;
     nameTextField: Atomic.UITextField;
+    compressionSize: Atomic.UISelectDropdown;
+    compressionSizeSource: Atomic.UISelectItemSource;
     fd: Atomic.UIFontDescription = new Atomic.UIFontDescription();
+    importer: ToolCore.TextureImporter;
+    compressionSizes: number[] = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192];
 
 }
 

--- a/Source/Atomic/Graphics/Renderer.h
+++ b/Source/Atomic/Graphics/Renderer.h
@@ -206,6 +206,8 @@ public:
     void SetMobileShadowBiasAdd(float add);
     /// Force reload of shaders.
     void ReloadShaders();
+	/// Reload textures.
+	void ReloadTextures();
 
     /// Return number of backbuffer viewports.
     unsigned GetNumViewports() const { return viewports_.Size(); }
@@ -369,8 +371,6 @@ private:
     void LoadPassShaders(Pass* pass);
     /// Release shaders used in materials.
     void ReleaseMaterialShaders();
-    /// Reload textures.
-    void ReloadTextures();
     /// Create light volume geometries.
     void CreateGeometries();
     /// Create instancing vertex buffer.

--- a/Source/Atomic/Resource/ResourceCache.cpp
+++ b/Source/Atomic/Resource/ResourceCache.cpp
@@ -371,8 +371,33 @@ bool ResourceCache::ReloadResource(Resource* resource)
 
     bool success = false;
     SharedPtr<File> file = GetFile(resource->GetName());
-    if (file)
-        success = resource->Load(*(file.Get()));
+	
+
+	if (file) 
+	{
+#ifdef ATOMIC_PLATFORM_DESKTOP
+		String ext = GetExtension(resource->GetName());
+		if (ext == ".jpg" || ext == ".png" || ext == ".tga")
+		{
+			String ddsName = "DDS/" + resource->GetName() + ".dds";
+			file = GetFile(ddsName, false);
+			if (file != NULL)
+				success = resource->Load(*(file.Get()));
+			else
+			{
+				file = GetFile(resource->GetName());
+				success = resource->Load(*(file.Get()));
+			}
+		}
+		else
+		{
+			success = resource->Load(*(file.Get()));
+		}
+#else
+		success = resource->Load(*(file.Get()));
+#endif
+	}
+
 
     if (success)
     {

--- a/Source/ToolCore/Assets/TextureImporter.h
+++ b/Source/ToolCore/Assets/TextureImporter.h
@@ -41,6 +41,9 @@ public:
     Resource* GetResource(const String& typeName = String::EMPTY);
     Node* InstantiateNode(Node* parent, const String& name);
 
+	void SetCompressedImageSize(unsigned int compressedSize) { compressedSize_ = compressedSize; }
+	unsigned int GetCompressedImageSize() { return compressedSize_; }
+
 protected:
 
     bool Import();
@@ -50,6 +53,8 @@ protected:
     virtual bool SaveSettingsInternal(JSONValue& jsonRoot);
 
     bool compressTextures_;
+
+	unsigned int compressedSize_;
 };
 
 }


### PR DESCRIPTION
This setting imposes the specified maximum dimensions on the compressed version of the texture in the cache.
Also fixes a case where the uncompressed file would have been loaded instead of the compressed version.