### PR TITLE
Fix linux crash on player exit

### DIFF
--- a/Source/Atomic/IPC/IPCChannel.cpp
+++ b/Source/Atomic/IPC/IPCChannel.cpp
@@ -99,7 +99,7 @@ bool IPCChannel::Receive()
             break;
 
         VectorBuffer newBuffer;
-        newBuffer.Write(dataBuffer_.GetData() + dataBuffer_.GetPosition(), dataBuffer_.GetSize() - dataBuffer_.GetPosition());
+        newBuffer.SetData(dataBuffer_.GetData() + dataBuffer_.GetPosition(), dataBuffer_.GetSize() - dataBuffer_.GetPosition());
         newBuffer.Seek(0);
         dataBuffer_ = newBuffer;
     }


### PR DESCRIPTION
This pr fixes the editor crash when the player is exited. It was tracked down to an optimization issue with g++ -O3 and VectorBuffer::Write() in a particular situation. This call was changed to VectorBuffer::SetData(), which will perform the same action for filling a new VectorBuffer, and does not incur the -O3 optimization problem.