### PR TITLE
Add a flag to set whether non-skinned bones should be included

### DIFF
--- a/Source/ToolCore/Assets/ModelImporter.cpp
+++ b/Source/ToolCore/Assets/ModelImporter.cpp
@@ -63,6 +63,7 @@ void ModelImporter::SetDefaults()
     scale_ = 1.0;
     importAnimations_ = false;
     importMaterials_ = importer->GetImportMaterialsDefault();
+    includeNonSkinningBones_ = importer->GetIncludeNonSkinningBones();
     animationInfo_.Clear();
 
 }
@@ -80,6 +81,7 @@ bool ModelImporter::ImportModel()
     importer->SetExportAnimations(false);
     importer->SetImportNode(importNode_);
     importer->SetImportMaterials(importMaterials_);
+    importer->SetIncludeNonSkinningBones(includeNonSkinningBones_);
 
     if (importer->Load(asset_->GetPath()))
     {

--- a/Source/ToolCore/Assets/ModelImporter.h
+++ b/Source/ToolCore/Assets/ModelImporter.h
@@ -112,6 +112,7 @@ protected:
     double scale_;
     bool importAnimations_;
     bool importMaterials_;
+    bool includeNonSkinningBones_;
     Vector<SharedPtr<AnimationImportInfo>> animationInfo_;
 
     SharedPtr<Node> importNode_;

--- a/Source/ToolCore/Import/ImportConfig.cpp
+++ b/Source/ToolCore/Import/ImportConfig.cpp
@@ -68,6 +68,8 @@ bool ImportConfig::LoadModelImporterConfig(const JSONValue& jModelImporterConfig
             valueMap_["aiProcess_OptimizeMeshes"] = GetBoolValue(jvalue, true);
         else if (key == "importMaterials")
             valueMap_["ImportMaterials"] = GetBoolValue(jvalue, true);
+        else if (key == "includeNonSkinningBones")
+            valueMap_["IncludeNonSkinningBones"] = GetBoolValue(jvalue, true);
     }
 
     return true;

--- a/Source/ToolCore/Import/OpenAssetImporter.cpp
+++ b/Source/ToolCore/Import/OpenAssetImporter.cpp
@@ -66,6 +66,7 @@ OpenAssetImporter::OpenAssetImporter(Context* context) : Object(context) ,
     noEmptyNodes_(false),
     saveMaterialList_(false),
     includeNonSkinningBones_(false),
+    includeNonSkinningBonesDefault_(false),
     verboseLog_(false),
     emissiveAO_(false),
     noOverwriteMaterial_(true),
@@ -906,6 +907,8 @@ void OpenAssetImporter::SetOveriddenFlags(VariantMap& aiFlagParameters)
             ApplyFlag(aiProcess_OptimizeMeshes, itr->second_.GetBool());
         else if (itr->first_ == "ImportMaterials")
             importMaterialsDefault_ = itr->second_.GetBool();
+        else if (itr->first_ == "IncludeNonSkinningBones")
+            includeNonSkinningBonesDefault_ = itr->second_.GetBool();
 
         itr++;
     }

--- a/Source/ToolCore/Import/OpenAssetImporter.h
+++ b/Source/ToolCore/Import/OpenAssetImporter.h
@@ -61,9 +61,12 @@ public:
     void SetScale(float scale) { scale_ = scale; }
     void SetExportAnimations(bool exportAnimations) { noAnimations_ = !exportAnimations; }
     void SetImportMaterials(bool importMaterials) { importMaterials_ = importMaterials; }
+    void SetIncludeNonSkinningBones(bool includeNonSkinningBones) { includeNonSkinningBones_ = includeNonSkinningBones; }
     void SetVerboseLog(bool verboseLog) { verboseLog_ = verboseLog; }
 
     bool GetImportMaterialsDefault() { return importMaterialsDefault_; }
+
+    bool GetIncludeNonSkinningBones() { return includeNonSkinningBonesDefault_; }
 
     const Vector<AnimationInfo>& GetAnimationInfos() { return animationInfos_; }
 
@@ -121,6 +124,7 @@ private:
     bool noEmptyNodes_;
     bool saveMaterialList_;
     bool includeNonSkinningBones_;
+    bool includeNonSkinningBonesDefault_;
     bool verboseLog_;
     bool emissiveAO_;
     bool noOverwriteMaterial_;


### PR DESCRIPTION
In some cases it's necessary to import non-skinned bones on a skinned model. OpenAssetImporter ignores them by default,