### PR TITLE
Generate TypeScript project files for external editors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,6 +35,8 @@
 
 - Tarik Belabbas (https://github.com/Tarik-B)
 
+- Kobus vd Walt (https://github.com/Kobusvdwalt)
+
 ### Contribution Copyright and Licensing
 
 Atomic Game Engine contribution copyrights are held by their authors.  Each author retains the copyright to their contribution and agrees to irrevocably license the contribution under the Atomic Game Engine Contribution License `CONTRIBUTION_LICENSE.md`.  Please see `CONTRIBUTING.md` for more details.

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
@@ -343,39 +343,22 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
 
     generateExternalProject ()
     {
-      var projectPath : string = ToolCore.toolSystem.project.projectPath;
+      var projectDir : string = ToolCore.toolSystem.project.projectPath;
 
       // Create TypeScript folder in project root
-      var tsPath : string = projectPath + "TypeScript/";
-      Atomic.getFileSystem().createDir(tsPath);
+      var projectDirTypeScript : string = Atomic.addTrailingSlash(projectDir + "TypeScript");
+      Atomic.getFileSystem().createDir(projectDirTypeScript);
 
       // Copy the Atomic.d.ts definition file to the TypeScript folder
       var toolDataDir : string = ToolCore.toolEnvironment.toolDataDir;
-      Atomic.getFileSystem().copy(toolDataDir + "/TypeScriptSupport/Atomic.d.ts", tsPath + "Atomic.d.ts");
+      var typescriptSupportDir : string = Atomic.addTrailingSlash(toolDataDir + "TypeScriptSupport");
+      Atomic.getFileSystem().copy(typescriptSupportDir + "Atomic.d.ts", projectDirTypeScript + "Atomic.d.ts");
 
       // Generate a tsconfig.json file
-      var config = new Atomic.File(projectPath + "tsconfig.json", Atomic.FILE_WRITE);
-      config.writeString
-(`
-{
-    "compilerOptions": {
-        "noEmitOnError": true,
-        "noImplicitAny": false,
-        "target": "ES5",
-        "module": "commonjs",
-        "outDir": "./Resources",
-        "rootDir": "./Resources",
-        "declaration": false,
-        "inlineSourceMap": false,
-        "removeComments": false,
-        "allowJs": true,
-        "noLib": true,
-        "allowNonTsExtensions": true,
-    }
-}
-`);
-
+      var config = new Atomic.File(projectDir + "tsconfig.json", Atomic.FILE_WRITE);
+      config.writeString(JSON.stringify(defaultCompilerOptions));
       config.close();
+
     }
     /**
      * Perform a full compile of the TypeScript

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
@@ -345,19 +345,23 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
     {
       var projectDir : string = ToolCore.toolSystem.project.projectPath;
 
-      // Create TypeScript folder in project root
-      var projectDirTypeScript : string = Atomic.addTrailingSlash(projectDir + "TypeScript");
-      Atomic.getFileSystem().createDir(projectDirTypeScript);
+      // Create the typings folder in project root
+      var projectDirTypings : string = Atomic.addTrailingSlash(projectDir + "typings/main/ambient/atomicgameengine");
+      Atomic.getFileSystem().createDir(projectDirTypings);
 
-      // Copy the Atomic.d.ts definition file to the TypeScript folder
+      // Copy the Atomic.d.ts definition file to the typings folder
       var toolDataDir : string = ToolCore.toolEnvironment.toolDataDir;
       var typescriptSupportDir : string = Atomic.addTrailingSlash(toolDataDir + "TypeScriptSupport");
-      Atomic.getFileSystem().copy(typescriptSupportDir + "Atomic.d.ts", projectDirTypeScript + "Atomic.d.ts");
+      Atomic.getFileSystem().copy(typescriptSupportDir + "Atomic.d.ts", projectDirTypings + "Atomic.d.ts");
 
       // Generate a tsconfig.json file
-      var config = new Atomic.File(projectDir + "tsconfig.json", Atomic.FILE_WRITE);
-      config.writeString(JSON.stringify(defaultCompilerOptions));
-      config.close();
+      defaultCompilerOptions.noLib = false;
+      var tsconfigFile = new Atomic.File(projectDir + "tsconfig.json", Atomic.FILE_WRITE);
+      let tsconfig = {
+        compilerOptions: defaultCompilerOptions
+      };
+      tsconfigFile.writeString(JSON.stringify(tsconfig));
+      tsconfigFile.close();
 
     }
     /**

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
@@ -341,8 +341,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
         WebView.WebBrowserHost.setGlobalStringProperty("TypeScriptLanguageExtension", "tsConfig", JSON.stringify(tsConfig));
     }
 
-    generateExternalProject ()
-    {
+    generateExternalProject () {
       var projectDir : string = ToolCore.toolSystem.project.projectPath;
 
       // Create the typings folder in project root
@@ -360,7 +359,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
       let tsconfig = {
         compilerOptions: defaultCompilerOptions
       };
-      tsconfigFile.writeString(JSON.stringify(tsconfig));
+      tsconfigFile.writeString(JSON.stringify(tsconfig, null, 4));
       tsconfigFile.close();
 
     }

--- a/Script/tsconfig.json
+++ b/Script/tsconfig.json
@@ -109,15 +109,8 @@
         "./AtomicEditor/ui/ScriptWidget.ts",
         "./AtomicEditor/ui/Shortcuts.ts",
         "./AtomicEditor/ui/UIEvents.ts",
-        "./TypeScript/Atomic.d.ts",
-        "./TypeScript/AtomicApp.d.ts",
-        "./TypeScript/AtomicNETScript.d.ts",
-        "./TypeScript/AtomicPlayer.d.ts",
         "./TypeScript/AtomicWork.d.ts",
         "./TypeScript/duktape.d.ts",
-        "./TypeScript/Editor.d.ts",
-        "./TypeScript/EditorWork.d.ts",
-        "./TypeScript/ToolCore.d.ts",
-        "./TypeScript/WebView.d.ts"
+        "./TypeScript/EditorWork.d.ts"
     ]
 }

--- a/Script/tsconfig.json
+++ b/Script/tsconfig.json
@@ -109,8 +109,15 @@
         "./AtomicEditor/ui/ScriptWidget.ts",
         "./AtomicEditor/ui/Shortcuts.ts",
         "./AtomicEditor/ui/UIEvents.ts",
+        "./TypeScript/Atomic.d.ts",
+        "./TypeScript/AtomicApp.d.ts",
+        "./TypeScript/AtomicNETScript.d.ts",
+        "./TypeScript/AtomicPlayer.d.ts",
         "./TypeScript/AtomicWork.d.ts",
         "./TypeScript/duktape.d.ts",
-        "./TypeScript/EditorWork.d.ts"
+        "./TypeScript/Editor.d.ts",
+        "./TypeScript/EditorWork.d.ts",
+        "./TypeScript/ToolCore.d.ts",
+        "./TypeScript/WebView.d.ts"
     ]
 }


### PR DESCRIPTION
If you create a TypeScript project and you go to Developer>>Plugins>>TypeScript>>Generate External Editor Project the editor will create a tsconfig.json file in the root of the project and copy its Atomic.d.ts file into a folder "TypeScript" in the root of the project. This means that if you open the project in VS Code or Atom it will have autocomplete.

I am new to working on open source stuff so feel free to criticize as much as you want :)