### PR TITLE
Add an AtomicTool Project command

### DIFF
--- a/Source/ToolCore/Command/CommandParser.cpp
+++ b/Source/ToolCore/Command/CommandParser.cpp
@@ -29,6 +29,7 @@
 #include "EditCmd.h"
 #include "BindCmd.h"
 #include "NETCmd.h"
+#include "ProjectCmd.h"
 
 namespace ToolCore
 {
@@ -80,6 +81,10 @@ Command* CommandParser::Parse(const Vector<String>& arguments)
             else if (argument == "net")
             {
                 cmd = new NETCmd(context_);
+            }
+            else if (argument == "project")
+            {
+                cmd = new ProjectCmd(context_);
             }
 
         }

--- a/Source/ToolCore/Command/ProjectCmd.cpp
+++ b/Source/ToolCore/Command/ProjectCmd.cpp
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2014-2016 THUNDERBEAST GAMES LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include <Atomic/Core/StringUtils.h>
+#include <Atomic/IO/Log.h>
+#include <Atomic/IO/File.h>
+#include <Atomic/IO/FileSystem.h>
+
+#include "../ToolSystem.h"
+#include "../Project/ProjectFile.h"
+#include "../Project/ProjectEvents.h"
+
+#include "ProjectCmd.h"
+
+#include <Poco/File.h>
+
+#define  PROJECTCMD_CACHE_CLEAN 0x1 // Cache command first cleans current cache
+
+namespace ToolCore
+{
+
+ProjectCmd::ProjectCmd(Context* context) : 
+    Command(context),
+    requiresProjectLoad_(false),
+    options_(0)
+{
+
+}
+
+ProjectCmd::~ProjectCmd()
+{
+
+}
+
+// usage: project <projectPath> [cache (-clean)]
+bool ProjectCmd::Parse(const Vector<String>& arguments, unsigned startIndex, String& errorMsg)
+{
+    String argument = arguments[startIndex].ToLower();
+    if (argument != "project")
+    {
+        errorMsg = "Unable to parse project command";
+        return false;
+    }
+
+    command_ = startIndex + 2 < arguments.Size() ? arguments[startIndex + 2] : String::EMPTY;
+    if (command_ == "cache")
+    {
+        requiresProjectLoad_ = true;
+        SubscribeToEvent(E_PROJECTLOADED, ATOMIC_HANDLER(ProjectCmd, HandleProjectLoaded));
+
+        for (unsigned i = startIndex + 3; i < arguments.Size(); i++)
+        {
+            if (arguments[i].Length() > 1 && arguments[i][0] == '-')
+            {
+                String argument = arguments[i].Substring(1).ToLower();
+                String value = i + 1 < arguments.Size() ? arguments[i + 1] : String::EMPTY;
+
+                if (argument == "clean")
+                {
+                    options_ = options_ | PROJECTCMD_CACHE_CLEAN;
+                    SubscribeToEvent(E_PROJECTBEGINLOAD, ATOMIC_HANDLER(ProjectCmd, HandleProjectBeginLoad));
+                    i++;
+                }
+            }
+        }
+    }
+    else
+    {
+        errorMsg = "Unknown project command";
+        return false;
+    }
+
+    projectPath_ = startIndex + 1 < arguments.Size() ? arguments[startIndex + 1] : String::EMPTY;
+
+    return true;
+}
+
+void ProjectCmd::HandleProjectBeginLoad(StringHash eventType, VariantMap& eventData)
+{
+    if (options_ & PROJECTCMD_CACHE_CLEAN)
+    {
+        String cachePath = GetPath(eventData[ProjectBeginLoad::P_PROJECTPATH].GetString());
+        cachePath = AddTrailingSlash(cachePath) + "Cache";
+
+        FileSystem* fileSystem = GetSubsystem<FileSystem>();
+        if (!fileSystem->RemoveDir(cachePath, true))
+            Error("Cache clean failed");
+    }
+}
+
+void ProjectCmd::HandleProjectLoaded(StringHash eventType, VariantMap& eventData)
+{
+    bool result = eventData[ProjectLoaded::P_RESULT].GetBool();
+
+    if (!eventData[ProjectLoaded::P_RESULT].GetBool())
+        Error("Project load failed");
+    else
+        Finished();
+}
+
+void ProjectCmd::Run()
+{
+    if (command_ == "cache")
+    {
+        // Nothing to do here
+    }
+    else
+    {
+        Finished();
+    }
+
+}
+
+}

--- a/Source/ToolCore/Command/ProjectCmd.h
+++ b/Source/ToolCore/Command/ProjectCmd.h
@@ -22,34 +22,40 @@
 
 #pragma once
 
-#include <Atomic/Core/Object.h>
+#include "Command.h"
 
 using namespace Atomic;
 
 namespace ToolCore
 {
 
-ATOMIC_EVENT(E_PROJECTBEGINLOAD, ProjectBeginLoad)
+class ProjectCmd: public Command
 {
-    ATOMIC_PARAM(P_PROJECTPATH, ProjectPath);   // string
-    ATOMIC_PARAM(P_PROJECT, Project);           // Project *
-}
+    ATOMIC_OBJECT(ProjectCmd, Command);
 
-ATOMIC_EVENT(E_PROJECTLOADED, ProjectLoaded)
-{
-    ATOMIC_PARAM(P_PROJECTPATH, ProjectPath);   // string
-    ATOMIC_PARAM(P_PROJECT, Project);           // Project *
-    ATOMIC_PARAM(P_RESULT, Result);             // bool
-}
+public:
 
-ATOMIC_EVENT(E_PROJECTUNLOADED, ProjectUnloaded)
-{
-}
+    ProjectCmd(Context* context);
+    virtual ~ProjectCmd();
 
-ATOMIC_EVENT(E_PROJECTUSERPREFSAVED, ProjectUserPrefSaved)
-{
-    ATOMIC_PARAM(P_PREFS, Prefs);    // ProjectUserPrefs
-}
+    bool Parse(const Vector<String>& arguments, unsigned startIndex, String& errorMsg);
 
+    void Run();
+
+    bool RequiresProjectLoad() { return requiresProjectLoad_; }
+
+    const String& GetProjectPath() const { return projectPath_; }
+
+private:
+
+    void HandleProjectBeginLoad(StringHash eventType, VariantMap& eventData);
+    void HandleProjectLoaded(StringHash eventType, VariantMap& eventData);
+
+    String projectPath_;
+    String command_;
+    bool requiresProjectLoad_;
+    int options_;
+
+};
 
 }

--- a/Source/ToolCore/Project/Project.cpp
+++ b/Source/ToolCore/Project/Project.cpp
@@ -172,6 +172,10 @@ bool Project::Load(const String& fullpath)
 
     }
 
+    VariantMap data;
+    data[ProjectBeginLoad::P_PROJECTPATH] = projectFilePath_;
+    data[ProjectBeginLoad::P_PROJECT] = this;
+    SendEvent(E_PROJECTBEGINLOAD, data);
 
     SharedPtr<ProjectFile> pfile(new ProjectFile(context_));
     bool result = pfile->Load(this);
@@ -186,6 +190,7 @@ bool Project::Load(const String& fullpath)
         VariantMap data;
         data[ProjectLoaded::P_PROJECTPATH] = projectFilePath_;
         data[ProjectLoaded::P_PROJECT] = this;
+        data[ProjectLoaded::P_RESULT] = result;
         SendEvent(E_PROJECTLOADED, data);
     }
 


### PR DESCRIPTION
Currently includes a cache task, with an option to clean the cache first

usage: AtomicTool project "path\to\project" [cache (-clean)]

Addresses #1199 