### PR TITLE
Add audio strings into bindings for 1152

### DIFF
--- a/Source/ToolCore/JSBind/CSharp/CSModuleWriter.cpp
+++ b/Source/ToolCore/JSBind/CSharp/CSModuleWriter.cpp
@@ -203,7 +203,9 @@ String CSModuleWriter::GetManagedPrimitiveType(JSBPrimitiveType* ptype)
         return "int";
     if (ptype->kind_ == JSBPrimitiveType::Float)
         return "float";
-
+    if (ptype->kind_ == JSBPrimitiveType::Char)
+        return "string";  // it technically should return "char", but the
+                          // intent is really to support a string constant
     return "int";
 }
 
@@ -366,7 +368,11 @@ void CSModuleWriter::GenerateManagedEnumsAndConstants(String& source)
                 }
             }
 
-            String line = "public const " + managedType + " " + cname + " = " + value;
+            String line = "public const " + managedType + " " + cname + " = ";
+
+            if (managedType == "string")
+              line = line + "\"" + value + "\"";
+            else line += value;
 
             if (managedType == "float" && !line.EndsWith("f") && IsDigit(line[line.Length()-1]))
                 line += "f";

--- a/Source/ToolCore/JSBind/JSBHeaderVisitor.h
+++ b/Source/ToolCore/JSBind/JSBHeaderVisitor.h
@@ -568,6 +568,24 @@ public:
 
         Type* type = dtype.type();
 
+        if (type->isNamedType())
+        {
+            String classname = getNameString(type->asNamedType()->name());
+            if ( dtype.isConst() && classname == "String" )  // find a const string
+            {
+                const StringLiteral* sinit = decl->getInitializer();
+                if (sinit)
+                {
+                    if (sinit->chars())
+                    {
+                        String svalue = sinit->chars();
+                        module_->RegisterConstant(getNameString(decl->name()).CString(), svalue, JSBPrimitiveType::Char );
+                        return true;  // tag this constant as a Char type, because there is no String Primitive type
+                   }
+                }
+            }
+        }
+
         if (type->isPointerType() || type->isReferenceType())
             return true;
 

--- a/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
+++ b/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
@@ -243,8 +243,12 @@ void JSModuleWriter::WriteModulePreInit(String& source)
     Vector<String> constants = module_->constants_.Keys();
 
     for (unsigned i = 0; i < constants.Size(); i++)
-    {
-        source.AppendWithFormat("duk_push_number(ctx, (double) %s);\n", constants.At(i).CString());
+    {       // use char primitive type to signify a const string constant 
+        if ( module_->constants_[ constants.At(i) ].type->ToString() == "char" )
+            source.AppendWithFormat("duk_push_string(ctx, \"%s\");\n", constants.At(i).CString() );
+        else
+            source.AppendWithFormat("duk_push_number(ctx, (double) %s);\n", constants.At(i).CString());
+
         source.AppendWithFormat("duk_put_prop_string(ctx, -2, \"%s\");\n", constants.At(i).CString());
     }
 


### PR DESCRIPTION
This will allow const String constants in general to be bound into both JS and C#.  I thought that this might match other instances in the Atomic source code, but the Audio strings were the only ones.
I freely admit to repurposing the char primitive type to represent a string for the module constants, for two reasons, only numeric constants were being registered, and changing the primitives type enum could have compatibility issues.