### PR TITLE
Potential array out of bounds access #993

### DIFF
--- a/Source/Atomic/Atomic2D/ParticleEffect2D.cpp
+++ b/Source/Atomic/Atomic2D/ParticleEffect2D.cpp
@@ -43,7 +43,11 @@ static const int srcBlendFuncs[] =
     0x0302, // GL_SRC_ALPHA
     0x0302, // GL_SRC_ALPHA
     1,      // GL_ONE
-    0x0305  // GL_ONE_MINUS_DST_ALPHA
+    0x0305, // GL_ONE_MINUS_DST_ALPHA
+// ATOMIC_BEGIN
+    1,      // GL_ONE
+    0x0302  // GL_SRC_ALPHA
+// ATOMIC END
 };
 
 static const int destBlendFuncs[] =
@@ -54,7 +58,11 @@ static const int destBlendFuncs[] =
     0x0303, // GL_ONE_MINUS_SRC_ALPHA
     1,      // GL_ONE
     0x0303, // GL_ONE_MINUS_SRC_ALPHA
-    0x0304  // GL_DST_ALPHA
+    0x0304, // GL_DST_ALPHA
+// ATOMIC_BEGIN
+    1,      // GL_ONE
+    1       // GL_ONE
+// ATOMIC END   
 };
 
 ParticleEffect2D::ParticleEffect2D(Context* context) :

--- a/Source/Atomic/Atomic2D/ParticleEmitter2D.cpp
+++ b/Source/Atomic/Atomic2D/ParticleEmitter2D.cpp
@@ -296,8 +296,9 @@ void ParticleEmitter2D::Update(float timeStep)
             --numParticles_;
         }
     }
-
-    if (emissionTime_ >= 0.0f)
+    // ATOMIC BEGIN
+    if (emissionTime_ > 0.0f)
+    // ATOMIC END
     {
         float worldAngle = GetNode()->GetWorldRotation().RollAngle();
 


### PR DESCRIPTION
This PR plugs a hole for a potential crash from calling ParticleEffect2D API, and fixes the ability for a ParticleEmitter2D to use the Duration setting in a pex file.