### PR TITLE
Override CSComponent GetTypeName to return the managed type name

### DIFF
--- a/Script/AtomicNET/AtomicNET/Scene/CSComponent.cs
+++ b/Script/AtomicNET/AtomicNET/Scene/CSComponent.cs
@@ -1,9 +1,14 @@
+using System;
 namespace AtomicEngine
 {
 
     public partial class CSComponent : ScriptComponent
     {
 
+        public override string GetTypeName()
+        {
+            return GetType().Name;
+        }
 
     }
 


### PR DESCRIPTION
Otherwise, it returns "CSComponent" instead of the managed class name, which is misleading