### PR TITLE
- Material inspector now removes references to textures correctly

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/MaterialInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/MaterialInspector.ts
@@ -279,8 +279,6 @@ class MaterialInspector extends ScriptWidget {
             if (texture) {
                 inspector.material.setTexture(textureUnit, texture);
                 textureWidget.texture = inspector.getTextureThumbnail(texture);
-
-                this.sendEvent(EditorEvents.InspectorProjectReference, { "path": texture.getName() });
             }
 
         });
@@ -324,6 +322,7 @@ class MaterialInspector extends ScriptWidget {
 
         if (texture != null && textureWidget != null) {
             textureWidget.setTexture(null);
+            this.material.setTexture(textureUnit, null);
         }
 
     }


### PR DESCRIPTION
- Stopped the project frame from referencing the texture being assigned from the resource select menu.