### PR TITLE
Animation Transition Fix

### DIFF
--- a/Source/Atomic/Graphics/AnimatedModel.cpp
+++ b/Source/Atomic/Graphics/AnimatedModel.cpp
@@ -1364,7 +1364,6 @@ void AnimatedModel::UpdateAnimation(const FrameInfo& frame)
     // (first AnimatedModel in a node)
     if (isMaster_)
     {
-        skeleton_.ResetSilent();
         for (Vector<SharedPtr<AnimationState> >::Iterator i = animationStates_.Begin(); i != animationStates_.End(); ++i)
             (*i)->Apply();
 


### PR DESCRIPTION
Resetting the skeleton of a mesh each frame causes animation blending to not work as hoped/expected when transitioning from one animation to another, involving a regression toward the base/T pose. This reset doesn't seem to really be necessary, and it looks like it would be fine to simply lerp from the last position of the skeleton into the new animation frames.

This change removes the skeleton reset, and appears to work well for the cases tested of blending between animations.  