### PR TITLE
Consistent AtomicNET.dll referencing regardless of build

### DIFF
--- a/Source/Atomic/IO/FileSystem.cpp
+++ b/Source/Atomic/IO/FileSystem.cpp
@@ -1314,7 +1314,18 @@ bool GetRelativePath(const String& fromPath, const String& toPath, String& outpu
     }
 
     if (startIdx == toParts.Size())
+    {
+        if (from.EndsWith("/") && to.EndsWith("/"))
+        {
+            for (unsigned i = 0; i < fromParts.Size() - startIdx; i++)
+            {
+                output += "../";
+            }
+
+            return true;
+        }
         return false;
+    }
 
     for (int i = 0; i < (int)fromParts.Size() - startIdx; i++)
     {

--- a/Source/ToolCore/JSBind/JSBHeaderVisitor.h
+++ b/Source/ToolCore/JSBind/JSBHeaderVisitor.h
@@ -644,7 +644,10 @@ public:
                 }
                 else
                 {
-                    ATOMIC_LOGINFOF("Warning: %s baseclass %s not in bindings", name.CString(), baseclassname.CString());
+                    if (!i)
+                    {
+                        ATOMIC_LOGINFOF("Warning: %s first baseclass %s not in bindings", name.CString(), baseclassname.CString());
+                    }
                 }
             }
             else

--- a/Source/ToolCore/NETTools/NETBuildSystem.cpp
+++ b/Source/ToolCore/NETTools/NETBuildSystem.cpp
@@ -351,7 +351,7 @@ namespace ToolCore
 
             // close out quote
             compile += "\"";
-                
+
             args.Push(compile);
 
 #else
@@ -459,7 +459,7 @@ namespace ToolCore
         configurations.Push("Release");
 #endif
 
-        AtomicNETCopyAssemblies(context_, project->GetProjectPath() + "Lib/");
+        AtomicNETCopyAssemblies(context_, project->GetProjectPath() + "AtomicNET/Lib/");
 
         String solutionPath = project->GetProjectPath() + "AtomicNET/Solution/" + project->GetProjectSettings()->GetName() + ".sln";
 
@@ -470,7 +470,7 @@ namespace ToolCore
             ProjectSettings* settings = project->GetProjectSettings();
 
             // This path is currently only hit when refreshing for desktop
-            if (settings->GetSupportsAndroid() || settings->GetSupportsIOS()) 
+            if (settings->GetSupportsAndroid() || settings->GetSupportsIOS())
             {
                 // Build the PCL, which will get copied to Resources
                 build->targets_.Push(project->GetProjectSettings()->GetName());

--- a/Source/ToolCore/NETTools/NETBuildSystem.cpp
+++ b/Source/ToolCore/NETTools/NETBuildSystem.cpp
@@ -459,6 +459,8 @@ namespace ToolCore
         configurations.Push("Release");
 #endif
 
+        AtomicNETCopyAssemblies(context_, project->GetProjectPath() + "Lib/");
+
         String solutionPath = project->GetProjectPath() + "AtomicNET/Solution/" + project->GetProjectSettings()->GetName() + ".sln";
 
         NETBuild* build = Build(solutionPath, platforms, configurations);

--- a/Source/ToolCore/NETTools/NETProjectGen.cpp
+++ b/Source/ToolCore/NETTools/NETProjectGen.cpp
@@ -407,13 +407,17 @@ namespace ToolCore
         String outputPath = assemblyOutputPath_;
         outputPath.Replace("$ATOMIC_CONFIG$", "Release");
 
-        String atomicProjectPath = projectGen_->GetAtomicProjectPath();
-
-        if (atomicProjectPath.Length())
+        if (IsAbsolutePath(outputPath))
         {
-            if (!GetRelativeProjectPath(outputPath, projectPath_, outputPath))
+
+            String atomicProjectPath = projectGen_->GetAtomicProjectPath();
+
+            if (atomicProjectPath.Length())
             {
-                ATOMIC_LOGERRORF("NETCSProject::CreateReleasePropertyGroup - unable to get relative output path");
+                if (!GetRelativeProjectPath(outputPath, projectPath_, outputPath))
+                {
+                    ATOMIC_LOGERRORF("NETCSProject::CreateReleasePropertyGroup - unable to get relative output path");
+                }
             }
         }
 
@@ -432,8 +436,9 @@ namespace ToolCore
         pgroup.CreateChild("ConsolePause").SetValue("false");
         pgroup.CreateChild("AllowUnsafeBlocks").SetValue("true");
 
-        // Don't warn on missing XML documentation
-        pgroup.CreateChild("NoWarn").SetValue("1591");
+        // 1591 - Don't warn on missing documentation 
+        // 1570 - malformed xml, remove once (https://github.com/AtomicGameEngine/AtomicGameEngine/issues/1161) resolved
+        pgroup.CreateChild("NoWarn").SetValue("1591;1570");
 
         if (genAssemblyDocFile_)
         {
@@ -509,14 +514,18 @@ namespace ToolCore
         String outputPath = assemblyOutputPath_;
         outputPath.Replace("$ATOMIC_CONFIG$", "Debug");
 
-        String atomicProjectPath = projectGen_->GetAtomicProjectPath();
-
-        if (atomicProjectPath.Length())
+        if (IsAbsolutePath(outputPath))
         {
-            if (!GetRelativeProjectPath(outputPath, projectPath_, outputPath))
+            String atomicProjectPath = projectGen_->GetAtomicProjectPath();
+
+            if (atomicProjectPath.Length())
             {
-                ATOMIC_LOGERRORF("NETCSProject::CreateDebugPropertyGroup - unable to get relative output path");
+                if (!GetRelativeProjectPath(outputPath, projectPath_, outputPath))
+                {
+                    ATOMIC_LOGERRORF("NETCSProject::CreateDebugPropertyGroup - unable to get relative output path");
+                }
             }
+
         }
 
         pgroup.CreateChild("OutputPath").SetValue(outputPath);
@@ -535,8 +544,9 @@ namespace ToolCore
         pgroup.CreateChild("ConsolePause").SetValue("false");
         pgroup.CreateChild("AllowUnsafeBlocks").SetValue("true");
 
-        // Don't warn on missing XML documentation
-        pgroup.CreateChild("NoWarn").SetValue("1591");
+        // 1591 - Don't warn on missing documentation 
+        // 1570 - malformed xml, remove once (https://github.com/AtomicGameEngine/AtomicGameEngine/issues/1161) resolved
+        pgroup.CreateChild("NoWarn").SetValue("1591;1570");
 
         pgroup.CreateChild("DebugSymbols").SetValue("true");
 
@@ -1820,11 +1830,9 @@ namespace ToolCore
         if (!JSONFile::ParseJSON(netJSONString, netJSON))
             return false;
 
-#else
+#endif
 
         AtomicNETCopyAssemblies(context_, atomicProjectPath_ + "AtomicNET/Lib/");
-
-#endif
 
 #ifdef ATOMIC_DEV_BUILD
 

--- a/Source/ToolCore/NETTools/NETProjectGen.cpp
+++ b/Source/ToolCore/NETTools/NETProjectGen.cpp
@@ -165,15 +165,17 @@ namespace ToolCore
 
                 compile.SetAttribute("Include", path.CString());
 
+                String link = result[j];
+
                 // put generated files into generated folder
                 if (sourceFolder.Contains("Generated") && sourceFolder.Contains("CSharp") && sourceFolder.Contains("Packages"))
                 {
-                    compile.CreateChild("Link").SetValue("Generated\\" + result[j]);
+                    link = "Generated\\" + result[j];
                 }
-                else
-                {
-                    compile.CreateChild("Link").SetValue(result[j]);
-                }
+
+                link.Replace('/', '\\');
+
+                compile.CreateChild("Link").SetValue(link);
 
             }
 

--- a/Source/ToolCore/NETTools/NETProjectGen.h
+++ b/Source/ToolCore/NETTools/NETProjectGen.h
@@ -95,7 +95,6 @@ namespace ToolCore
 
         void CreateCompileItemGroup(XMLElement &projectRoot);
         void CreateReferencesItemGroup(XMLElement &projectRoot);
-        void CreateProjectReferencesItemGroup(XMLElement & projectRoot);
         void CreatePackagesItemGroup(XMLElement &projectRoot);
         void CreateMainPropertyGroup(XMLElement &projectRoot);
         void CreateDebugPropertyGroup(XMLElement &projectRoot);

--- a/Source/ToolCore/NETTools/NETProjectSystem.h
+++ b/Source/ToolCore/NETTools/NETProjectSystem.h
@@ -92,6 +92,7 @@ namespace ToolCore
 
         String idePath_;
 
+        String projectPath_;
         String solutionPath_;
         String projectAssemblyPath_;
 
@@ -104,5 +105,8 @@ namespace ToolCore
         WeakPtr<Subprocess> ideSubprocess_;
 
     };
+
+    /// Copies the core Atomic NET assemblies to a specified folder
+    bool AtomicNETCopyAssemblies(Context* context, const String& dstFolder);
 
 }


### PR DESCRIPTION
This PR introduces an AtomicNET/Lib folder to C# projects which contains the AtomicNET native and managed libraries, including desktop and mobile.  This facilitates a consistent assembly referencing between custom external solutions and generated ones.  It also is a consistent assembly reference for both projects opened by a development build of the editor, as well as a redistributable one.

It also cleans up absolute paths being used in csproj, which should make solutions portable across machines.  *Note**: There may still be some cases of absolute paths to flag, I did not test moving the solution across machines.

This is a pretty core change, Windows, OSX, Android, iOS, have been tested.  Linux should also work once past CI. 

One issue introduced by the change to binary references + dependencies instead of project references where they were possible, is that source navigation between the dependent and the project no longer works and instead, since it is now a binary reference, navigation brings you to the binary assembly explorer and not the source.   It is still however possible to trace and setup breakpoints in the development build AtomicNET sources.

The external solution test was changed to reference the AtomicNET binary and works both when AtomicNET is available (with debugging) in a development build and when opened from a binary editor installation.  AtomicTool is also able to build the external solution project.

Closes #1142 