### PR TITLE
[WINDOWS] Fix for blurred text in editor under OpenGL on Windows.

### DIFF
--- a/Source/ThirdParty/TurboBadger/renderers/tb_renderer_batcher.cpp
+++ b/Source/ThirdParty/TurboBadger/renderers/tb_renderer_batcher.cpp
@@ -238,7 +238,7 @@ void TBRendererBatcher::AddQuadInternal(const TBRect &dst_rect, const TBRect &sr
 
 #ifdef _MSC_VER
     //Direct3D9 Adjustment
-#ifdef ATOMIC_D3D11
+#if defined(ATOMIC_D3D11) || defined(ATOMIC_OPENGL)
     float posAdjust = 0.0f;
 #else
     float posAdjust = 0.5f;


### PR DESCRIPTION
This was due to scaling logic in TurboBadger/renderers/tb_renderer_batcher.cpp not accounting for the OpenGL case.