### PR TITLE
(DDS Resource Loading) Updates for PR #1085 

### DIFF
--- a/Source/Atomic/Resource/ResourceCache.cpp
+++ b/Source/Atomic/Resource/ResourceCache.cpp
@@ -712,7 +712,26 @@ SharedPtr<Resource> ResourceCache::GetTempResource(StringHash type, const String
     }
 
     // Attempt to load the resource
-    SharedPtr<File> file = GetFile(name, sendEventOnFailure);
+    SharedPtr<File> file;
+
+    // #623 BEGIN TODO: For now try to get DDS version of textures from /DDS cache sub directory,
+    // ultimately should have per platform compressed versions saved in cache
+#ifdef ATOMIC_PLATFORM_DESKTOP
+    String ext = Atomic::GetExtension(name);
+    if (ext == ".jpg" || ext == ".png" || ext == ".tga")
+    {
+        String ddsName = "DDS/" + name + ".dds";
+        file = GetFile(ddsName, false);
+        if (file)
+            LOGDEBUG("Loaded cached DDS " + name + ".dds");
+    }
+    if (!file)
+        file = GetFile(name, sendEventOnFailure);
+#else
+    // #623 END TODO
+    file = GetFile(name, sendEventOnFailure);
+#endif
+
     if (!file)
         return SharedPtr<Resource>();  // Error is already logged
 

--- a/Source/Atomic/Resource/ResourceCache.cpp
+++ b/Source/Atomic/Resource/ResourceCache.cpp
@@ -711,6 +711,8 @@ SharedPtr<Resource> ResourceCache::GetTempResource(StringHash type, const String
         return SharedPtr<Resource>();
     }
 
+// ATOMIC BEGIN
+
     // Attempt to load the resource
     SharedPtr<File> file;
 
@@ -723,7 +725,7 @@ SharedPtr<Resource> ResourceCache::GetTempResource(StringHash type, const String
         String ddsName = "DDS/" + name + ".dds";
         file = GetFile(ddsName, false);
         if (file)
-            LOGDEBUG("Loaded cached DDS " + name + ".dds");
+            ATOMIC_LOGDEBUG("Loaded cached DDS " + name + ".dds");
     }
     if (!file)
         file = GetFile(name, sendEventOnFailure);
@@ -731,6 +733,8 @@ SharedPtr<Resource> ResourceCache::GetTempResource(StringHash type, const String
     // #623 END TODO
     file = GetFile(name, sendEventOnFailure);
 #endif
+
+// ATOMIC END
 
     if (!file)
         return SharedPtr<Resource>();  // Error is already logged


### PR DESCRIPTION

Adding ATOMIC_BEGIN/ATOMIC_END around changed block, fixes logging macro