### PR TITLE
Remove exception from native type wrapping

### DIFF
--- a/Script/AtomicNET/AtomicNET/IO/Log.cs
+++ b/Script/AtomicNET/AtomicNET/IO/Log.cs
@@ -7,6 +7,12 @@ namespace AtomicEngine
     public partial class Log : AObject
     {
 
+        public static void Debug(string message)
+        {
+            Log.Write(Constants.LOG_DEBUG, message);
+        }
+
+
         public static void Warn(string message)
         {
             Log.Write(Constants.LOG_WARNING, message);

--- a/Source/AtomicNET/NETNative/NETCInterop.cpp
+++ b/Source/AtomicNET/NETNative/NETCInterop.cpp
@@ -68,11 +68,15 @@ namespace Atomic
             refCounted->ReleaseRef();
         }
 
-        ATOMIC_EXPORT_API const char* csi_Atomic_AObject_GetTypeName(Object* self)
+        ATOMIC_EXPORT_API const char* csi_Atomic_RefCounted_GetTypeName(RefCounted* self)
         {
+            if (!self->IsObject())
+            {
+                return "RefCounted";
+            }
 
             static String returnValue;
-            returnValue = self->GetTypeName();
+            returnValue = ((Object*)self)->GetTypeName();
             return returnValue.CString();
         }
 


### PR DESCRIPTION
Attempting to wrap a native of unknown type no longer throws an exception, instead returns null with optional logging, these cases are quite rare and as C# is strongly typed, mostly happen when querying event data.  

For example, Renderer2D is an internal native class which generates a component added event, the event data will now have a null for the component parameter, instead of throwing an exception when accessed