### PR TITLE
fix setting PostUpdate event mask in JSComponent

### DIFF
--- a/Source/AtomicJS/Javascript/JSComponent.cpp
+++ b/Source/AtomicJS/Javascript/JSComponent.cpp
@@ -459,7 +459,7 @@ void JSComponent::UpdateEventSubscription()
         SubscribeToEvent(scene, E_SCENEPOSTUPDATE, ATOMIC_HANDLER(JSComponent, HandleScenePostUpdate));
         currentEventMask_ |= USE_POSTUPDATE;
     }
-    else if (!needUpdate && (currentEventMask_ & USE_POSTUPDATE))
+    else if (!needPostUpdate && (currentEventMask_ & USE_POSTUPDATE))
     {
         UnsubscribeFromEvent(scene, E_SCENEPOSTUPDATE);
         currentEventMask_ &= ~USE_POSTUPDATE;


### PR DESCRIPTION
Fix setting PostUpdate event mask in JSComponent
Without this patch, disabling the PostUpdate event does not seem to work for JS components, and (according to the Chrome profiler for the Web version) this can add up to a significant % when there are a lot of nodes.