### PR TITLE
Shortcut fixes for #697

### DIFF
--- a/Data/AtomicEditor/CodeEditor/MonacoEditor.html
+++ b/Data/AtomicEditor/CodeEditor/MonacoEditor.html
@@ -106,6 +106,12 @@
                 interop.getInstance().preferencesChanged(prefs);
             });
         }
+
+        function HOST_invokeShortcut(shortcut) {
+            setupEditor.then((interop) => {
+                interop.getInstance().invokeShortcut(shortcut);
+            });
+        }
     </script>
 
 </body>

--- a/Data/AtomicEditor/CodeEditor/MonacoEditor.html
+++ b/Data/AtomicEditor/CodeEditor/MonacoEditor.html
@@ -112,6 +112,12 @@
                 interop.getInstance().invokeShortcut(shortcut);
             });
         }
+
+        function HOST_formatCode() {
+            setupEditor.then((interop) => {
+                interop.getInstance().formatCode();
+            });
+        }
     </script>
 
 </body>

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -168,7 +168,6 @@ class Shortcuts extends Atomic.ScriptObject {
         if (!ToolCore.toolSystem.project) return;
         var resourceFrame = EditorUI.getMainFrame().resourceframe.currentResourceEditor;
         if (resourceFrame) {
-            resourceFrame.setFocus();
             resourceFrame.invokeShortcut(shortcut);
         }
     }

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -38,7 +38,7 @@ class Shortcuts extends Atomic.ScriptObject {
     }
 
     //this should be moved somewhere else...
-    invokePlayOrStopPlayer(debug:boolean = false) {
+    invokePlayOrStopPlayer(debug: boolean = false) {
         this.sendEvent(EditorEvents.SaveAllResources);
         if (Atomic.editorMode.isPlayerEnabled()) {
             this.sendEvent("IPCPlayerExitRequest");
@@ -63,8 +63,8 @@ class Shortcuts extends Atomic.ScriptObject {
 
                         let pos = Atomic.graphics.windowPosition;
 
-                        playerWindow.x = pos[0] + (Atomic.graphics.width/2 - playerWindow.width/2);
-                        playerWindow.y = pos[1] + (Atomic.graphics.height/2 - playerWindow.height/2);
+                        playerWindow.x = pos[0] + (Atomic.graphics.width / 2 - playerWindow.width / 2);
+                        playerWindow.y = pos[1] + (Atomic.graphics.height / 2 - playerWindow.height / 2);
 
                         // if too small a window, use default (which maximizes)
                         if (playerWindow.width < 480) {
@@ -164,10 +164,11 @@ class Shortcuts extends Atomic.ScriptObject {
         }
     }
 
-    invokeResourceFrameShortcut(shortcut: string) {
+    invokeResourceFrameShortcut(shortcut: Editor.EditorShortcutType) {
         if (!ToolCore.toolSystem.project) return;
         var resourceFrame = EditorUI.getMainFrame().resourceframe.currentResourceEditor;
         if (resourceFrame) {
+            resourceFrame.setFocus();
             resourceFrame.invokeShortcut(shortcut);
         }
     }

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionEventNames.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionEventNames.ts
@@ -30,4 +30,5 @@ export default class ClientExtensionEventNames {
     static ResourceRenamedEvent = "ResourceRenamedEvent";
     static ResourceDeletedEvent = "ResourceDeletedEvent";
     static PreferencesChangedEvent = "PreferencesChangedEvent";
+    static FormatCodeEvent = "FormatCodeEvent";
 }

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -101,6 +101,7 @@ export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExten
         eventDispatcher.subscribeToEvent(ClientExtensionEventNames.ResourceDeletedEvent, (ev) => this.deleteResource(ev));
         eventDispatcher.subscribeToEvent(ClientExtensionEventNames.CodeSavedEvent, (ev) => this.saveCode(ev));
         eventDispatcher.subscribeToEvent(ClientExtensionEventNames.PreferencesChangedEvent, (ev) => this.preferencesChanged(ev));
+        eventDispatcher.subscribeToEvent(ClientExtensionEventNames.FormatCodeEvent, (ev) => this.formatCode());
     }
 
     /**
@@ -164,6 +165,22 @@ export class WebViewServicesProvider extends ServicesProvider<Editor.ClientExten
                 // Verify that the service contains the appropriate methods and that it can handle the rename
                 if (service.rename) {
                     service.rename(ev);
+                }
+            } catch (e) {
+                alert(`Error detected in extension ${service.name}\n \n ${e.stack}`);
+            }
+        });
+    }
+
+    /**
+     * Called when the editor code should be formatted
+     */
+    formatCode() {
+        this.registeredServices.forEach((service) => {
+            try {
+                // Verify that the service contains the appropriate methods and that it can handle the rename
+                if (service.formatCode) {
+                    service.formatCode();
                 }
             } catch (e) {
                 alert(`Error detected in extension ${service.name}\n \n ${e.stack}`);

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/javascript/JavascriptLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/javascript/JavascriptLanguageExtension.ts
@@ -27,6 +27,9 @@ export default class JavascriptLanguageExtension implements Editor.ClientExtensi
     name: string = "ClientJavascriptLanguageExtension";
     description: string = "Javascript language services for the editor.";
 
+    private editor: monaco.editor.IStandaloneCodeEditor;
+    private active = false;
+
     private serviceLocator: Editor.ClientExtensions.ClientServiceLocator;
 
     /**
@@ -55,14 +58,18 @@ export default class JavascriptLanguageExtension implements Editor.ClientExtensi
      */
     configureEditor(ev: Editor.EditorEvents.EditorFileEvent) {
         if (this.isValidFiletype(ev.filename)) {
-            // TODO: configure the editor
-            //let editor = <AceAjax.Editor>ev.editor;
-            //editor.session.setMode("ace/mode/javascript");
-
-            //editor.setOptions({
-                //enableBasicAutocompletion: true,
-                //enableLiveAutocompletion: true
-            //});
+            this.editor = ev.editor; // cache this so that we can reference it later
+            this.active = true;
+        } else {
+            this.active = false;
         }
+    }
+
+    /**
+     * Format the code
+     * @memberOf JavascriptLanguageExtension
+     */
+    formatCode() {
+        // do nothing.  This is being handled by the TypeScriptLanguageExtension
     }
 }

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/turbobadger/TurboBadgerLanguageExtension.ts
@@ -28,6 +28,7 @@ export default class TurboBadgerLanguageExtension implements Editor.ClientExtens
     description: string = "TurboBadger language services for the editor.";
 
     private serviceLocator: Editor.ClientExtensions.ClientServiceLocator;
+    private active = false;
 
     /**
     * Initialize the language service
@@ -54,7 +55,7 @@ export default class TurboBadgerLanguageExtension implements Editor.ClientExtens
      */
     configureEditor(ev: Editor.EditorEvents.EditorFileEvent) {
         if (this.isValidFiletype(ev.filename)) {
-
+            this.active = true;
             monaco.languages.register({ id: "turbobadger" });
             // TODO: set up syntax hilighter
             // monaco.languages.setMonarchTokensProvider("turbobadger", this.getTokensProvider());
@@ -78,6 +79,15 @@ export default class TurboBadgerLanguageExtension implements Editor.ClientExtens
             editor.getModel().updateOptions({
                 insertSpaces: false
             });
+        }
+    }
+
+    /**
+     * Format the code
+     */
+    formatCode() {
+        if (this.active) {
+            alert("Code formatted not available for this syntax.");
         }
     }
 }

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
@@ -131,6 +131,8 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
      */
     configureEditor(ev: Editor.EditorEvents.EditorFileEvent) {
         if (this.isValidFiletype(ev.filename)) {
+            let editor = ev.editor as monaco.editor.IStandaloneCodeEditor;
+            this.editor = editor; // cache this so that we can reference it later
             this.active = true;
 
             this.overrideBuiltinServiceProviders();
@@ -143,8 +145,6 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
 
             this.filename = ev.filename;
 
-            let editor = ev.editor as monaco.editor.IStandaloneCodeEditor;
-            this.editor = editor; // cache this so that we can reference it later
             // Let's turn some things off in the editor.  These will be provided by the shared web worker
             if (this.isJsFile(ev.filename)) {
                 monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
@@ -284,6 +284,21 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
     saveFile(event: WorkerProcessTypes.SaveMessageData) {
         if (this.active) {
             this.serviceLocator.clientServices.getHostInterop().saveFile(event.filename, event.code);
+        }
+    }
+
+    /**
+     * Format the code
+     */
+    formatCode() {
+        if (this.active) {
+            const action = this.editor.getAction("editor.action.format");
+            if (action && action.isSupported()) {
+                if (this.editor.getSelection().isEmpty()) {
+                    this.editor.setSelection(this.editor.getModel().getFullModelRange());
+                }
+                action.run();
+            }
         }
     }
 

--- a/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/languageExtensions/typescript/TypescriptLanguageExtension.ts
@@ -294,10 +294,22 @@ export default class TypescriptLanguageExtension implements Editor.ClientExtensi
         if (this.active) {
             const action = this.editor.getAction("editor.action.format");
             if (action && action.isSupported()) {
+                let wasEmpty = false;
+                let cursorPosition;
+
                 if (this.editor.getSelection().isEmpty()) {
+                    wasEmpty = true;
+                    cursorPosition = this.editor.getPosition();
+
                     this.editor.setSelection(this.editor.getModel().getFullModelRange());
                 }
-                action.run();
+
+                action.run().then(() => {
+                    // Make sure we put the cursor back to where it was
+                    if (wasEmpty && cursorPosition) {
+                        this.editor.setPosition(cursorPosition);
+                    }
+                });
             }
         }
     }

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -33,7 +33,7 @@ import ClientExtensionEventNames from "../clientExtensions/ClientExtensionEventN
 export function configure(fileExt: string, filename: string) {
 
     // converter to handle new version of the renderWhitespace setting
-    const renderWhitespaceAdapter = (setting): 'none' | 'boundary' | 'all' => {
+    const renderWhitespaceAdapter = (setting): "none" | "boundary" | "all" => {
         switch (setting.toLowerCase()) {
             case "true": return "all";
             case "false": return "none";
@@ -153,4 +153,47 @@ export function preferencesChanged(prefs: Editor.ClientExtensions.PreferencesCha
 
 export function setEditor(editor: any) {
     internalEditor.setInternalEditor(editor);
+}
+
+/**
+ * Called when the editor should respond to a host shortcut command
+ */
+export function invokeShortcut(shortcut: Editor.EditorShortcutType) {
+
+    const ed = internalEditor.getInternalEditor();
+    // Execute in the next cycle
+    window.setTimeout(() => {
+
+        ed.focus();
+        switch (shortcut) {
+            case "cut":
+            case "copy":
+            case "undo":
+            case "redo":
+                window.document.execCommand(shortcut);
+                break;
+
+            case "selectall":
+                ed.setSelection(ed.getModel().getFullModelRange());
+                break;
+        }
+    }, 100);
+
+
+    /*
+case "undo":
+    cmd = ed["cursor"]["_handlers"]["undo"];
+    ed.executeCommand("Atomic", cmd);
+    break;
+    //ed.executeCommand("Atomic", ))
+    // ed.executeCommand("Atomic", "undo");
+case "redo":
+    cmd = ed["cursor"]["_handlers"]["redo"];
+    ed.executeCommand("Atomic", cmd);
+    break;
+    */
+    //const sel = ed.getSelection();
+    //if (!sel.isEmpty()) {
+    //const s = ed.getModel().getValueInRange(sel);
+    //}
 }

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -56,9 +56,10 @@ export function configure(fileExt: string, filename: string) {
         filename: filename,
         editor: monacoEditor
     });
-    
+
     // Override CMD/CTRL+I since that is going to be used for Format Code and in the editor it is assigned to something else
-    monacoEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_I, null, null);
+    const noOpCommand: monaco.editor.ICommandHandler = () => { };
+    monacoEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_I, noOpCommand, null);
 
 }
 

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -56,6 +56,10 @@ export function configure(fileExt: string, filename: string) {
         filename: filename,
         editor: monacoEditor
     });
+    
+    // Override CMD/CTRL+I since that is going to be used for Format Code and in the editor it is assigned to something else
+    monacoEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_I, null, null);
+
 }
 
 /**
@@ -156,12 +160,21 @@ export function setEditor(editor: any) {
 }
 
 /**
+ * Called when a resource is getting deleted
+ * @param  {string} path
+ */
+export function formatCode() {
+    serviceLocator.sendEvent(ClientExtensionEventNames.FormatCodeEvent, null);
+}
+
+/**
  * Called when the editor should respond to a host shortcut command
  */
 export function invokeShortcut(shortcut: Editor.EditorShortcutType) {
 
     const ed = internalEditor.getInternalEditor();
     ed.focus();
+
     switch (shortcut) {
         case "cut":
         case "copy":

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -161,39 +161,16 @@ export function setEditor(editor: any) {
 export function invokeShortcut(shortcut: Editor.EditorShortcutType) {
 
     const ed = internalEditor.getInternalEditor();
-    // Execute in the next cycle
-    window.setTimeout(() => {
+    ed.focus();
+    switch (shortcut) {
+        case "cut":
+        case "copy":
+        case "paste":
+            window.document.execCommand(shortcut);
+            break;
 
-        ed.focus();
-        switch (shortcut) {
-            case "cut":
-            case "copy":
-            case "undo":
-            case "redo":
-                window.document.execCommand(shortcut);
-                break;
-
-            case "selectall":
-                ed.setSelection(ed.getModel().getFullModelRange());
-                break;
-        }
-    }, 100);
-
-
-    /*
-case "undo":
-    cmd = ed["cursor"]["_handlers"]["undo"];
-    ed.executeCommand("Atomic", cmd);
-    break;
-    //ed.executeCommand("Atomic", ))
-    // ed.executeCommand("Atomic", "undo");
-case "redo":
-    cmd = ed["cursor"]["_handlers"]["redo"];
-    ed.executeCommand("Atomic", cmd);
-    break;
-    */
-    //const sel = ed.getSelection();
-    //if (!sel.isEmpty()) {
-    //const s = ed.getModel().getValueInRange(sel);
-    //}
+        case "selectall":
+            ed.setSelection(ed.getModel().getFullModelRange());
+            break;
+    }
 }

--- a/Script/AtomicWebViewEditor/interop.ts
+++ b/Script/AtomicWebViewEditor/interop.ts
@@ -234,4 +234,11 @@ export default class HostInteropType {
     invokeShortcut(shortcut: Editor.EditorShortcutType) {
        editorCommands.invokeShortcut(shortcut);
     }
+
+    /**
+     * Format the code inside the editor
+     */
+    formatCode() {
+        editorCommands.formatCode();
+    }
 }

--- a/Script/AtomicWebViewEditor/interop.ts
+++ b/Script/AtomicWebViewEditor/interop.ts
@@ -226,4 +226,12 @@ export default class HostInteropType {
     setEditor(editor: any) {
         editorCommands.setEditor(editor);
     }
+
+    /**
+     * Called when a shortcut should be invoked, coming from the host editor
+     * @param {Editor.EditorShortcutType} shortcut shortcut to be executed
+     */
+    invokeShortcut(shortcut: Editor.EditorShortcutType) {
+       editorCommands.invokeShortcut(shortcut);
+    }
 }

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -514,3 +514,10 @@ declare module Editor.ClientExtensions {
         addCustomHostRoutine(routineName: string, callback: (...any) => void);
     }
 }
+
+declare module Editor {
+    /**
+     * Valid editor shortcuts that can be called from menus
+     */
+    export type EditorShortcutType = "cut" | "copy" | "paste" | "undo" | "redo" | "close" | "frameselected" | "selectall";
+}

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -420,6 +420,7 @@ declare module Editor.ClientExtensions {
         delete?(ev: EditorEvents.DeleteResourceEvent);
         rename?(ev: EditorEvents.RenameResourceEvent);
         projectUnloaded?();
+        formatCode?();
         preferencesChanged?(preferences: PreferencesChangedEventData);
     }
 

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -188,6 +188,7 @@ bool JSResourceEditor::OnEvent(const TBWidgetEvent &ev)
             map["ForceSuperDown"] = true;
             #else
             map[KeyUp::P_QUALIFIERS] = QUAL_CTRL;
+			webClient_->SendFocusEvent();
             #endif
             webClient_->SendKeyEvent( StringHash("KeyDown"), map);
         } else if (ev.ref_id == TBIDC("redo")) {
@@ -202,6 +203,7 @@ bool JSResourceEditor::OnEvent(const TBWidgetEvent &ev)
             map["ForceSuperDown"] = true;
             #else
             map[KeyUp::P_QUALIFIERS] = QUAL_SHIFT | QUAL_CTRL;
+			webClient_->SendFocusEvent();
             #endif
             webClient_->SendKeyEvent( StringHash("KeyDown"), map);
         } else {

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -167,7 +167,7 @@ void JSResourceEditor::HandleWebMessage(StringHash eventType, VariantMap& eventD
 
 void JSResourceEditor::FormatCode()
 {
-    //webClient_->ExecuteJavaScript("beautifyCode();");
+    webClient_->ExecuteJavaScript("HOST_formatCode();");
 }
 
 bool JSResourceEditor::OnEvent(const TBWidgetEvent &ev)

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -177,6 +177,25 @@ bool JSResourceEditor::OnEvent(const TBWidgetEvent &ev)
         if (ev.ref_id == TBIDC("close"))
         {
             RequestClose();
+        } else if (ev.ref_id == TBIDC("paste")) {
+            // Paste needs to be handled here due to permissions in the web client that don't allow paste to be called from JavaScript.
+            // The others can be passed directly to the editor and be handled there
+            webClient_->SendFocusEvent(true);
+            webClient_->ShortcutPaste();
+        } else if (ev.ref_id == TBIDC("undo")) {
+            webClient_->SendFocusEvent(true);
+            webClient_->ShortcutUndo();
+        } else if (ev.ref_id == TBIDC("redo")) {
+            webClient_->SendFocusEvent(true);
+            webClient_->ShortcutRedo();
+        } else {
+            String shortcut;
+            UI* ui = GetSubsystem<UI>();
+            ui->GetTBIDString(ev.ref_id, shortcut);
+
+            webClient_->SendFocusEvent();
+            //webClient_->SendKeyEvent(Atomicjkb);
+            webClient_->ExecuteJavaScript(ToString("HOST_invokeShortcut(\"%s\");", shortcut.CString()));
         }
     }
 

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -188,7 +188,7 @@ bool JSResourceEditor::OnEvent(const TBWidgetEvent &ev)
             map["ForceSuperDown"] = true;
             #else
             map[KeyUp::P_QUALIFIERS] = QUAL_CTRL;
-			webClient_->SendFocusEvent();
+            webClient_->SendFocusEvent();
             #endif
             webClient_->SendKeyEvent( StringHash("KeyDown"), map);
         } else if (ev.ref_id == TBIDC("redo")) {
@@ -203,7 +203,7 @@ bool JSResourceEditor::OnEvent(const TBWidgetEvent &ev)
             map["ForceSuperDown"] = true;
             #else
             map[KeyUp::P_QUALIFIERS] = QUAL_SHIFT | QUAL_CTRL;
-			webClient_->SendFocusEvent();
+            webClient_->SendFocusEvent();
             #endif
             webClient_->SendKeyEvent( StringHash("KeyDown"), map);
         } else {

--- a/Source/AtomicWebView/WebClient.cpp
+++ b/Source/AtomicWebView/WebClient.cpp
@@ -353,6 +353,8 @@ public:
         browserSettings.file_access_from_file_urls = STATE_ENABLED;
         browserSettings.universal_access_from_file_urls = STATE_ENABLED;
         browserSettings.web_security = WebBrowserHost::GetWebSecurity() ? STATE_ENABLED : STATE_DISABLED;
+        browserSettings.javascript_access_clipboard = STATE_ENABLED;
+        browserSettings.javascript_dom_paste = STATE_ENABLED;
 
         windowInfo.width = width;
         windowInfo.height = height;        


### PR DESCRIPTION
This hooks up the editor menu shortcuts properly and fixes #697

Edit->Undo 
Edit->Redo
Edit->Cut
Edit->Copy
Edit->Paste
Edit->Select All
Edit->Format Code

Testing was done on OSX, but this needs to also be tested in Linux and Windows since the shortcut keys are different (CMD becomes CTRL in Windows and Linux).

This also fixes some linter errors in the TS.
