### PR TITLE
Update to latest version of TypeDoc

### DIFF
--- a/Build/CIScripts/GenEditorData.js
+++ b/Build/CIScripts/GenEditorData.js
@@ -51,9 +51,11 @@ namespace('build', function() {
     fs.copySync(atomicRoot + "Build/Docs/Readme.md", jsDocFolder + "Readme.md");
     fs.copySync(atomicRoot + "Build/Docs/atomic-theme", jsDocFolder + "atomic-theme");
 
+
     cmds = [
       "git clone https://github.com/AtomicGameEngine/AtomicExamples " + buildDir + "AtomicExamples && rm -rf " + buildDir + "AtomicExamples/.git",
-      "cd " + jsDocFolder + " && npm install typedoc@0.3.12",
+      "cd " + jsDocFolder + " && echo {} > package.json", // newer versions of npm require package.json to be in the folder or else it searches up the heirarchy
+      "cd " + jsDocFolder + " && npm install typedoc",
       "cd " + jsDocFolder + " && ./node_modules/.bin/typedoc --out out ../../../Script/TypeScript/dist/Atomic.d.ts --module commonjs --includeDeclarations --mode file --theme atomic-theme --name 'Atomic Game Engine' --readme ./Readme.md",
     ];
 

--- a/Build/Docs/gendocs.sh
+++ b/Build/Docs/gendocs.sh
@@ -1,8 +1,14 @@
 # Shortcut script that generates docs the same way that the CI script does.  Works on OSX.
+mkdir ../../Artifacts/Build/JSDoc
+mkdir ../../Artifacts/Build/EditorData
+mkdir ../../Artifacts/Build/EditorData/Docs
+
 cp Readme.md ../../Artifacts/Build/JSDoc
 cp -R atomic-theme ../../Artifacts/Build/JSDoc/
 cd ../../Artifacts/Build/JSDoc
-npm install typedoc@0.3.12
+# Create a package.json in this directory so the modules don't get put anywhere else
+echo {} > package.json
+npm install typedoc
 ./node_modules/.bin/typedoc --out out ../../../Script/TypeScript/dist/Atomic.d.ts --module commonjs --includeDeclarations --mode file --theme atomic-theme --name 'Atomic Game Engine' --readme ./Readme.md
 
 cp -R out/ ../EditorData/Docs


### PR DESCRIPTION
The issue that wasn't allowing the TypeDoc documentation to be generated with a custom theme has been resolved ( https://github.com/TypeStrong/typedoc/issues/227 ) 

This change does the following
- Allows for the latest TypeDoc to be pulled which uses the latest TypeScript
- adds a fix for the latest NPM so that the node_modules get put in the right place