### PR TITLE
Fixes #177 - Display name of JS file in inspector when a JS component is selected

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
@@ -145,7 +145,7 @@ class JSComponentSection extends ComponentSection {
         this.hasDynamicAttr = true;
 
         this.subscribeToEvent(this, "AttributeEditResourceChanged", (ev) => this.handleAttributeEditResourceChanged(ev));
-
+        this.updateTitleFromComponentClass();
     }
 
     private handleAttributeEditResourceChanged(ev: AttributeEditResourceChangedEvent) {
@@ -157,7 +157,15 @@ class JSComponentSection extends ComponentSection {
 
         var attrInfos = jsc.getAttributes();
         this.updateDynamicAttrInfos(attrInfos);
+        this.updateTitleFromComponentClass();
+    }
 
+    private updateTitleFromComponentClass() {
+        this.text = this.editType.typeName;
+        let jsc = this.editType.getFirstObject() as Atomic.JSComponent;
+        if (jsc && jsc.componentFile) {
+            this.text = jsc.componentFile.name.split("/").pop();
+        }
     }
 
 }


### PR DESCRIPTION
I opted for just displaying the bare .js filename with the .js file extension here.  

So,
```Components/Spinner.js``` would be titled ```Spinner.js```.  That should give enough information to know that it is a JSComponent and that it resides in Spinner.js and doesn't take up extra screen real-estate on the title bar.

I didn't touch the way the C# components display (the class name).