### PR TITLE
Android C# support for redistributable Atomic Editor binary builds

### DIFF
--- a/Build/Scripts/BuildAndroid.js
+++ b/Build/Scripts/BuildAndroid.js
@@ -8,40 +8,40 @@ var buildDir = host.artifactsRoot + "Build/Android/";
 
 namespace('build', function() {
 
-  task('android_native', {
-    async: true
-  }, function() {
+    task('android_native', {
+        async: true
+    }, function() {
 
-    // Clean build
-    common.cleanCreateDir(buildDir);
+        // Clean build
+        common.cleanCreateDir(buildDir);
 
-    process.chdir(buildDir);
+        process.chdir(buildDir);
 
-    var cmds = [];
+        var cmds = [];
 
-    if (os.platform() == "win32") {
-      cmds.push(atomicRoot + "Build/Scripts/Windows/CompileAndroid.bat");
-    }
-    else {
-      cmds.push("cmake -G \"Unix Makefiles\" -DCMAKE_TOOLCHAIN_FILE=../../../Build/CMake/Toolchains/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release ../../../");
-      cmds.push("make -j4");
-    }
+        if (os.platform() == "win32") {
+            cmds.push(atomicRoot + "Build/Scripts/Windows/CompileAndroid.bat");
+        }
+        else {
+            cmds.push("cmake -G \"Unix Makefiles\" -DCMAKE_TOOLCHAIN_FILE=../../../Build/CMake/Toolchains/android.toolchain.cmake -DCMAKE_BUILD_TYPE=Release ../../../");
+            cmds.push("make -j4");
+        }
 
-    jake.exec(cmds, function() {
+        jake.exec(cmds, function() {
 
-      var editorAppFolder = host.artifactsRoot + (os.platform() == "win32" ? "AtomicEditor/" : "AtomicEditor/AtomicEditor.app/");
+            var editorAppFolder = host.artifactsRoot + (os.platform() == "win32" ? "AtomicEditor/" : "AtomicEditor/AtomicEditor.app/");
 
-      // Install Deployment
-      fs.copySync(buildDir + "Source/AtomicPlayer/Application/libAtomicPlayer.so",
-        editorAppFolder + "Resources/ToolData/Deployment/Android/libs/armeabi-v7a/libAtomicPlayer.so");
+            // Install Deployment
+            fs.copySync(buildDir + "Source/AtomicPlayer/Application/libAtomicPlayer.so",
+            editorAppFolder + "Contents/Resources/ToolData/Deployment/Android/libs/armeabi-v7a/libAtomicPlayer.so");
 
-      complete();
+            complete();
 
-    }, {
-      printStdout: true,
-      breakOnError : false
+        }, {
+            printStdout: true,
+            breakOnError : false
+        });
+
     });
-
-  });
 
 }); // end of build namespace

--- a/Build/Scripts/BuildAndroid.js
+++ b/Build/Scripts/BuildAndroid.js
@@ -8,7 +8,7 @@ var buildDir = host.artifactsRoot + "Build/Android/";
 
 namespace('build', function() {
 
-  task('android_player', ["build:atomiceditor"], {
+  task('android_native', {
     async: true
   }, function() {
 

--- a/Build/Scripts/BuildWindows.js
+++ b/Build/Scripts/BuildWindows.js
@@ -8,119 +8,120 @@ var editorAppFolder = host.artifactsRoot + "AtomicEditor/";
 
 namespace('build', function() {
 
-  // Builds a standalone Atomic Editor, which can be distributed out of build tree
-  task('atomiceditor', {
-    async: true
-}, function(android) {
+    // Builds a standalone Atomic Editor, which can be distributed out of build tree
+    task('atomiceditor', {
+        async: true
+    }, function(android) {
 
-    android = android == "android" ? true : false;
+        android = android == "android" ? true : false;
 
-    // Clean build
-    var cleanBuild = true;
-    if (cleanBuild) {
-      common.cleanCreateDir(buildDir);
-      common.cleanCreateDir(editorAppFolder);
-      common.cleanCreateDir(host.getGenScriptRootDir("WINDOWS"));
-    }
+        // Clean build
+        var cleanBuild = true;
+        if (cleanBuild) {
+            common.cleanCreateDir(host.artifactsRoot + "AtomicNET/");
+            common.cleanCreateDir(buildDir);
+            common.cleanCreateDir(editorAppFolder);
+            common.cleanCreateDir(host.getGenScriptRootDir());
+        }
 
-    process.chdir(buildDir);
+        process.chdir(buildDir);
 
-    var cmds = [];
+        var cmds = [];
 
-    // Build the AtomicEditor
-    cmds.push(atomicRoot + "Build/Scripts/Windows/CompileAtomicEditor.bat");
-    cmds.push(host.atomicTool + " net compile " + atomicRoot + "Script/AtomicNET/AtomicNETProject.json " + (android ? "ANDROID" : "WINDOWS") + " Release");
+        // Build the AtomicEditor
+        cmds.push(atomicRoot + "Build/Scripts/Windows/CompileAtomicEditor.bat");
+        cmds.push(host.atomicTool + " net compile " + atomicRoot + "Script/AtomicNET/AtomicNETProject.json " + (android ? "ANDROID" : "WINDOWS") + " Release");
 
-    function copyAtomicNET() {
+        function copyAtomicNET() {
 
-        fs.copySync(atomicRoot + "Artifacts/AtomicNET/Release",
-          editorAppFolder + "Resources/ToolData/AtomicNET/Release");
+            fs.copySync(atomicRoot + "Artifacts/AtomicNET/Release",
+            editorAppFolder + "Resources/ToolData/AtomicNET/Release");
 
-        fs.copySync(atomicRoot + "Script/AtomicNET/AtomicProject.json",
-          editorAppFolder + "Resources/ToolData/AtomicNET/Build/Projects/AtomicProject.json");
+            fs.copySync(atomicRoot + "Script/AtomicNET/AtomicProject.json",
+            editorAppFolder + "Resources/ToolData/AtomicNET/Build/Projects/AtomicProject.json");
 
-    }
+        }
 
-    jake.exec(cmds, function() {
+        jake.exec(cmds, function() {
 
-      // Copy the Editor binaries
-      fs.copySync(buildDir + "Source/AtomicEditor/Release",
-        host.artifactsRoot + "AtomicEditor");
+            // Copy the Editor binaries
+            fs.copySync(buildDir + "Source/AtomicEditor/Release",
+            host.artifactsRoot + "AtomicEditor");
 
-      // We need some resources to run
-      fs.copySync(atomicRoot + "Resources/CoreData",
-        editorAppFolder + "Resources/CoreData");
+            // We need some resources to run
+            fs.copySync(atomicRoot + "Resources/CoreData",
+            editorAppFolder + "Resources/CoreData");
 
-      fs.copySync(atomicRoot + "Resources/PlayerData",
-        editorAppFolder + "Resources/PlayerData");
+            fs.copySync(atomicRoot + "Resources/PlayerData",
+            editorAppFolder + "Resources/PlayerData");
 
-      fs.copySync(atomicRoot + "Data/AtomicEditor",
-        editorAppFolder + "Resources/ToolData");
+            fs.copySync(atomicRoot + "Data/AtomicEditor",
+            editorAppFolder + "Resources/ToolData");
 
-      fs.copySync(atomicRoot + "Resources/EditorData",
-        editorAppFolder + "Resources/EditorData");
+            fs.copySync(atomicRoot + "Resources/EditorData",
+            editorAppFolder + "Resources/EditorData");
 
-      fs.copySync(atomicRoot + "Artifacts/Build/Resources/EditorData/AtomicEditor/EditorScripts",
-        editorAppFolder + "Resources/EditorData/AtomicEditor/EditorScripts");
+            fs.copySync(atomicRoot + "Artifacts/Build/Resources/EditorData/AtomicEditor/EditorScripts",
+            editorAppFolder + "Resources/EditorData/AtomicEditor/EditorScripts");
 
-      fs.copySync(buildDir +  "Source/AtomicPlayer/Application/Release/AtomicPlayer.exe",
-        editorAppFolder + "Resources/ToolData/Deployment/Windows/x64/AtomicPlayer.exe");
+            fs.copySync(buildDir +  "Source/AtomicPlayer/Application/Release/AtomicPlayer.exe",
+            editorAppFolder + "Resources/ToolData/Deployment/Windows/x64/AtomicPlayer.exe");
 
-      fs.copySync(buildDir +  "Source/AtomicPlayer/Application/Release/D3DCompiler_47.dll",
-        editorAppFolder + "Resources/ToolData/Deployment/Windows/x64/D3DCompiler_47.dll");
+            fs.copySync(buildDir +  "Source/AtomicPlayer/Application/Release/D3DCompiler_47.dll",
+            editorAppFolder + "Resources/ToolData/Deployment/Windows/x64/D3DCompiler_47.dll");
 
-      if (android) {
+            if (android) {
 
-          var androidNativeTask = jake.Task['build:android_native'];
+                var androidNativeTask = jake.Task['build:android_native'];
 
-          androidNativeTask.addListener('complete', function () {
-              copyAtomicNET();
-              console.log("\nAtomic Editor build to ", editorAppFolder);
-              complete();
-          });
+                androidNativeTask.addListener('complete', function () {
+                    copyAtomicNET();
+                    console.log("\nAtomic Editor build to ", editorAppFolder);
+                    complete();
+                });
 
-          androidNativeTask.invoke();
+                androidNativeTask.invoke();
 
-      }
-      else {
-          copyAtomicNET();
-          console.log("\nAtomic Editor build to ", editorAppFolder);
-          complete();
-      }
+            }
+            else {
+                copyAtomicNET();
+                console.log("\nAtomic Editor build to ", editorAppFolder);
+                complete();
+            }
 
-    }, {
-      printStdout: true
+        }, {
+            printStdout: true
+        });
+
     });
 
-  });
+    // Generate a Visual Studio 2015 solution
+    task('genvs2015', {
+        async: true
+    }, function(devBuild) {
+        if (devBuild === undefined)
+        devBuild = 1;
 
-  // Generate a Visual Studio 2015 solution
-  task('genvs2015', {
-    async: true
-  }, function(devBuild) {
-    if (devBuild === undefined)
-      devBuild = 1;
+        var slnRoot = path.resolve(atomicRoot, "") + "-VS2015\\";
 
-    var slnRoot = path.resolve(atomicRoot, "") + "-VS2015\\";
+        if (!fs.existsSync(slnRoot)) {
+            jake.mkdirP(slnRoot);
+        }
 
-    if (!fs.existsSync(slnRoot)) {
-        jake.mkdirP(slnRoot);
-    }
+        process.chdir(slnRoot);
 
-    process.chdir(slnRoot);
+        var cmds = [];
 
-    var cmds = [];
+        cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot + " " + devBuild);
 
-    cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot + " " + devBuild);
+        jake.exec(cmds, function() {
 
-    jake.exec(cmds, function() {
+            complete();
 
-      complete();
+        }, {
+            printStdout: true
+        });
 
-    }, {
-      printStdout: true
     });
-
-  });
 
 }); // end of build namespace

--- a/Build/Scripts/Windows/CompileAtomicEditor.bat
+++ b/Build/Scripts/Windows/CompileAtomicEditor.bat
@@ -1,4 +1,3 @@
 call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
 cmake ..\\..\\..\\ -DATOMIC_DEV_BUILD=0 -G "Visual Studio 14 2015 Win64"
 msbuild /m Atomic.sln /t:AtomicEditor /t:AtomicPlayer /t:AtomicNETNative /p:Configuration=Release /p:Platform=x64
-msbuild Source/AtomicTool/GenerateAtomicNET.vcxproj /p:Configuration=Release /p:Platform=x64

--- a/Build_AtomicEditor.bat
+++ b/Build_AtomicEditor.bat
@@ -1,11 +1,37 @@
-@ECHO OFF
+@echo OFF
+setlocal enabledelayedexpansion
+
+set ATOMICEDITOR_BUILD_CMD=Build\Windows\node\node.exe Build\node_modules\jake\bin\cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+
+for %%a in (%*) do (
+  if /I "%%a"=="--with-android" (set ATOMICEDITOR_ANDROID=YES)
+)
+
+:: If we're building in android support, make sure ANDROID_NDK is defined
+if "%ATOMICEDITOR_ANDROID%" == "YES" (
+
+    if "%ANDROID_NDK%" == "" (
+        @echo:
+        echo ANDROID_NDK not set, exiting
+        @echo:
+        exit /B
+    )
+
+    @echo:
+    echo Building Atomic Editor with Android support
+    @echo:
+    set ATOMICEDITOR_BUILD_CMD=!ATOMICEDITOR_BUILD_CMD!["android"]
+)
+
 @echo:
 @echo:
 ECHO Building Atomic Editor, this process will take a few minutes
 @echo:
 @echo:
 PAUSE
-Build\Windows\node\node.exe Build\node_modules\jake\bin\cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+%ATOMICEDITOR_BUILD_CMD%
 @echo:
 @echo:
 PAUSE
+
+endlocal

--- a/Build_AtomicEditor.bat
+++ b/Build_AtomicEditor.bat
@@ -20,7 +20,7 @@ if "%ATOMICEDITOR_ANDROID%" == "YES" (
     @echo:
     echo Building Atomic Editor with Android support
     @echo:
-    set ATOMICEDITOR_BUILD_CMD=!ATOMICEDITOR_BUILD_CMD!["android"]
+    set ATOMICEDITOR_BUILD_CMD=!ATOMICEDITOR_BUILD_CMD![android]
 )
 
 @echo:

--- a/Build_AtomicEditor.sh
+++ b/Build_AtomicEditor.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env sh
 
+buildcmd="build:atomiceditor"
+
+for var in "$@"
+do
+    if [ $var == "--with-android" ]; then
+        if [ "$ANDROID_NDK" == "" ]; then
+            echo "\n\nANDROID_NDK environment variable not set, exiting\n\n"
+            exit 1
+        fi
+        echo "\n\nBuilding Atomic Editor with Android support\n\n"
+        buildcmd+="[android]"
+    fi
+done
+
 if [ "$(uname)" = "Darwin" ]; then
-    ./Build/Mac/node/node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+    ./Build/Mac/node/node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js $buildcmd
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
-    ./Build/Linux/node/node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+    ./Build/Linux/node/node ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js $buildcmd
 elif [ "$(expr substr $(uname -s) 1 7)" = "MSYS_NT" ]; then
-    ./Build/Windows/node/node.exe ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js build:atomiceditor
+    ./Build/Windows/node/node.exe ./Build/node_modules/jake/bin/cli.js -f ./Build/Scripts/Bootstrap.js $buildcmd
 fi

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
@@ -67,6 +67,7 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
             menu.addItem(new Atomic.UIMenuItem("Open Solution", `${this.name}.opensolution`));
             menu.addItem(new Atomic.UIMenuItem("Compile Project", `${this.name}.compileproject`));
             menu.addItem(new Atomic.UIMenuItem("Generate Solution", `${this.name}.generatesolution`));
+            menu.addItem(new Atomic.UIMenuItem("Package Resources", `${this.name}.packageresources`));
 
             this.compileOnSaveMenuItem = new Atomic.UIMenuItem(`Compile on Save: ${isCompileOnSave ? "On" : "Off"}`, `${this.name}.compileonsave`);
             menu.addItem(this.compileOnSaveMenuItem);
@@ -201,6 +202,9 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
                 case "generatesolution":
                     this.generateSolution();
                     return true;
+                case "packageresources":
+                    this.packageResources();
+                    return true;
                 case "compileonsave":
                     let isCompileOnSave = this.serviceRegistry.projectServices.getUserPreference(this.name, "CompileOnSave", false);
                     // Toggle
@@ -243,5 +247,15 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
 
     }
 
+    /**
+    * Generate Solution
+    */
+    packageResources() {
+
+        if (ToolCore.netProjectSystem) {
+            ToolCore.netProjectSystem.generateResourcePak();
+        }
+
+    }
 
 }

--- a/Source/Atomic/IO/FileSystem.cpp
+++ b/Source/Atomic/IO/FileSystem.cpp
@@ -439,7 +439,7 @@ bool FileSystem::SystemOpen(const String& fileName, const String& mode)
     {
         // ATOMIC BEGIN
         // allow opening of http and file urls
-        if (!fileName.StartsWith("http://") && !fileName.StartsWith("https://") && !fileName.StartsWith("file://"))        
+        if (!fileName.StartsWith("http://") && !fileName.StartsWith("https://") && !fileName.StartsWith("file://"))
             if (!FileExists(fileName) && !DirExists(fileName))
             {
                 ATOMIC_LOGERROR("File or directory " + fileName + " not found");
@@ -1261,6 +1261,8 @@ String GetSanitizedPath(const String& path)
     String sanitized = GetInternalPath(path);
     StringVector parts = sanitized.Split('/');
 
+    bool hasTrailingSlash = path.EndsWith("/") || path.EndsWith("\\");
+
 #ifndef ATOMIC_PLATFORM_WINDOWS
 
     bool absolute = IsAbsolutePath(path);
@@ -1273,6 +1275,9 @@ String GetSanitizedPath(const String& path)
     sanitized = String::Joined(parts, "/");
 
 #endif
+
+    if (hasTrailingSlash)
+        sanitized += "/";
 
     return sanitized;
 
@@ -1305,7 +1310,7 @@ bool GetRelativePath(const String& fromPath, const String& toPath, String& outpu
     for (startIdx = 0; startIdx < toParts.Size(); startIdx++)
     {
         if (startIdx >= fromParts.Size() || fromParts[startIdx] != toParts[startIdx])
-            break;       
+            break;
     }
 
     if (startIdx == toParts.Size())

--- a/Source/ToolCore/Build/BuildBase.h
+++ b/Source/ToolCore/Build/BuildBase.h
@@ -81,6 +81,9 @@ public:
 	bool GetResourcesOnly() const { return resourcesOnly_; }
 	void SetResourcesOnly(bool resourcesOnly = true) { resourcesOnly_ = resourcesOnly;  }
 
+	bool GetBuildFailed() const { return buildFailed_; }
+	const Vector<String>& GetBuildErrors() const { return buildErrors_; }
+
 protected:
 
     bool BuildClean(const String& path);

--- a/Source/ToolCore/Build/BuildWindows.cpp
+++ b/Source/ToolCore/Build/BuildWindows.cpp
@@ -173,13 +173,16 @@ void BuildWindows::Build(const String& buildPath)
     ToolSystem* tsystem = GetSubsystem<ToolSystem>();
     Project* project = tsystem->GetProject();
 
-    buildPath_ = AddTrailingSlash(buildPath) + GetBuildSubfolder();
+	buildPath_ = AddTrailingSlash(buildPath);
 
+	if (!resourcesOnly_)
+		buildPath_ += GetBuildSubfolder();
+		
     BuildLog("Starting Windows Deployment");
 
     Initialize();
 
-    if (!BuildClean(buildPath_))
+    if (!resourcesOnly_ && !BuildClean(buildPath_))
         return;
 
     String rootSourceDir = tenv->GetRootSourceDir();        
@@ -187,11 +190,18 @@ void BuildWindows::Build(const String& buildPath)
     if (!BuildCreateDirectory(buildPath_))
         return;
 
-    if (!BuildCreateDirectory(buildPath_ + "/AtomicPlayer_Resources"))
+    if (!resourcesOnly_ && !BuildCreateDirectory(buildPath_ + "/AtomicPlayer_Resources"))
         return;
 
     String resourcePackagePath = buildPath_ + "/AtomicPlayer_Resources/AtomicResources" + PAK_EXTENSION;
+
+	if (resourcesOnly_)
+	{
+		resourcePackagePath = buildPath_ + "/AtomicResources" + PAK_EXTENSION;
+	}
+
     GenerateResourcePackage(resourcePackagePath);
+
     if (buildFailed_)
         return;
 

--- a/Source/ToolCore/NETTools/NETProjectGen.cpp
+++ b/Source/ToolCore/NETTools/NETProjectGen.cpp
@@ -219,20 +219,25 @@ namespace ToolCore
 			{
 				if (GetIsPCL())
 				{
+					ref = "AtomicNET";
 					platform = "Portable";
 				}
 				else if (SupportsDesktop())
 				{
+					ref = "AtomicNET";
 					platform = "Desktop";
 				}
 				else if (SupportsPlatform("android"))
 				{
+					if (ref != "AtomicNET.Android.SDL")
+						ref = "AtomicNET";
+
 					platform = "Android";
 				}
 
 				if (platform.Length())
 				{					
-					String atomicNETAssembly = tenv->GetAtomicNETCoreAssemblyDir() + ToString("%s/AtomicNET.dll", platform.CString(), ref.CString());
+					String atomicNETAssembly = tenv->GetAtomicNETCoreAssemblyDir() + ToString("%s/%s.dll", platform.CString(), ref.CString());
 					xref = igroup.CreateChild("Reference");
 					xref.SetAttribute("Include", atomicNETAssembly);
 				}
@@ -617,7 +622,7 @@ namespace ToolCore
 #endif
 
 			// TODO: more than armeabi-v7a (which this is)
-			String nativePath = AddTrailingSlash(tenv->GetAtomicNETRootDir()) + config + "/Android/Native/libAtomicNETNative.so";
+			String nativePath = AddTrailingSlash(tenv->GetAtomicNETRootDir()) + config + "/Native/Android/libAtomicNETNative.so";
 
 			XMLElement nativeLibrary =  projectRoot.CreateChild("ItemGroup").CreateChild("AndroidNativeLibrary"); 
 			nativeLibrary.SetAttribute("Include", nativePath);

--- a/Source/ToolCore/NETTools/NETProjectSystem.h
+++ b/Source/ToolCore/NETTools/NETProjectSystem.h
@@ -63,6 +63,7 @@ namespace ToolCore
         void OpenSourceFile(const String& sourceFilePath);
 
         bool GenerateSolution();
+		bool GenerateResourcePak();
 
     private:
 


### PR DESCRIPTION
1) Ensure **ANDROID_NDK** environment variable is set to your installation of the Android NDK

**Windows:** ```Build_AtomicEditor.bat --with-android``` 
**OSX:** ```./Build_AtomicEditor.sh --with-android``` 
Linux: I haven't installed or looked into the Xamarin Android C# stuff for Linux yet

2) Make sure the Xamarin Android tooling is installed in your VS2015 or Xamarin Studio installation

3)  Add "android" to your project's Settings/Project.json platforms property, for example:

```json
{
    "name" : "AtomicBlaster",
    "platforms": ["desktop", "android"]
}
```