### PR TITLE
Minor enhancements and a try/catch to prevent dll parsing from failing

### DIFF
--- a/Script/AtomicNET/AtomicNET/Math/Color.cs
+++ b/Script/AtomicNET/AtomicNET/Math/Color.cs
@@ -25,8 +25,10 @@ namespace AtomicEngine
         }
 
 
-
         public static readonly Color White = new Color(1, 1, 1, 1);
+        public static readonly Color Red = new Color(1, 0, 0, 1);
+        public static readonly Color Blue = new Color(0, 1, 0, 1);
+        public static readonly Color Green = new Color(0, 0, 1, 1);
         public static readonly Color LightBlue = new Color(0.50f, 0.88f, 0.81f);
         public static readonly Color Transparent = new Color(0, 0, 0, 0);
 

--- a/Script/AtomicNET/AtomicNET/Math/Vector3.cs
+++ b/Script/AtomicNET/AtomicNET/Math/Vector3.cs
@@ -924,6 +924,45 @@ namespace AtomicEngine
             result.Z = blend * (b.Z - a.Z) + a.Z;
         }
 
+        /// <summary>
+        /// Returns a new Vector that is the linear blend of the 2 given Vectors
+        /// </summary>
+        /// <param name="a">First input vector</param>
+        /// <param name="b">Second input vector</param>
+        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
+        /// <returns>a when blend=0, b when blend=1, and a linear combination otherwise</returns>
+        public static Vector3 ClampedLerp(Vector3 a, Vector3 b, float blend)
+        {
+            if (blend > 1)
+                blend = 1;
+            else if (blend < 0)
+                blend = 0;
+
+            a.X = blend * (b.X - a.X) + a.X;
+            a.Y = blend * (b.Y - a.Y) + a.Y;
+            a.Z = blend * (b.Z - a.Z) + a.Z;
+            return a;
+        }
+
+        /// <summary>
+        /// Returns a new Vector that is the linear blend of the 2 given Vectors
+        /// </summary>
+        /// <param name="a">First input vector</param>
+        /// <param name="b">Second input vector</param>
+        /// <param name="blend">The blend factor. a when blend=0, b when blend=1.</param>
+        /// <param name="result">a when blend=0, b when blend=1, and a linear combination otherwise</param>
+        public static void ClampedLerp(ref Vector3 a, ref Vector3 b, float blend, out Vector3 result)
+        {
+            if (blend > 1)
+                blend = 1;
+            else if (blend < 0)
+                blend = 0;
+
+            result.X = blend * (b.X - a.X) + a.X;
+            result.Y = blend * (b.Y - a.Y) + a.Y;
+            result.Z = blend * (b.Z - a.Z) + a.Z;
+        }
+
         #endregion
 
         #region Barycentric

--- a/Script/AtomicNET/AtomicNETService/AssemblyInspector.cs
+++ b/Script/AtomicNET/AtomicNETService/AssemblyInspector.cs
@@ -83,7 +83,7 @@ namespace AtomicTools
                 if (genericParams.Count != 0)
                     continue;
 
-                var parentName = metaReader.GetString(typeDef.Name);
+                var typeName = metaReader.GetString(typeDef.Name);
 
                 var baseTypeHandle = typeDef.BaseType;
 
@@ -104,9 +104,9 @@ namespace AtomicTools
 
                     var typeRef = metaReader.GetTypeReference((TypeReferenceHandle)baseTypeHandle);
 
-                    var name = metaReader.GetString(typeRef.Name);
+                    var baseName = metaReader.GetString(typeRef.Name);
 
-                    if (name != "CSComponent")
+                    if (baseName != "CSComponent")
                         continue;
 
                     var inspector = new CSComponentInspector(typeDef, peFile, metaReader);

--- a/Script/AtomicNET/AtomicNETService/CSComponentInspector.cs
+++ b/Script/AtomicNET/AtomicNETService/CSComponentInspector.cs
@@ -441,21 +441,28 @@ namespace AtomicTools
 
                             var fieldDef = metaReader.GetFieldDefinition(fieldHandle);
 
-                            var fieldName = metaReader.GetString(fieldDef.Name);
-
-                            if (opCode.ToString() == "stfld")
+                            // No way to predetermine if fieldDef.Name is valid
+                            try
                             {
+                                var fieldName = metaReader.GetString(fieldDef.Name);
 
-                                InspectorField inspectorField;
-
-                                if (_inspectorComponent.Fields.TryGetValue(fieldName, out inspectorField))
+                                if (opCode.ToString() == "stfld")
                                 {
-                                    inspectorField.DefaultValue = String.Join(" ", loadedValues.ToArray());
+
+                                    InspectorField inspectorField;
+
+                                    if (_inspectorComponent.Fields.TryGetValue(fieldName, out inspectorField))
+                                    {
+                                        inspectorField.DefaultValue = String.Join(" ", loadedValues.ToArray());
+                                    }
+
                                 }
-
                             }
-
-                            loadedValues.Clear();
+                            catch (Exception) { break; }
+                            finally
+                            {
+                                loadedValues.Clear();
+                            }
 
                             break;
                         case OperandType.InlineMethod:


### PR DESCRIPTION
The first three commits are harmless/simple

The last one (wrap InlineField handling..) is related to the issue I was having last week. The parser is stumbling on components that have no constructor, and no explicit inline assigned values. This is a complete showstopper, so until a better solution can be found I'm wrapping the source of the exception in a try/catch.

The loadedValues still gets cleared, so parsing of the rest of the component (and other components in the assembly) still succeeds. Should .ctor processing perhaps just be skipped entirely?