### PR TITLE
Project handling improvements

### DIFF
--- a/Script/AtomicEditor/ui/modal/build/BuildSettingsWindow.ts
+++ b/Script/AtomicEditor/ui/modal/build/BuildSettingsWindow.ts
@@ -142,6 +142,11 @@ export class BuildSettingsWindow extends ModalWindow {
 
                 var index = this.platformSelect.value;
 
+                var showMessage = function(target, title, message) {
+                    var window = new Atomic.UIMessageWindow(target, "modal_error");
+                    window.show(title, message, Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 260);
+                }
+
                 for (var name in this.platformInfo) {
 
                     var info: { widget: Atomic.UIWidget, index: number, logo: string } = this.platformInfo[name];
@@ -150,17 +155,41 @@ export class BuildSettingsWindow extends ModalWindow {
 
                         var platform = toolSystem.getPlatformByName(name);
 
-                        if (platform.platformID == ToolCore.PLATFORMID_IOS) {
+                        // Do we have a C# project?
+                        if (ToolCore.netProjectSystem.solutionAvailable) {
 
-                            if (Atomic.platform == "Windows") {
+                            if (platform.platformID == ToolCore.PLATFORMID_WEB) {
 
-                                var message = "\niOS Deployment requires running the Atomic Editor on MacOSX\n\n";
-                                new Atomic.UIMessageWindow(this, "modal_error").show("MacOSX Required", message, Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 260);
+                                showMessage(this, "Platform Info", "\nThe web platform is not available when using C# at this time\n\n");
                                 return true;
 
                             }
 
+                            if (platform.platformID == ToolCore.PLATFORMID_IOS || platform.platformID == ToolCore.PLATFORMID_ANDROID) {
+
+                                var ide = Atomic.platform == "Windows" ? "Visual Studio" : "Xamarin Studio";
+                                var message = `Please open the following solution in ${ide}:\n\n ${ToolCore.netProjectSystem.solutionPath}\n\n`;
+                                message += "HINT: You can open the solution by clicking on any C# script in the project or from the Developer->Plugins->AtomicNET menu\n";
+                                showMessage(this, "IDE Deployment Required", message);
+                                return true;
+                            }
+
+
+                        } else {
+
+                            if (platform.platformID == ToolCore.PLATFORMID_IOS) {
+
+                                if (Atomic.platform == "Windows") {
+
+                                    showMessage(this, "MacOSX Required", "\niOS Deployment requires running the Atomic Editor on MacOSX\n\n");
+                                    return true;
+
+                                }
+
+                            }
+
                         }
+
 
                         toolSystem.setCurrentPlatform(platform.platformID);
 

--- a/Source/AtomicApp/Player/IPCPlayerApp.cpp
+++ b/Source/AtomicApp/Player/IPCPlayerApp.cpp
@@ -194,7 +194,8 @@ namespace Atomic
             SubscribeToEvent(E_PLAYERQUIT, ATOMIC_HANDLER(IPCPlayerApp, HandleQuit));
         }
 
-        
+        GetSubsystem<Graphics>()->RaiseWindow();
+
 
     }
 

--- a/Source/AtomicEditor/EditorMode/AEEditorMode.cpp
+++ b/Source/AtomicEditor/EditorMode/AEEditorMode.cpp
@@ -128,6 +128,9 @@ void EditorMode::HandleIPCJSError(StringHash eventType, VariantMap& eventData)
 
 bool EditorMode::PlayProject(String addArgs, bool debug)
 {
+    if (playerBroker_.NotNull())
+        return false;
+
     FileSystem* fileSystem = GetSubsystem<FileSystem>();
     ToolSystem* tsystem = GetSubsystem<ToolSystem>();
     ToolEnvironment* tenv = GetSubsystem<ToolEnvironment>();

--- a/Source/ThirdParty/SDL/src/video/windows/SDL_windowswindow.c
+++ b/Source/ThirdParty/SDL/src/video/windows/SDL_windowswindow.c
@@ -488,7 +488,12 @@ WIN_HideWindow(_THIS, SDL_Window * window)
 void
 WIN_RaiseWindow(_THIS, SDL_Window * window)
 {
-    WIN_SetWindowPositionInternal(_this, window, SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOSIZE);
+    // ATOMIC BEGIN
+    // See: http://hg.libsdl.org/SDL/rev/76e7fa1a446d
+    // WIN_SetWindowPositionInternal(_this, window, SWP_NOCOPYBITS | SWP_NOMOVE | SWP_NOSIZE);
+    HWND hwnd = ((SDL_WindowData *)window->driverdata)->hwnd;
+    SetForegroundWindow(hwnd);
+    // ATOMIC END
 }
 
 void

--- a/Source/ToolCore/NETTools/NETBuildSystem.cpp
+++ b/Source/ToolCore/NETTools/NETBuildSystem.cpp
@@ -311,8 +311,25 @@ namespace ToolCore
                 compile += ToString("&& \"%s\" restore \"%s\" ", nugetBinary.CString(), solutionPath.CString());
             }
 
-            compile += ToString("&& msbuild \"%s\" %s %s\"", solutionPath.CString(), platforms.CString(), configs.CString());
+            compile += ToString("&& msbuild \"%s\" %s %s", solutionPath.CString(), platforms.CString(), configs.CString());
 
+            if (curBuild_->targets_.Size()) {
+
+                StringVector targets;
+
+                for (unsigned i = 0; i < curBuild_->targets_.Size(); i++)
+                {
+                    const char* tname = curBuild_->targets_[i].CString();
+                    targets.Push(ToString("/t:\"%s:Rebuild\"", tname));
+                }
+
+                compile += " " + String::Joined(targets, " ");
+
+            }
+
+            // close out quote
+            compile += "\"";
+                
             args.Push(compile);
 
 #else
@@ -412,7 +429,21 @@ namespace ToolCore
 
         if (build)
         {
+            ProjectSettings* settings = project->GetProjectSettings();
+
+            // This path is currently only hit when refreshing for desktop
+            if (settings->GetSupportsAndroid() || settings->GetSupportsIOS()) 
+            {
+                // Build the PCL, which will get copied to Resources
+                build->targets_.Push(project->GetProjectSettings()->GetName());
+
+                // Build the Desktop executable, so we can run it
+                // IMPORTANT NOTE: msbuild requires replacing '.' with '_' when in project name
+                build->targets_.Push(project->GetProjectSettings()->GetName() + "_Desktop");
+            }
+
             build->project_ = project;
+
         }
 
         ATOMIC_LOGINFOF("Received build for project %s", project->GetProjectFilePath().CString());

--- a/Source/ToolCore/NETTools/NETBuildSystem.h
+++ b/Source/ToolCore/NETTools/NETBuildSystem.h
@@ -70,6 +70,7 @@ namespace ToolCore
         String solutionPath_;
         StringVector configurations_;
         StringVector platforms_;
+        StringVector targets_;
 
         NETBuildStatus status_;
         String allArgs_;

--- a/Source/ToolCore/NETTools/NETProjectSystem.cpp
+++ b/Source/ToolCore/NETTools/NETProjectSystem.cpp
@@ -327,7 +327,11 @@ namespace ToolCore
         {
             fileSystem->ScanDir(results, AddTrailingSlash(projectPath) + "Resources", "*.dll", SCAN_FILES, true);
             if (!results.Size())
-                return;
+            {
+                solutionPath_.Clear();
+                return;                
+            }
+                
         }            
 
         // if the solution or project assemblies don't exist mark as dirty

--- a/Source/ToolCore/NETTools/NETProjectSystem.h
+++ b/Source/ToolCore/NETTools/NETProjectSystem.h
@@ -52,6 +52,9 @@ namespace ToolCore
 
         bool GetIDEAvailable() const { return idePath_.Length() != 0; }
 
+        /// Returns true if there is a solution available for the loaded project (true = managed app)
+        bool GetSolutionAvailable() const { return solutionPath_.Length() != 0; }
+
         const String& GetSolutionPath() const { return solutionPath_; }
 
         void BuildAtomicProject();        


### PR DESCRIPTION
+  Only build PCL + Desktop when refreshing project assembly from Atomic Editor
+  Fix for issue with Graphics::RaiseWindow on Windows (fixed in SDL)
+  Protect against launching more than one player processes
+ Additional clarification messages for builds