### PR TITLE
Fix issue #480 Allow the camera to rotate in the scene view infinitely

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,6 +37,8 @@
 
 - Kobus vd Walt (https://github.com/Kobusvdwalt)
 
+- Benjamin Wolf (https://github.com/Benwolf)
+
 ### Contribution Copyright and Licensing
 
 Atomic Game Engine contribution copyrights are held by their authors.  Each author retains the copyright to their contribution and agrees to irrevocably license the contribution under the Atomic Game Engine Contribution License `CONTRIBUTION_LICENSE.md`.  Please see `CONTRIBUTING.md` for more details.

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
@@ -229,6 +229,11 @@ void SceneView3D::MoveCamera(float timeStep)
         yaw_ += MOUSE_SENSITIVITY * mouseMove.x_;
         pitch_ += MOUSE_SENSITIVITY * mouseMove.y_;
         pitch_ = Atomic::Clamp(pitch_, -90.0f, 90.0f);
+        input->SetMouseVisible(false);
+    }
+    else
+    {
+        input->SetMouseVisible(true);
     }
 
     // Construct new orientation for the camera scene node from yaw and pitch. Roll is fixed to zero


### PR DESCRIPTION
Right click on viewport will hide the cursor and allow the camera to continue to rotate. Fix issue #480