### PR TITLE
Copy libAtomicPlayer.so to build dir

### DIFF
--- a/Build/Scripts/BuildAndroid.js
+++ b/Build/Scripts/BuildAndroid.js
@@ -35,6 +35,10 @@ namespace('build', function() {
             fs.copySync(buildDir + "Source/AtomicPlayer/Application/libAtomicPlayer.so",
             editorResourceFolder + "ToolData/Deployment/Android/libs/armeabi-v7a/libAtomicPlayer.so");
 
+            // Install local deployment
+            fs.copySync(buildDir + "Source/AtomicPlayer/Application/libAtomicPlayer.so",
+            atomicRoot + "Artifacts/AtomicEditor/Resources/ToolData/Deployment/Android/libs/armeabi-v7a/libAtomicPlayer.so");
+
             complete();
 
         }, {


### PR DESCRIPTION
The --with-android task correctly builds the libAtomicPlayer.so, and it copies it into AtomicEditor.app/Contents/Resources/ToolData/Deployment/Android/libs/armeabi-v7a, for managed C# deployment. This leaves the in-editor Build Android option unable to create an apk, as Dirk found in a Q&A entry.  This additional copy will restore the editor Build android functionality.