### PR TITLE
linux xbuild config test

### DIFF
--- a/Build/Scripts/BuildConfig.js
+++ b/Build/Scripts/BuildConfig.js
@@ -1,6 +1,21 @@
 var os = require('os');
 var path = require('path');
 var spawnSync = require('child_process').spawnSync;
+var fs = require('fs-extra');
+
+// function from BuildCommon, checks to see if a file exists
+function programFileExists(filePath)
+{
+    try
+    {
+        return fs.statSync(filePath).isFile();
+    }
+    catch (err)
+    {
+        return false;
+    }
+}
+
 
 function processOptions(config) {
 
@@ -12,14 +27,16 @@ function processOptions(config) {
     } else {
         if (os.platform() == "win32") {
             config["with-atomicnet"] = true;
-        } else {
+        } else if (os.platform() == "darwin") {
             // see if xbuild is available
             config["with-atomicnet"]  = false;
-            if ( spawnSync) // TODO: CI box doesn't have spawnSync
+            if ( spawnSync)
                 config["with-atomicnet"] = spawnSync("which", ["xbuild"]).status == 1 ? false : true;
+        } else if (os.platform() == "linux") {  // see if xbuild is available on linux
+            config["with-atomicnet"] = programFileExists('/usr/bin/xbuild');
         }
-    }
-
+	}
+	
     // paths
     config.atomicRoot = path.resolve(__dirname, "../..") + "/";
     config.artifactsRoot = config.atomicRoot + "Artifacts/";


### PR DESCRIPTION
Test for the existence of xbuild by looking for it as an installed program, instead of using a node command.
I didn't know if you wanted the OSX to do the same thing, so I left it as is, since it was working.