### PR TITLE
Changes to allow building for DirectX 11 and OpenGL on Windows.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -43,6 +43,8 @@
 
 - Isaac Burns (https://github.com/flyover)
 
+- Darryl Ryan (https://github.com/darrylryan)
+
 ### Contribution Copyright and Licensing
 
 Atomic Game Engine contribution copyrights are held by their authors.  Each author retains the copyright to their contribution and agrees to irrevocably license the contribution under the Atomic Game Engine Contribution License `CONTRIBUTION_LICENSE.md`.  Please see `CONTRIBUTING.md` for more details.

--- a/Build/CMake/Modules/AtomicWindows.cmake
+++ b/Build/CMake/Modules/AtomicWindows.cmake
@@ -18,10 +18,17 @@ add_definitions(-D_CRT_SECURE_NO_WARNINGS )
 
 add_link_libraries_exported(MojoShader user32 gdi32 winmm imm32 ole32 oleaut32 version uuid Ws2_32)
 
-if (ATOMIC_D3D11)
+if (ATOMIC_D3D11) #DirectX 11
     add_definitions_exported(-DATOMIC_D3D11)
     add_link_libraries_exported(d3d11 d3dcompiler dxguid)
-else()
+elseif(ATOMIC_OPENGL) #OpenGL
+	find_package(OpenGL REQUIRED)
+	include_directories(${OpenGL_INCLUDE_DIRS})
+	link_directories(${OpenGL_LIBRARY_DIRS})
+	add_definitions(${OpenGL_DEFINITIONS})
+	add_definitions (-DATOMIC_OPENGL -DGLEW_STATIC)
+	list (APPEND ATOMIC_LINK_LIBRARIES GLEW opengl32 glu32)
+else() #DirectX 9
     add_link_libraries_exported(d3d9 d3dcompiler)
 endif()
 

--- a/Build/Scripts/Bootstrap.js
+++ b/Build/Scripts/Bootstrap.js
@@ -27,6 +27,8 @@ function printHelp() {
     console.log("--with-android  : Build with Android platform support");
     console.log("--with-ios      : Build with iOS platform support");
     console.log("--with-web      : Build with Web platform support");
+	console.log("--opengl        : Use OpenGL instead of DirectX 9 (only affects Windows builds)");
+	console.log("--d3d11         : Use DirectX 11 instead of DirectX 9 (only affects Windows builds)");
     console.log("--debug         : Build debug version of the editor and associated platform runtimes");
     console.log("--noclean       : Do not clean before building, useful during development");
     console.log("--nonet         : Build without AtomicNET C# scripting support");
@@ -91,6 +93,37 @@ if (cmd == "buildeditor") {
             process.exit(1);
         }
     }
+	
+	if (config["d3d11"] && config["opengl"]) {
+
+        if (os.platform() == "win32") {
+            console.log("\nBoth DirectX 11 and OpenGL flags specified. Please choose only one at a time.\nExiting...\n");
+            process.exit(1);
+        }
+    }
+	
+	if (config["d3d11"]) {
+
+        if (os.platform() != "win32") {
+            console.log("\nDirectX 11 build requires Windows, exiting\n");
+            process.exit(1);
+        }
+		else {
+			console.log("\nDirectX 11 build selected.\n");
+		}
+    }
+	
+	
+	if (config["opengl"]) {
+
+        if (os.platform() != "win32") {
+            console.log("\nOpenGL flag ignored, OpenGL is default on non-Windows platforms anyway.\nContinuing...\n");
+        }
+		else {
+			console.log("\nOpenGL build selected.\n");
+		}
+    }
+
 
     buildTask.invoke();
 

--- a/Build/Scripts/Bootstrap.js
+++ b/Build/Scripts/Bootstrap.js
@@ -27,8 +27,10 @@ function printHelp() {
     console.log("--with-android  : Build with Android platform support");
     console.log("--with-ios      : Build with iOS platform support");
     console.log("--with-web      : Build with Web platform support");
-	console.log("--opengl        : Use OpenGL instead of DirectX 9 (only affects Windows builds)");
-	console.log("--d3d11         : Use DirectX 11 instead of DirectX 9 (only affects Windows builds)");
+if (os.platform() == "win32") {
+    console.log("--opengl        : Enable OpenGL renderer");
+    console.log("--d3d11         : Enable DirectX 11 renderer");
+}
     console.log("--debug         : Build debug version of the editor and associated platform runtimes");
     console.log("--noclean       : Do not clean before building, useful during development");
     console.log("--nonet         : Build without AtomicNET C# scripting support");
@@ -93,35 +95,35 @@ if (cmd == "buildeditor") {
             process.exit(1);
         }
     }
-	
-	if (config["d3d11"] && config["opengl"]) {
+
+    if (config["d3d11"] && config["opengl"]) {
 
         if (os.platform() == "win32") {
             console.log("\nBoth DirectX 11 and OpenGL flags specified. Please choose only one at a time.\nExiting...\n");
             process.exit(1);
         }
     }
-	
-	if (config["d3d11"]) {
+
+    if (config["d3d11"]) {
 
         if (os.platform() != "win32") {
             console.log("\nDirectX 11 build requires Windows, exiting\n");
             process.exit(1);
         }
-		else {
-			console.log("\nDirectX 11 build selected.\n");
-		}
+        else {
+            console.log("\nDirectX 11 build selected.\n");
+        }
     }
-	
-	
-	if (config["opengl"]) {
+
+
+    if (config["opengl"]) {
 
         if (os.platform() != "win32") {
             console.log("\nOpenGL flag ignored, OpenGL is default on non-Windows platforms anyway.\nContinuing...\n");
         }
-		else {
-			console.log("\nOpenGL build selected.\n");
-		}
+        else {
+            console.log("\nOpenGL build selected.\n");
+        }
     }
 
 

--- a/Build/Scripts/BuildWindows.js
+++ b/Build/Scripts/BuildWindows.js
@@ -135,14 +135,9 @@ namespace('build', function() {
     }, function(devBuild) {
         if (devBuild === undefined)
         devBuild = 1;
-	
-	    var d3d11 = "OFF";
-		var opengl = "OFF";
-		
-	    if (config["opengl"])
-			opengl = "ON";
-		else if (config["d3d11"])
-			d3d11 = "ON";
+
+        var opengl = config["opengl"] ? "ON" : "OFF"; 
+        var d3d11 = config["d3d11"] ? "ON" : "OFF"; 
 
         var slnRoot = path.resolve(atomicRoot, "") + "-VS2015\\";
 

--- a/Build/Scripts/BuildWindows.js
+++ b/Build/Scripts/BuildWindows.js
@@ -135,6 +135,14 @@ namespace('build', function() {
     }, function(devBuild) {
         if (devBuild === undefined)
         devBuild = 1;
+	
+	    var d3d11 = "OFF";
+		var opengl = "OFF";
+		
+	    if (config["opengl"])
+			opengl = "ON";
+		else if (config["d3d11"])
+			d3d11 = "ON";
 
         var slnRoot = path.resolve(atomicRoot, "") + "-VS2015\\";
 
@@ -146,7 +154,7 @@ namespace('build', function() {
 
         var cmds = [];
 
-        cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot + " " + devBuild);
+        cmds.push(atomicRoot + "Build/Scripts/Windows/GenerateVS2015.bat " + atomicRoot + " " + devBuild + " " + opengl + " " + d3d11);
 
         jake.exec(cmds, function() {
 

--- a/Build/Scripts/Windows/GenerateVS2015.bat
+++ b/Build/Scripts/Windows/GenerateVS2015.bat
@@ -1,3 +1,3 @@
 call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
-cmake %1 -DATOMIC_DEV_BUILD=%2 -G "Visual Studio 14 2015 Win64"
+cmake %1 -DATOMIC_DEV_BUILD=%2 -DATOMIC_OPENGL=%3 -DATOMIC_D3D11=%4 -G "Visual Studio 14 2015 Win64"
 

--- a/CMake_VS2015.bat
+++ b/CMake_VS2015.bat
@@ -1,9 +1,35 @@
 @ECHO OFF
 @echo:
 @echo:
+SET ARG=%1
+@echo:
+@echo:
 ECHO Generating Visual Studio Solution (64 bit)
 @echo:
-@echo:
+SET BUILDMODE="d3d9"
+IF DEFINED ARG (
+    IF "%ARG%"=="--opengl" (
+    	SET BUILDMODE="opengl"
+		ECHO OpenGL configuration selected.
+	)
+	IF "%ARG%"=="/opengl" (
+    	SET BUILDMODE="opengl"
+		ECHO OpenGL configuration selected.
+	)
+    IF "%ARG%"=="--d3d11" (
+    	SET BUILDMODE="d3d11"
+		ECHO Direct3D 11 configuration selected.
+	)
+    IF "%ARG%"=="/d3d11" (
+    	SET BUILDMODE="d3d11"
+		ECHO Direct3D 11 configuration selected.
+	)
+)
+IF %BUILDMODE%=="d3d9" (
+  ECHO Direct3D 9 configuration selected by default (Use /opengl or /d3d11 switches to specify OpenGL or DirectX 11)
+
+)
+@echo: 
 call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
 :: remove any generated sources
 if exist "%~p0Artifacts\Build\Source\Generated\" rd /q /s "%~p0Artifacts\Build\Source\Generated\"
@@ -13,7 +39,19 @@ set "cdir=%~dp0"
 set "cdir=%cdir:~0,-1%"
 for %%i IN ("%cdir%") do set "foldername=%%~nxi"
 :: run cmake
-cmake -E make_directory "..\%foldername%-VS2015" && cmake -E chdir "..\%foldername%-VS2015" cmake %~dp0 -G "Visual Studio 14 2015 Win64"
-@echo:
-ECHO Solution created in ..\%foldername%-VS2015
+IF %BUILDMODE%=="d3d9" (
+ cmake -E make_directory "..\%foldername%-VS2015" && cmake -E chdir "..\%foldername%-VS2015" cmake %~dp0 -G "Visual Studio 14 2015 Win64"
+ @echo:
+ ECHO Solution created in ..\%foldername%-VS2015
+)
+IF %BUILDMODE%=="d3d11" (
+ cmake -E make_directory "..\%foldername%-VS2015-d3d11" && cmake -E chdir "..\%foldername%-VS2015-d3d11" cmake %~dp0 -G "Visual Studio 14 2015 Win64" -DATOMIC_D3D11=ON
+ @echo:
+ ECHO Solution created in ..\%foldername%-VS2015-d3d11
+)
+IF %BUILDMODE%=="opengl" (
+ cmake -E make_directory "..\%foldername%-VS2015-opengl" && cmake -E chdir "..\%foldername%-VS2015-opengl" cmake %~dp0 -G "Visual Studio 14 2015 Win64" -DATOMIC_OPENGL=ON
+ @echo:
+ ECHO Solution created in ..\%foldername%-VS2015-opengl
+)
 @echo:

--- a/CMake_VS2015.bat
+++ b/CMake_VS2015.bat
@@ -27,7 +27,6 @@ IF DEFINED ARG (
 )
 IF %BUILDMODE%=="d3d9" (
   ECHO Direct3D 9 configuration selected by default (Use /opengl or /d3d11 switches to specify OpenGL or DirectX 11)
-
 )
 @echo: 
 call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat"
@@ -38,20 +37,17 @@ set "cdir=%~dp0"
 :: for loop requires removing trailing backslash from %~dp0 output
 set "cdir=%cdir:~0,-1%"
 for %%i IN ("%cdir%") do set "foldername=%%~nxi"
-:: run cmake
-IF %BUILDMODE%=="d3d9" (
- cmake -E make_directory "..\%foldername%-VS2015" && cmake -E chdir "..\%foldername%-VS2015" cmake %~dp0 -G "Visual Studio 14 2015 Win64"
- @echo:
- ECHO Solution created in ..\%foldername%-VS2015
-)
-IF %BUILDMODE%=="d3d11" (
- cmake -E make_directory "..\%foldername%-VS2015-d3d11" && cmake -E chdir "..\%foldername%-VS2015-d3d11" cmake %~dp0 -G "Visual Studio 14 2015 Win64" -DATOMIC_D3D11=ON
- @echo:
- ECHO Solution created in ..\%foldername%-VS2015-d3d11
-)
+SET "DIRECTORY=..\%foldername%-VS2015" 
+IF %BUILDMODE%=="d3d11" ( 
+   SET "DIRECTORY=%DIRECTORY%_D3D11"
+   SET "RENDERERFLAG=-DATOMIC_D3D11=ON"
+) 
 IF %BUILDMODE%=="opengl" (
- cmake -E make_directory "..\%foldername%-VS2015-opengl" && cmake -E chdir "..\%foldername%-VS2015-opengl" cmake %~dp0 -G "Visual Studio 14 2015 Win64" -DATOMIC_OPENGL=ON
- @echo:
- ECHO Solution created in ..\%foldername%-VS2015-opengl
+	SET "DIRECTORY=%DIRECTORY%_OPENGL"
+	SET "RENDERERFLAG=-DATOMIC_OPENGL=ON"
 )
+:: run cmake
+cmake -E make_directory %DIRECTORY% && cmake -E chdir %DIRECTORY% cmake %~dp0 -G "Visual Studio 14 2015 Win64" %RENDERERFLAG%
+@echo:
+ECHO Solution created in %DIRECTORY%
 @echo:

--- a/Source/Atomic/CMakeLists.txt
+++ b/Source/Atomic/CMakeLists.txt
@@ -32,9 +32,11 @@ endif()
 file (GLOB GRAPHICS_SOURCE Graphics/*.cpp Graphics/*.h)
 
 if (MSVC)
-    if (ATOMIC_D3D11)
+    if (ATOMIC_D3D11) #DirectX 11
       file (GLOB GRAPHICS_IMPL_SOURCE Graphics/Direct3D11/*.cpp Graphics/Direct3D11/*.h)
-    else()
+    elseif (ATOMIC_OPENGL) #OpenGL
+	  file (GLOB GRAPHICS_IMPL_SOURCE Graphics/OpenGL/*.cpp Graphics/OpenGL/*.h)
+	else() #DirectX 9
       file (GLOB GRAPHICS_IMPL_SOURCE Graphics/Direct3D9/*.cpp Graphics/Direct3D9/*.h)
     endif()
 else()

--- a/Source/AtomicWebView/WebTexture2D.cpp
+++ b/Source/AtomicWebView/WebTexture2D.cpp
@@ -210,6 +210,7 @@ public:
     void D3D9Blit(const IntRect& dstRect, unsigned char* src, unsigned srcStride, bool discard = false)
     {
 #ifndef ATOMIC_D3D11
+#ifndef ATOMIC_OPENGL
 
         RECT d3dRect;
 
@@ -242,12 +243,14 @@ public:
 
         object->UnlockRect(level);
 #endif
+#endif
     }
 
     void OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList &dirtyRects,
                  const void *buffer, int width, int height) OVERRIDE
     {
 #ifndef ATOMIC_D3D11
+#ifndef ATOMIC_OPENGL
 
         if (type == PET_VIEW)
         {
@@ -302,6 +305,7 @@ public:
 
         }
 
+#endif
 #endif
 
     }

--- a/Source/ThirdParty/CMakeLists.txt
+++ b/Source/ThirdParty/CMakeLists.txt
@@ -50,7 +50,7 @@ if (NOT IOS AND NOT ANDROID AND NOT EMSCRIPTEN)
     add_subdirectory(libsquish)
 endif ()
 
-if (LINUX OR APPLE AND NOT IOS)
+if (LINUX OR APPLE OR ATOMIC_OPENGL AND NOT IOS)
     add_subdirectory(GLEW)
 endif()
 


### PR DESCRIPTION
The "--d3d11" or "--opengl" flags can now be specified on the command line to both Build_AtomicEditor.bat and GenerateVS2015.bat to switch graphics libraries.

DirectX 9 remains the default if no flags are specified.

resolves #1155