### PR TITLE
Stop crash from null objects at exit 248

### DIFF
--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -494,6 +494,10 @@ void Engine::RunFrame()
     time->BeginFrame(timeStep_);
 
 // ATOMIC BEGIN
+
+    if ( exiting_ ) // exit check for script event handlers
+        return;
+
     // If paused, or pause when minimized -mode is in use, stop updates and audio as necessary
     if ((paused_ && !runNextPausedFrame_) ||
         (pauseMinimized_ && input->IsMinimized()))
@@ -711,8 +715,6 @@ void Engine::DumpMemory()
 
 void Engine::Update()
 {
-    if (exiting_)
-        return;
     
     ATOMIC_PROFILE(Update);
 
@@ -735,8 +737,6 @@ void Engine::Update()
 
 void Engine::Render()
 {
-    if ( exiting_ )
-        return;
 
     if (headless_)
         return;

--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -715,7 +715,6 @@ void Engine::DumpMemory()
 
 void Engine::Update()
 {
-    
     ATOMIC_PROFILE(Update);
 
     // Logic update event
@@ -737,7 +736,6 @@ void Engine::Update()
 
 void Engine::Render()
 {
-
     if (headless_)
         return;
 

--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -711,6 +711,9 @@ void Engine::DumpMemory()
 
 void Engine::Update()
 {
+    if (exiting_)
+        return;
+    
     ATOMIC_PROFILE(Update);
 
     // Logic update event
@@ -732,6 +735,9 @@ void Engine::Update()
 
 void Engine::Render()
 {
+    if ( exiting_ )
+        return;
+
     if (headless_)
         return;
 

--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -495,8 +495,9 @@ void Engine::RunFrame()
 
 // ATOMIC BEGIN
 
-    if ( exiting_ ) // exit check for script event handlers
-        return;
+    // check for exit again that comes in thru an event handler
+    if ( exiting_ ) // needed to prevent scripts running the 
+        return;     // current frame update with null objects
 
     // If paused, or pause when minimized -mode is in use, stop updates and audio as necessary
     if ((paused_ && !runNextPausedFrame_) ||


### PR DESCRIPTION
This pr will stop crashes from accessing null objects in user event handlers by not issuing Update events once the application has started to exit. 