### PR TITLE
CSComponent resource improvements

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/CSComponentClassSelector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/CSComponentClassSelector.ts
@@ -28,7 +28,7 @@ class CSComponentClassSelector extends Atomic.UIWindow {
 
         super();
 
-        var assemblyFile = component.assemblyFile;
+        var assemblyFile = component.componentFile;
 
         this.text = "Select Class: " + assemblyFile.name;
 

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionEditTypes.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionEditTypes.ts
@@ -64,7 +64,7 @@ class CSComponentEditType extends SerializableEditType {
         var csc1 = <AtomicNETScript.CSComponent>(otherType.objects[0]);
         var csc2 = <AtomicNETScript.CSComponent>(this.objects[0]);
 
-        return csc1.assemblyFile == csc2.assemblyFile && csc1.componentClassName == csc2.componentClassName;
+        return csc1.componentFile == csc2.componentFile && csc1.componentClassName == csc2.componentClassName;
 
     }
 

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
@@ -176,6 +176,8 @@ class CSComponentSection extends ComponentSection {
 
         this.subscribeToEvent("CSComponentAssemblyChanged", (ev) => this.handleCSComponentAssemblyChanged(ev));
 
+        this.subscribeToEvent("CSComponentClassChanged", (ev) => this.handleCSComponentClassChanged(ev));
+
     }
 
     private handleCSComponentAssemblyChanged(ev) {
@@ -185,7 +187,7 @@ class CSComponentSection extends ComponentSection {
         if (!csc)
           return;
 
-        if (csc.assemblyFile == <AtomicNETScript.CSComponentAssembly> ev.resource) {
+        if (csc.componentFile == <Atomic.ScriptComponentFile> ev.resource) {
 
           var attrInfos = csc.getAttributes();
           this.updateDynamicAttrInfos(attrInfos);
@@ -193,6 +195,20 @@ class CSComponentSection extends ComponentSection {
         }
 
     }
+
+    private handleCSComponentClassChanged(ev) {
+
+        var csc = <AtomicNETScript.CSComponent>this.editType.getFirstObject();
+
+        if (!csc)
+          return;
+
+        var attrInfos = csc.getAttributes();
+        this.updateDynamicAttrInfos(attrInfos);
+        this.updateTextFromClassAttr();
+
+    }
+
 
     private handleAttributeEditResourceChanged(ev: AttributeEditResourceChangedEvent) {
 

--- a/Script/AtomicNET/AtomicNET/Scene/CSComponentCore.cs
+++ b/Script/AtomicNET/AtomicNET/Scene/CSComponentCore.cs
@@ -329,10 +329,7 @@ namespace AtomicEngine
         {
 #if ATOMIC_DESKTOP || ATOMIC_MOBILE
             string assemblyPath = eventData["AssemblyPath"];
-
             string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-            if (componentCache.ContainsKey(assemblyName))
-                return;
 
             Assembly assembly = Assembly.LoadFrom(assemblyPath);
 
@@ -356,14 +353,13 @@ namespace AtomicEngine
         void ParseAssembly(Assembly assembly)
         {
 #if ATOMIC_DESKTOP || ATOMIC_MOBILE
-            String assemblyPath = assembly.GetName().Name;
 
-            if (parsedAssemblies.ContainsKey(assemblyPath))
+            if (parsedAssemblies.ContainsKey(assembly))
             {
                 return;
             }
 
-            parsedAssemblies[assemblyPath] = true;
+            parsedAssemblies[assembly] = true;
 
             Type[] types = assembly.GetTypes();
 
@@ -400,7 +396,7 @@ namespace AtomicEngine
         Dictionary<string, CSComponentInfo> componentCache = new Dictionary<string, CSComponentInfo>();
 
         [Obsolete("Member parsedAssemblies is temporarily required for runtime component assemblies loading")]
-        Dictionary<string, bool> parsedAssemblies = new Dictionary<string, bool>();
+        Dictionary<Assembly, bool> parsedAssemblies = new Dictionary<Assembly, bool>();
 
         Dictionary<Type, CSComponentInfo> csinfoLookup = new Dictionary<Type, CSComponentInfo>();
 

--- a/Script/AtomicNET/AtomicNET/Scene/CSComponentCore.cs
+++ b/Script/AtomicNET/AtomicNET/Scene/CSComponentCore.cs
@@ -298,25 +298,17 @@ namespace AtomicEngine
 
         void HandleComponentLoad(uint eventType, ScriptVariantMap eventData)
         {
-            var assemblyPath = eventData["AssemblyPath"];
-
             var className = eventData["ClassName"];
+
             IntPtr csnative = eventData.GetVoidPtr("NativeInstance");
             IntPtr fieldValues = IntPtr.Zero;
 
             if (eventData.Contains("FieldValues"))
                 fieldValues = eventData.GetVoidPtr("FieldValues");
 
-            Dictionary<string, CSComponentInfo> assemblyTypes = null;
-
-            if (!componentCache.TryGetValue(assemblyPath, out assemblyTypes))
-            {
-                return;
-            }
-
             CSComponentInfo csinfo;
 
-            if (!assemblyTypes.TryGetValue(className, out csinfo))
+            if (!componentCache.TryGetValue(className, out csinfo))
             {
                 return;
             }
@@ -332,6 +324,7 @@ namespace AtomicEngine
 
         }
 
+        [Obsolete("Method HandleComponentAssemblyReference is deprecated (loading component assemblies at runtime, will be changed to preload them)")]
         void HandleComponentAssemblyReference(uint eventType, ScriptVariantMap eventData)
         {
 #if ATOMIC_DESKTOP || ATOMIC_MOBILE
@@ -365,12 +358,12 @@ namespace AtomicEngine
 #if ATOMIC_DESKTOP || ATOMIC_MOBILE
             String assemblyPath = assembly.GetName().Name;
 
-            Dictionary<string, CSComponentInfo> assemblyTypes = null;
-
-            if (!componentCache.TryGetValue(assemblyPath, out assemblyTypes))
+            if (parsedAssemblies.ContainsKey(assemblyPath))
             {
-                componentCache[assemblyPath] = assemblyTypes = new Dictionary<string, CSComponentInfo>();
+                return;
             }
+
+            parsedAssemblies[assemblyPath] = true;
 
             Type[] types = assembly.GetTypes();
 
@@ -380,7 +373,7 @@ namespace AtomicEngine
                 {
                     var csinfo = new CSComponentInfo(type);
                     csinfoLookup[csinfo.Type] = csinfo;
-                    assemblyTypes[type.Name] = csinfo;
+                    componentCache[type.Name] = csinfo;
                 }
             }
 #endif
@@ -403,7 +396,11 @@ namespace AtomicEngine
 
         }
 
-        Dictionary<string, Dictionary<string, CSComponentInfo>> componentCache = new Dictionary<string, Dictionary<string, CSComponentInfo>>();
+        // type name -> CSComponentInfo lookup TODO: store with namespace to solve ambiguities
+        Dictionary<string, CSComponentInfo> componentCache = new Dictionary<string, CSComponentInfo>();
+
+        [Obsolete("Member parsedAssemblies is temporarily required for runtime component assemblies loading")]
+        Dictionary<string, bool> parsedAssemblies = new Dictionary<string, bool>();
 
         Dictionary<Type, CSComponentInfo> csinfoLookup = new Dictionary<Type, CSComponentInfo>();
 

--- a/Source/Atomic/Script/ScriptComponentFile.h
+++ b/Source/Atomic/Script/ScriptComponentFile.h
@@ -40,6 +40,8 @@ public:
 
     static void RegisterObject(Context* context);
 
+    /// Only valid in editor, as we don't inspect classnames at runtime
+    virtual const Vector<String>& GetClassNames() { return classNames_; }
     const EnumMap& GetEnums(const String& classname = String::EMPTY) const;
     const FieldMap& GetFields(const String& classname = String::EMPTY) const;
     const VariantMap& GetDefaultFieldValues(const String& classname = String::EMPTY) const;
@@ -53,6 +55,9 @@ protected:
     void AddEnum(const String& enumName, const EnumInfo& enumInfo, const String& classname = String::EMPTY);
     void AddField(const String& fieldName, VariantType variantType, const String& classname = String::EMPTY);
     void AddDefaultValue(const String& fieldName, const Variant& value, const String& classname = String::EMPTY);
+
+    // only valid in editor
+    Vector<String> classNames_;
 
 private:
 

--- a/Source/AtomicEditor/EditorMode/AEEditorMode.cpp
+++ b/Source/AtomicEditor/EditorMode/AEEditorMode.cpp
@@ -180,7 +180,9 @@ bool EditorMode::PlayProject(String addArgs, bool debug)
     paths.Push(project->GetResourcePath());
 
     // fixme: this is for loading from cache
+    // https://github.com/AtomicGameEngine/AtomicGameEngine/issues/1037
     paths.Push(project->GetProjectPath());
+
     paths.Push(project->GetProjectPath() + "Cache");
 
     String resourcePaths;

--- a/Source/AtomicNET/NETNative/Desktop/NETIPCPlayerApp.cpp
+++ b/Source/AtomicNET/NETNative/Desktop/NETIPCPlayerApp.cpp
@@ -23,9 +23,9 @@
 
 #include <Atomic/Engine/Engine.h>
 #include <Atomic/IO/FileSystem.h>
-
 #include "NETCore.h"
 #include <AtomicNET/NETScript/NETScript.h>
+#include <AtomicNET/NETScript/CSComponentAssembly.h>
 
 #include "NETIPCPlayerApp.h"
 
@@ -74,6 +74,9 @@ namespace Atomic
             ErrorExit();
             return exitCode_;
         }
+
+        // TODO: Proper CSComponent assembly preload (this only works on desktop)
+        CSComponentAssembly::PreloadClassAssemblies();
 
         Start();
 

--- a/Source/AtomicNET/NETScript/CSComponent.cpp
+++ b/Source/AtomicNET/NETScript/CSComponent.cpp
@@ -76,17 +76,18 @@ void CSComponent::ApplyFieldValues()
 
 void CSComponent::SetComponentClassName(const String& name)
 {
+    if (componentClassName_ == name)
+        return;
+
     componentClassName_ = name;
 
-    // if (assemblyFile_ && assemblyFile_->GetClassNames().Contains(name))
+    if (context_->GetEditorContext())
     {
-        /*
         using namespace CSComponentClassChanged;
         VariantMap eventData;
         eventData[P_CSCOMPONENT] = this;
         eventData[P_CLASSNAME] = name;
         SendEvent(E_CSCOMPONENTCLASSCHANGED, eventData);
-        */
     }
 }
 

--- a/Source/AtomicNET/NETScript/CSComponent.h
+++ b/Source/AtomicNET/NETScript/CSComponent.h
@@ -60,13 +60,7 @@ public:
     void SetComponentClassName(const String& name);
     const String& GetComponentClassName() const { return componentClassName_; }
 
-    virtual ScriptComponentFile* GetComponentFile() { return assemblyFile_; }
-
-    CSComponentAssembly* GetAssemblyFile() { return assemblyFile_; }
-    void SetAssemblyFile(CSComponentAssembly* assemblyFile);
-
-    ResourceRef GetAssemblyFileAttr() const;
-    void SetAssemblyFileAttr(const ResourceRef& value);
+    virtual ScriptComponentFile* GetComponentFile();
 
 protected:
 
@@ -80,7 +74,6 @@ private:
     void SendLoadEvent();
 
     String componentClassName_;
-    SharedPtr<CSComponentAssembly> assemblyFile_;
 
 };
 

--- a/Source/AtomicNET/NETScript/CSComponentAssembly.h
+++ b/Source/AtomicNET/NETScript/CSComponentAssembly.h
@@ -64,6 +64,12 @@ namespace Atomic
         /// Only valid in editor, as we don't inspect assembly at runtime
         const Vector<String>& GetClassNames() { return classNames_; }
 
+        // Find assembly by class name or namespace qualified classname
+        static CSComponentAssembly* ResolveClassAssembly(const String& fullClassName);
+
+        // TODO: Proper method to preload class assemblies (which will also work on mobile)
+        static bool PreloadClassAssemblies();
+
     private:
 
         static void InitTypeMap();

--- a/Source/AtomicNET/NETScript/CSComponentAssembly.h
+++ b/Source/AtomicNET/NETScript/CSComponentAssembly.h
@@ -78,9 +78,6 @@ namespace Atomic
 
         String fullAssemblyPath_;
 
-        // only valid in editor
-        Vector<String> classNames_;
-
         HashMap<String, Vector<EnumInfo>> assemblyEnums_;
         static HashMap<StringHash, VariantType> typeMap_;
 

--- a/Source/AtomicNET/NETScript/NETScriptEvents.h
+++ b/Source/AtomicNET/NETScript/NETScriptEvents.h
@@ -47,5 +47,10 @@ namespace Atomic
         ATOMIC_PARAM(P_ASSEMBLYPATH, AssemblyPath); // String
     }
 
+    ATOMIC_EVENT(E_CSCOMPONENTCLASSCHANGED, CSComponentClassChanged)
+    {
+        ATOMIC_PARAM(P_CSCOMPONENT, Component); // CSComponent*
+        ATOMIC_PARAM(P_CLASSNAME, Classname); // String
+    }
 
 }


### PR DESCRIPTION
This PR removes the dependency on CSComponentAssembly resources from CSComponent, which made it really easy for components to drop out based on the resources being renamed, inaccessible, etc.  It also reintroduces changing classes on the fly in the inspector and having the attributes refresh properly.

Components are currently looked up by classname, we will support looking up by qualified namespace + classname in the future

IMPORTANT: Component assemblies are now preloaded for desktop (we will need a unified solution for mobile and desktop), this shouldn't break projects which contain components in multiple project assemblies, though beware