### PR TITLE
Get AtomicTool (net compile) running outside of the build tree, for example on a CI box

### DIFF
--- a/Build/Scripts/BuildAtomicNET.js
+++ b/Build/Scripts/BuildAtomicNET.js
@@ -64,7 +64,7 @@ namespace('build', function() {
 
         var cmds = [];
 
-        var netCmd = host.atomicTool + " net compile " + atomicRoot + "Script/AtomicNET/AtomicNETProject.json " + platforms + " -config " + config["config"];
+        var netCmd = host.atomicTool + " net compile " + atomicRoot + "Script/AtomicNET/AtomicNETProject.json " + platforms + " -config " + config["config"] + " -toolbootstrap";
 
         console.log(netCmd);
 

--- a/Build/Scripts/BuildWindows.js
+++ b/Build/Scripts/BuildWindows.js
@@ -27,6 +27,10 @@ function copyAtomicEditor() {
     fs.copySync(buildDir + "Source/AtomicEditor/" + config["config"],
     config.artifactsRoot + "AtomicEditor");
 
+    // copy AtomicTool
+    fs.copySync(buildDir +  "Source/AtomicTool/" + config["config"] +"/AtomicTool.exe",
+    editorAppFolder + "AtomicTool.exe");
+    
     // We need some resources to run
     fs.copySync(atomicRoot + "Resources/CoreData",
     editorAppFolder + "Resources/CoreData");

--- a/Source/AtomicEditor/Application/AEEditorApp.cpp
+++ b/Source/AtomicEditor/Application/AEEditorApp.cpp
@@ -89,18 +89,7 @@ namespace AtomicEditor
         ToolEnvironment* env = new ToolEnvironment(context_);
         context_->RegisterSubsystem(env);
 
-#ifdef ATOMIC_DEV_BUILD
-
-        if (!env->InitFromJSON())
-        {
-            ErrorExit(ToString("Unable to initialize tool environment from %s", env->GetDevConfigFilename().CString()));
-            return;
-        }
-#else
-
-        env->InitFromPackage();
-
-#endif
+        env->Initialize();
 
         ToolSystem* system = new ToolSystem(context_);
         context_->RegisterSubsystem(system);

--- a/Source/AtomicTool/AtomicTool.cpp
+++ b/Source/AtomicTool/AtomicTool.cpp
@@ -59,35 +59,8 @@ void AtomicTool::Setup()
 {
     const Vector<String>& arguments = GetArguments();
 
-    for (unsigned i = 0; i < arguments.Size(); ++i)
-    {
-        if (arguments[i].Length() > 1)
-        {
-            String argument = arguments[i].ToLower();
-            String value = i + 1 < arguments.Size() ? arguments[i + 1] : String::EMPTY;
-
-            if (argument == "--cli-data-path")
-            {
-                if (!value.Length())
-                    ErrorExit("Unable to parse --cli-data-path");
-
-                cliDataPath_ = AddTrailingSlash(value);
-            }
-            else if (argument == "--activate")
-            {
-                if (!value.Length())
-                    ErrorExit("Unable to parse --activation product key");
-
-                activationKey_ = value;
-            }
-            else if (argument == "--deactivate")
-            {
-                deactivate_ = true;
-            }
-
-        }
-
-    }
+    if (arguments.Contains("-toolbootstrap"))
+        ToolEnvironment::SetBootstrapping();
 
     engineParameters_["Headless"] = true;
     engineParameters_["LogLevel"] = LOG_INFO;
@@ -220,24 +193,12 @@ void AtomicTool::Start()
     ToolEnvironment* env = new ToolEnvironment(context_);
     context_->RegisterSubsystem(env);
 
-//#ifdef ATOMIC_DEV_BUILD
-
-    if (!env->InitFromJSON())
+    // Initialize the ToolEnvironment
+    if (!env->Initialize(true))
     {
-        ErrorExit(ToString("Unable to initialize tool environment from %s", env->GetDevConfigFilename().CString()));
+        ErrorExit("Unable to initialize tool environment");
         return;
     }
-
-    if (!cliDataPath_.Length())
-    {
-        cliDataPath_ = env->GetRootSourceDir() + "/Resources/";
-    }
-
-//#endif
-
-    tsystem->SetCLI();
-    tsystem->SetDataPath(cliDataPath_);
-
 
     if (activationKey_.Length())
     {

--- a/Source/AtomicTool/AtomicTool.h
+++ b/Source/AtomicTool/AtomicTool.h
@@ -35,7 +35,7 @@ namespace AtomicTool
 
 class AtomicTool : public Application
 {
-    ATOMIC_OBJECT(AtomicTool, Application);
+    ATOMIC_OBJECT(AtomicTool, Application)
 
 public:
 
@@ -69,8 +69,6 @@ private:
     void DoActivation();
     void DoDeactivation();
 
-    // use a variant map instead?
-    String cliDataPath_;
     String activationKey_;
     bool deactivate_;
 

--- a/Source/ToolCore/Command/NewProjectCmd.cpp
+++ b/Source/ToolCore/Command/NewProjectCmd.cpp
@@ -68,35 +68,7 @@ bool NewProjectCmd::Parse(const Vector<String>& arguments, unsigned startIndex, 
 
 void NewProjectCmd::Run()
 {
-    Poco::File projectDest(projectPath_.CString());
-
-    if (projectDest.exists())
-    {
-        Error(ToString("New project path: %s already exists", projectPath_.CString()));
-        return;
-    }
-
-    ToolSystem* tsystem = GetSubsystem<ToolSystem>();
-    String templateDir = tsystem->GetDataPath();
-    templateDir += "ProjectTemplates/Project2D/Resources";
-
-    Poco::File projectSrc(templateDir.CString());
-    if (!projectSrc.exists() || !projectSrc.isDirectory())
-    {
-        Error(ToString("New project path: %s source does not exist", templateDir.CString()));
-        return;
-    }
-
-    ATOMIC_LOGINFOF("Creating new project in: %s", projectPath_.CString());
-
-    projectDest.createDirectory();
-    projectSrc.copyTo((projectPath_ + "/Resources").CString());
-
-    String filename("NewProject");
-    SharedPtr<ProjectFile> pfile(new ProjectFile(context_));
-    pfile->WriteNewProject(projectPath_ + "/" + filename + ".atomic");
-
-    Finished();
+    Error("NewProjectCmd is under maintenance, please use the AtomicEditor to create a new project");
 }
 
 }

--- a/Source/ToolCore/NETTools/NETBuildSystem.cpp
+++ b/Source/ToolCore/NETTools/NETBuildSystem.cpp
@@ -240,6 +240,7 @@ namespace ToolCore
 
             StringVector stringVector;
             String platforms;
+            StringVector processedPlatforms;
             String configs;
 
             for (unsigned i = 0; i < curBuild_->configurations_.Size(); i++)
@@ -254,6 +255,20 @@ namespace ToolCore
             {
                 // map platform
                 String platform = curBuild_->platforms_[i];
+
+                if (platform == "windows" || platform == "macosx" || platform == "linux")
+                {
+                    ATOMIC_LOGINFOF("Platform \"%s\" mapped to \"desktop\"", platform.CString());
+                    platform = "desktop";
+                }
+
+                if (processedPlatforms.Contains(platform))
+                {
+                    ATOMIC_LOGWARNINGF("Platform \"%s\" is duplicated, skipping", platform.CString());
+                    continue;
+                }
+
+                processedPlatforms.Push(platform);
 
                 if (platform == "desktop" || platform == "android")
                 {

--- a/Source/ToolCore/Project/Project.cpp
+++ b/Source/ToolCore/Project/Project.cpp
@@ -31,6 +31,7 @@
 #include <Atomic/Resource/JSONFile.h>
 
 #include "../ToolSystem.h"
+#include "../ToolEnvironment.h"
 #include "../ToolEvents.h"
 #include "../Platform/Platform.h"
 
@@ -74,13 +75,14 @@ void Project::SaveUserPrefs()
 bool Project::LoadUserPrefs()
 {
     ToolSystem* tsystem = GetSubsystem<ToolSystem>();
+    ToolEnvironment* tenv = GetSubsystem<ToolEnvironment>();
 
     String path = GetProjectPath() + "UserPrefs.json";
 
     userPrefs_->Load(path);
 
     // If we're in CLI mode, the Build folder is always relative to project
-    if (tsystem->IsCLI())
+    if (tenv->GetCLI())
     {
         String path = GetPath(projectFilePath_) + "Build";
         userPrefs_->SetLastBuildPath(path);

--- a/Source/ToolCore/ToolEnvironment.h
+++ b/Source/ToolCore/ToolEnvironment.h
@@ -46,10 +46,7 @@ public:
     ToolEnvironment(Context* context);
     virtual ~ToolEnvironment();
 
-    bool InitFromPackage();
-
-    // dev build init env from json
-    bool InitFromJSON(bool atomicTool = false);
+    bool Initialize(bool cli = false);
 
     /// Root source and build directories for development source tree builds
     void SetRootSourceDir(const String& sourceDir);
@@ -77,7 +74,8 @@ public:
 
     const String& GetToolDataDir() { return toolDataDir_; }
 
-    const String& GetDevConfigFilename();
+    // Returns true if we running from a command line tool (aka: AtomicTool)
+    bool GetCLI() { return cli_; }
 
     // AtomicNET
 
@@ -94,7 +92,14 @@ public:
 
     void Dump();
 
+    static void SetBootstrapping() { bootstrapping_ = true; }
+
 private:
+
+    bool InitFromDistribution();
+
+    // Whether we are running from a command line tool, such as AtomicTool
+    bool cli_;
 
     // root source directory (for development builds)
     String rootSourceDir_;
@@ -137,8 +142,6 @@ private:
     String iosBuildDir_;
     String webBuildDir_;
 
-    String devConfigFilename_;
-
     // AtomicNET
     String atomicNETRootDir_;
     String atomicNETCoreAssemblyDir_;
@@ -146,6 +149,8 @@ private:
     String monoExecutableDir_;
 
     SharedPtr<ToolPrefs> toolPrefs_;
+
+    static bool bootstrapping_;
 };
 
 }

--- a/Source/ToolCore/ToolSystem.cpp
+++ b/Source/ToolCore/ToolSystem.cpp
@@ -50,7 +50,6 @@ namespace ToolCore
 {
 
 ToolSystem::ToolSystem(Context* context) : Object(context),
-    cli_(false),
     updateDelta_(0.0f)
 {
     context_->RegisterSubsystem(new AssetDatabase(context_));

--- a/Source/ToolCore/ToolSystem.h
+++ b/Source/ToolCore/ToolSystem.h
@@ -47,9 +47,6 @@ public:
     Project* GetProject() { return project_; }
     void CloseProject();
 
-    const String& GetDataPath() { return dataPath_; }
-    void SetDataPath(const String& path) { dataPath_ = path; }
-
     // Platforms
     void RegisterPlatform(Platform* platform);
     Platform* GetPlatformByID(PlatformID platform);
@@ -58,15 +55,9 @@ public:
     void SetCurrentPlatform(PlatformID platform);
     Platform* GetCurrentPlatform();
 
-    void SetCLI() { cli_ = true; }
-    bool IsCLI() { return cli_; }
-
 private:
 
     void HandleUpdate(StringHash eventType, VariantMap& eventData);
-
-    /// Full path to data files
-    String dataPath_;
 
     SharedPtr<Platform> currentPlatform_;
 
@@ -74,8 +65,6 @@ private:
     HashMap<unsigned, SharedPtr<Platform> > platforms_;
 
     SharedPtr<Project> project_;
-
-    bool cli_;
 
     float updateDelta_;
 


### PR DESCRIPTION

This PR cleans up ToolEnvironment initialization and makes it possible to running AtomicTool (including the net compile command) outside of the build tree