### PR TITLE
Addressing Visual Studio C# integration issues in 952

### DIFF
--- a/Script/AtomicNET/AtomicNET/Application/PlayerApp.cs
+++ b/Script/AtomicNET/AtomicNET/Application/PlayerApp.cs
@@ -23,6 +23,39 @@ namespace AtomicEngine
 
             AtomicNET.RegisterSubsystem("ResourceCache");
             AtomicNET.Cache = AtomicNET.GetSubsystem<ResourceCache>();
+
+            AppDomain currentDomain = AppDomain.CurrentDomain;
+            currentDomain.AssemblyResolve += new ResolveEventHandler(AtomicResolveEventHandler);
+
+        }
+
+        // Resolve assemblies from Resource directories at runtime (todo, assemblies in package files?)
+        static private Assembly AtomicResolveEventHandler(object sender, ResolveEventArgs args)
+        {
+            //This handler is called only when the common language runtime tries to bind to the assembly and fails.
+
+            string assemblyFileName = args.Name.Substring(0, args.Name.IndexOf(",")) + ".dll";
+
+            for (uint i = 0; i < AtomicNET.Cache.NumResourceDirs; i++)
+            {
+                string[] assemblies = Directory.GetFiles(AtomicNET.Cache.GetResourceDir(i), "*.dll", SearchOption.AllDirectories);
+
+                for (int j = 0; j < assemblies.Length; j++)
+                {
+                    if (assemblies[j].Contains(assemblyFileName))
+                    {
+                        //Load the assembly from the specified path.                    
+                        Assembly loadAssembly = Assembly.LoadFrom(assemblies[j]);
+
+                        //Return the loaded assembly.
+                        return loadAssembly;
+
+                    }
+                }
+            }
+
+            return null;
+
         }
 
         protected static void ExecuteAtomicMain(string[] args)

--- a/Source/Atomic/IO/FileSystem.h
+++ b/Source/Atomic/IO/FileSystem.h
@@ -166,6 +166,11 @@ ATOMIC_API bool IsAbsolutePath(const String& pathName);
 
 // ATOMIC BEGIN
 ATOMIC_API bool IsAbsoluteParentPath(const String& absParentPath, const String& fullPath);
+ATOMIC_API String GetSanitizedPath(const String& path);
+
+/// Given two absolute directory paths, get the relative path from one to the other
+/// Returns false if either path isn't absolute, or if they are unrelated
+ATOMIC_API bool GetRelativePath(const String& fromPath, const String& toPath, String& output);
 // ATOMIC END
 
 }

--- a/Source/Atomic/Resource/ResourceCache.h
+++ b/Source/Atomic/Resource/ResourceCache.h
@@ -210,6 +210,15 @@ public:
     /// Returns a formatted string containing the memory actively used.
     String PrintMemoryUsage() const;
 
+    // ATOMIC BEGIN
+    
+    /// Get the number of resource directories
+    unsigned GetNumResourceDirs() const { return resourceDirs_.Size(); }
+    /// Get resource directory at a given index
+    const String& GetResourceDir(unsigned index) const { return index < resourceDirs_.Size() ? resourceDirs_[index] : String::EMPTY; }
+
+    // ATOMIC END
+
 private:
     /// Find a resource.
     const SharedPtr<Resource>& FindResource(StringHash type, StringHash nameHash);

--- a/Source/ToolCore/Assets/AssetDatabase.h
+++ b/Source/ToolCore/Assets/AssetDatabase.h
@@ -75,7 +75,7 @@ private:
     void HandleFileChanged(StringHash eventType, VariantMap& eventData);
     void HandleResourceLoadFailed(StringHash eventType, VariantMap& eventData);
 
-    void AddAsset(SharedPtr<Asset>& asset);
+    void AddAsset(SharedPtr<Asset>& asset, bool newAsset = false);
 
     void PruneOrphanedDotAssetFiles();
 
@@ -94,6 +94,8 @@ private:
     HashMap<StringHash, unsigned> assetImportErrorTimes_;
 
     Vector<String> usedGUID_;
+
+    unsigned assetScanDepth_;
 
 };
 

--- a/Source/ToolCore/Assets/AssetEvents.h
+++ b/Source/ToolCore/Assets/AssetEvents.h
@@ -43,6 +43,19 @@ ATOMIC_EVENT(E_ASSETIMPORTERROR, AssetImportError)
     ATOMIC_PARAM(P_ERROR, Error);                  // string
 }
 
+ATOMIC_EVENT(E_ASSETSCANBEGIN, AssetScanBegin)
+{
+}
+
+ATOMIC_EVENT(E_ASSETSCANEND, AssetScanEnd)
+{
+}
+
+ATOMIC_EVENT(E_ASSETNEW, AssetNew)
+{
+    ATOMIC_PARAM(P_GUID, GUID);                  // string
+}
+
 ATOMIC_EVENT(E_ASSETRENAMED, AssetRenamed)
 {
     ATOMIC_PARAM(P_ASSET, Asset);                  // asset ptr

--- a/Source/ToolCore/NETTools/NETProjectGen.h
+++ b/Source/ToolCore/NETTools/NETProjectGen.h
@@ -111,7 +111,7 @@ namespace ToolCore
 
     public:
 
-        NETSolution(Context* context, NETProjectGen* projectGen);
+        NETSolution(Context* context, NETProjectGen* projectGen, bool rewrite = false);
         virtual ~NETSolution();
 
         bool Load(const JSONValue& root);
@@ -126,6 +126,10 @@ namespace ToolCore
         // Registers a NuGet package, returns true if the package hasn't been previously registered
         bool RegisterPackage(const String& package);
 
+        /// If true, the sln file will rewritten if it exists, default is false
+        void SetRewriteSolution(bool rewrite) { rewriteSolution_ = rewrite; }
+
+
     private:
 
         void GenerateSolution(const String& slnPath);
@@ -134,6 +138,7 @@ namespace ToolCore
         String outputPath_;
         String solutionGUID_;
         Vector<String> packages_;
+        bool rewriteSolution_;
 
     };
 
@@ -167,11 +172,17 @@ namespace ToolCore
 
         String GenerateUUID();
 
+        /// If true, the sln file will rewritten if it exists, default is false
+        void SetRewriteSolution(bool rewrite);
+
         bool LoadProject(const JSONValue& root);
         bool LoadProject(const String& projectPath);
         bool LoadProject(Project* project);
 
     private:
+
+        // if true, the solution (sln) file will be recreated if it exists
+        bool rewriteSolution_;
 
         String scriptPlatform_;
 

--- a/Source/ToolCore/NETTools/NETProjectSystem.h
+++ b/Source/ToolCore/NETTools/NETProjectSystem.h
@@ -76,6 +76,10 @@ namespace ToolCore
         void HandleAssetRenamed(StringHash eventType, VariantMap& eventData);
         void HandleAssetMoved(StringHash eventType, VariantMap& eventData);
 
+        void HandleAssetNew(StringHash eventType, VariantMap& eventData);
+        void HandleAssetScanBegin(StringHash eventType, VariantMap& eventData);
+        void HandleAssetScanEnd(StringHash eventType, VariantMap& eventData);
+
         void HandleProjectLoaded(StringHash eventType, VariantMap& eventData);
         void HandleProjectUnloaded(StringHash eventType, VariantMap& eventData);
 


### PR DESCRIPTION
Squashed commit:

[5b710af] Adding asset scan begin/end events, new asset event, regenerate C# solution before opening generated C# script/component

[2d90270] Switch C# project generator to use relative paths for source files and post build assembly copy

[16f244c] Binary assemblies in Resources will now be added to generated project assembly, project binary assemblies can be in any path and will be resolved at runtime