### PR TITLE
Adding Tools -> Logs folder for opening log file location, making tools folder available when no project loaded

### DIFF
--- a/Script/AtomicEditor/ui/frames/MainFrame.ts
+++ b/Script/AtomicEditor/ui/frames/MainFrame.ts
@@ -144,13 +144,11 @@ class MainFrame extends ScriptWidget {
     disableProjectMenus() {
         this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
         this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
-        this.getWidget("menu tools").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
     }
 
     enableProjectMenus() {
         this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
         this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
-        this.getWidget("menu tools").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
     }
 
     shutdown() {

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -271,7 +271,12 @@ class MainFrameMenu extends Atomic.ScriptObject {
             if (refid == "tools toggle profiler") {
                 Atomic.ui.toggleDebugHud();
                 return true;
-            }
+            } else if (refid.indexOf("tools log") != -1) {
+
+                let logName = refid.indexOf("editor") != -1 ? "AtomicEditor" : "AtomicPlayer";
+                let logFolder = Atomic.fileSystem.getAppPreferencesDir(logName, "Logs");
+                Atomic.fileSystem.systemOpen(logFolder);
+            } 
 
         } else if (target.id == "menu build popup") {
 
@@ -354,7 +359,12 @@ var editItems = {
 
 var toolsItems = {
 
-    "Toggle Profiler": ["tools toggle profiler"]
+    "Toggle Profiler": ["tools toggle profiler"],
+    "Logs": {
+        "Player Log": ["tools log player"],
+        "Editor Log": ["tools log editor"]
+    }
+    
 
 };
 
@@ -376,7 +386,6 @@ var developerItems = {
             "Force Reimport": ["developer assetdatabase force"]
         }
     }
-
 
 };
 


### PR DESCRIPTION
This PR adds a logs subitem to the Tools menu which opens the folder containing the editor or player log files

![logs](https://cloud.githubusercontent.com/assets/376203/20239270/93fb2054-a8b1-11e6-912b-3ec476753a6a.PNG)

Closes #1144 