### PR TITLE
Project template language and messaging #1190, #1118

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -341,6 +341,7 @@ interface EditorBuildData {
 
 interface EditorFeatures {
     closePlayerLog: boolean;
+    defaultLanguage: string;
 }
 
 class PreferencesFormat {
@@ -396,7 +397,8 @@ class PreferencesFormat {
         };
 
         this.editorFeatures = {
-            closePlayerLog: true
+            closePlayerLog: true,
+            defaultLanguage: "JavaScript"
         };
 
     }

--- a/Script/AtomicEditor/ui/modal/CreateProject.ts
+++ b/Script/AtomicEditor/ui/modal/CreateProject.ts
@@ -23,6 +23,7 @@
 import EditorEvents = require("../../editor/EditorEvents");
 import EditorUI = require("../EditorUI");
 import ModalWindow = require("./ModalWindow");
+import Preferences = require("../../editor/Preferences");
 
 import ProjectTemplates = require("../../resources/ProjectTemplates");
 
@@ -34,6 +35,7 @@ class CreateProject extends ModalWindow {
 
         this.projectPath = projectPath;
         this.projectTemplate = projectTemplate;
+        this.defaultLang = Preferences.getInstance().editorFeatures.defaultLanguage;
 
         this.init("Create Project", "AtomicEditor/editor/ui/createproject.tb.txt");
 
@@ -327,7 +329,12 @@ class CreateProject extends ModalWindow {
             }
             else if (id == "create") {
 
-                this.tryProjectCreate();
+                if ( this.tryProjectCreate() )
+                {
+                    Preferences.getInstance().editorFeatures.defaultLanguage = this.projectLanguageField.text;
+                    Preferences.getInstance().write();
+                    this.hide();
+                }
 
                 return true;
 
@@ -366,6 +373,26 @@ class CreateProject extends ModalWindow {
 
         this.projectLanguageField.source = this.projectLanguageFieldSource;
         this.projectLanguageField.value = 0;
+        let defrank = -1;
+        let jsrank = -1;
+        let csrank = -1;
+        let tsrank = -1;
+        let ii = 0;
+        for ( ii = 0; ii<this.projectLanguageFieldSource.getItemCount(); ii++ ) // get rankings
+        {
+            if ( this.projectLanguageFieldSource.getItemStr( ii ) == "JavaScript" ) jsrank = ii;
+            if ( this.projectLanguageFieldSource.getItemStr( ii ) == "CSharp" ) csrank = ii;
+            if ( this.projectLanguageFieldSource.getItemStr( ii ) == "TypeScript" ) tsrank = ii;
+        }
+
+        if ( this.defaultLang == "JavaScript" ) defrank = jsrank; // which is the default language
+        if ( this.defaultLang == "CSharp" ) defrank = csrank;
+        if ( this.defaultLang == "TypeScript" ) defrank = tsrank;
+
+        if ( defrank > -1 ) this.projectLanguageField.value = defrank;  // the default language is present
+        else if ( jsrank > -1 ) this.projectLanguageField.value = jsrank;  // js is present
+        else if ( csrank > -1 ) this.projectLanguageField.value = csrank;  // cs is present
+        else if ( tsrank > -1 ) this.projectLanguageField.value = tsrank;  // ts is present
     }
 
     projectPathField: Atomic.UIEditField;
@@ -383,6 +410,7 @@ class CreateProject extends ModalWindow {
     // if we have specified a projectPath, the dest will not be the combination of path + name
     projectPath: string;
     projectTemplate: ProjectTemplates.ProjectTemplateDefinition;
+    defaultLang: string;
 }
 
 

--- a/Script/AtomicEditor/ui/modal/CreateProject.ts
+++ b/Script/AtomicEditor/ui/modal/CreateProject.ts
@@ -331,8 +331,11 @@ class CreateProject extends ModalWindow {
 
                 if ( this.tryProjectCreate() )
                 {
-                    Preferences.getInstance().editorFeatures.defaultLanguage = this.projectLanguageField.text;
-                    Preferences.getInstance().write();
+                    if ( Preferences.getInstance().editorFeatures.defaultLanguage != this.projectLanguageField.text )
+                    {
+                        Preferences.getInstance().editorFeatures.defaultLanguage = this.projectLanguageField.text;
+                        Preferences.getInstance().write();
+                    }
                     this.hide();
                 }
 

--- a/Script/AtomicEditor/ui/modal/info/AtomicNETWindow.ts
+++ b/Script/AtomicEditor/ui/modal/info/AtomicNETWindow.ts
@@ -64,9 +64,14 @@ class AtomicNETWindow extends ModalWindow {
 
                 this.hide();
 
-                Atomic.fileSystem.systemOpen(Atomic.platform == "Windows" ?
-                "https://www.visualstudio.com/vs/community/" :
-                "https://www.xamarin.com/download/");
+                if ( Atomic.platform == "Windows") 
+                    Atomic.fileSystem.systemOpen( "https://www.visualstudio.com/vs/community/" );
+
+                if ( Atomic.platform == "MacOSX") 
+                    Atomic.fileSystem.systemOpen( "https://www.xamarin.com/download/");
+
+                if ( Atomic.platform == "Linux") 
+                    Atomic.fileSystem.systemOpen( "https://github.com/AtomicGameEngine/AtomicGameEngine/wiki/Detailed-instructions-for-building-on-Linux");
 
             }
         }
@@ -74,17 +79,23 @@ class AtomicNETWindow extends ModalWindow {
 
 
     generateAtomicNETText(): string {
+        // start at Atomic.platform == "Windows"
+        let ideText:string = "Visual Studio";
+        if ( Atomic.platform == "MacOSX") ideText = "Xamarin Studio";
+        if ( Atomic.platform == "Linux") ideText = "monodevelop";
 
-        let ideText:string = Atomic.platform == "Windows" ? "Visual Studio" : "Xamarin Studio";
 
         let installText = `Please install ${ideText} with <color #D4FB79>Xamarin.Android</color> and <color #D4FB79>Xamarin.iOS</color>`;
 
-        this.downloadButton.text = `Download ${ideText}`;
+        if ( Atomic.platform != "Linux" )
+            this.downloadButton.text = `Download ${ideText}`;
+        else
+            this.downloadButton.text = `Install ${ideText}`;
 
         let text = "";
 
         text += `
-Atomic C# is integrated with <color #D4FB79>Visual Studio</color> and <color #D4FB79>Xamarin Studio</color> to provide a first class editing, debugging, and deployment experience.
+Atomic C# is integrated with <color #D4FB79>Visual Studio</color> and <color #D4FB79>Xamarin Studio</color> and <color #D4FB79>monodevelop</color> to provide a first class editing, debugging, and deployment experience.
 
 ${installText}
 

--- a/Source/Atomic/UI/UISelectItem.cpp
+++ b/Source/Atomic/UI/UISelectItem.cpp
@@ -107,6 +107,17 @@ void UISelectItemSource::RemoveItemWithStr(const String& str)
     }
 }
 
+const String& UISelectItemSource::GetItemStr(int index)
+{
+	int nn = 0;
+    for (List<SharedPtr<UISelectItem> >::Iterator itr = items_.Begin(); itr != items_.End(); itr++)
+    {
+        if ( nn == index) return (*itr)->GetStr();
+		nn++;
+    }
+	return ( String::EMPTY );
+}
+
 TBSelectItemSource *UISelectItemSource::GetTBItemSource()
 {
     // caller's responsibility to clean up

--- a/Source/Atomic/UI/UISelectItem.cpp
+++ b/Source/Atomic/UI/UISelectItem.cpp
@@ -109,13 +109,13 @@ void UISelectItemSource::RemoveItemWithStr(const String& str)
 
 const String& UISelectItemSource::GetItemStr(int index)
 {
-	int nn = 0;
+    int nn = 0;
     for (List<SharedPtr<UISelectItem> >::Iterator itr = items_.Begin(); itr != items_.End(); itr++)
     {
         if ( nn == index) return (*itr)->GetStr();
-		nn++;
+        nn++;
     }
-	return ( String::EMPTY );
+    return ( String::EMPTY );
 }
 
 TBSelectItemSource *UISelectItemSource::GetTBItemSource()

--- a/Source/Atomic/UI/UISelectItem.h
+++ b/Source/Atomic/UI/UISelectItem.h
@@ -80,6 +80,8 @@ public:
 
     void Clear() { items_.Clear(); }
 
+    const String& GetItemStr(int index);
+
     // caller's responsibility to clean up
     virtual tb::TBSelectItemSource* GetTBItemSource();
 

--- a/Source/Atomic/UI/UISelectItem.h
+++ b/Source/Atomic/UI/UISelectItem.h
@@ -80,6 +80,7 @@ public:
 
     void Clear() { items_.Clear(); }
 
+    /// Returns item string for the index. Returns empty string for invalid indexes.
     const String& GetItemStr(int index);
 
     // caller's responsibility to clean up


### PR DESCRIPTION
Made JavaScript the default language used for new projects and examples ( if they support it )
Examples will use the user selected default language, and otherwise the language precedence is JS, CS, TS.
Upon successfully installing a new project or example, the language used will become the default language.
The default language is saved in a preference.
When CSharp is not installed on a platform, the dialog box that comes up will now include instructions for Linux+monodevelop.
The Linux install operation will be directed to the Wiki page for building linux, which includes the install instructions for monodevelop.
Added API to get item strings out of a UISelectItemSource
Did not fix the closing of the New Project Dialog if it brings up the CSharp Download dialog, because both are modal, and you can not have 2 modal dialogs up at a time.
