### PR TITLE
Add joystick cursor control

### DIFF
--- a/Source/Atomic/Input/Input.cpp
+++ b/Source/Atomic/Input/Input.cpp
@@ -1822,6 +1822,19 @@ void Input::JoystickRumble(unsigned int id, float strength, unsigned int length)
     if (jss)
         jss->DoRumble( strength, length);
 }
+
+void Input::JoystickSimulateMouseMove(int xpos, int ypos) /// moves the on screen cursor
+{
+    IntVector2 position(xpos,ypos);
+    SetMousePosition(position);
+}
+
+void Input::JoystickSimulateMouseButton(int button) /// simulated mouse press down & up
+{
+    SetMouseButton( button, true );
+    SetMouseButton( button, false );
+}
+
 // ATOMIC END
 
 void Input::SendInputFocusEvent()

--- a/Source/Atomic/Input/Input.h
+++ b/Source/Atomic/Input/Input.h
@@ -326,6 +326,8 @@ public:
     
     bool GetJoystickRumble(unsigned int id);  /// return if rumble is supported on game controller
     void JoystickRumble(unsigned int id, float strength, unsigned int length); /// produce rumble
+    void JoystickSimulateMouseMove(int xpos, int ypos); /// moves the on screen cursor
+    void JoystickSimulateMouseButton(int button); /// simulated mouse press down & up
 
 // ATOMIC END
 


### PR DESCRIPTION
This PR adds 2 functions which will allow the joystick/game controller the ability to move the mouse cursor and do a mouse button click. With these, you can operate most of the UI controls, and operate the game completely from the joystick.  
I'll "fix" space game with this ability, in addition to playing the game.