### PR TITLE
Fixing crash with animation preview

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/InspectorWidget.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorWidget.ts
@@ -165,6 +165,9 @@ class InspectorWidget extends ScriptWidget {
 
         button.onClick = function () {
             this.onPreviewAnimation(asset);
+            // button is deleted in callback, so make sure we return
+            // that we're handled
+            return true;
         }.bind(this);
 
         return button;


### PR DESCRIPTION
- Return handled when animation button is clicked as the button is deleted in the callback
- Updating widget remove child guard to ensure proper parent
- Guarding captured widget for multitouch

Closes #1216 