### PR TITLE
JS- inspector plugin support

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/InspectorFrame.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorFrame.ts
@@ -30,7 +30,7 @@ import ModelInspector = require("./ModelInspector");
 import PrefabInspector = require("./PrefabInspector");
 import TextureInspector = require("./TextureInspector");
 import AssemblyInspector = require("./AssemblyInspector");
-
+import ServiceLocator from "../../../hostExtensions/ServiceLocator";
 import SelectionInspector = require("./SelectionInspector");
 // make sure these are hooked in
 import "./SelectionEditTypes";
@@ -231,8 +231,19 @@ class InspectorFrame extends ScriptWidget {
 
         }
 
+        // Check if there are inspector plugins available for unknown asset types.
+        if (asset.importerType == null) {
+
+            ServiceLocator.uiServices.projectAssetClicked(asset);
+        }
     }
 
+    loadCustomInspectorWidget(rootWidget: Atomic.UIWidget) {
+
+        var container = this.getWidget("inspectorcontainer");
+        container.deleteAllChildren();
+        container.addChild(rootWidget);
+    }
 }
 
 export = InspectorFrame;

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -8,6 +8,7 @@
 /// <reference path="Atomic.d.ts" />
 /// <reference path="Editor.d.ts" />
 /// <reference path="ToolCore.d.ts" />
+/// <reference path="WebView.d.ts" />
 
 declare module Editor.EditorEvents {
 
@@ -342,6 +343,7 @@ declare module Editor.HostExtensions {
     export interface UIServicesEventListener extends Editor.Extensions.ServiceEventListener {
         menuItemClicked?(refid: string): boolean;
         projectContextItemClicked?(asset: ToolCore.Asset, refid: string): boolean;
+        projectAssetClicked?(asset: ToolCore.Asset): boolean;
         hierarchyContextItemClicked?(node: Atomic.Node, refid: string): boolean;
 
         /**
@@ -360,6 +362,7 @@ declare module Editor.HostExtensions {
         createProjectContextMenuItemSource(id: string, items: any): Atomic.UIMenuItemSource;
         removeProjectContextMenuItemSource(id: string);
         refreshHierarchyFrame();
+        loadCustomInspector(customInspector: Atomic.UIWidget);
         showModalWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow;
         showModalError(windowText: string, message: string);
         showResourceSelection(windowText: string, importerType: string, resourceType: string, callback: (retObject: any, args: any) => void, args?: any);

--- a/Source/ToolCore/Assets/Asset.cpp
+++ b/Source/ToolCore/Assets/Asset.cpp
@@ -274,7 +274,7 @@ bool Asset::CreateImporter()
         {
             importer_ = new ModelImporter(context_, this);
         }
-        if (ext == ".ogg" || ext == ".wav")
+        else if (ext == ".ogg" || ext == ".wav")
         {
             importer_ = new AudioImporter(context_, this);
         }
@@ -333,6 +333,10 @@ bool Asset::CreateImporter()
         else if (textureFormats.Contains(ext))
         {
             importer_ = new TextureImporter(context_, this);
+        }
+        else
+        {
+            importer_ = new AssetImporter(context_, this);
         }
 
     }


### PR DESCRIPTION
This will now allow the user to pass customized inspectors through the TS plugin system ( I will PR an example of how it gets used in the existing Atomic plugin example project shortly)

It comes with a change to recognize files with unknown extensions as .assets by using the default AssetImporter types.( I have left this change in a separate commit to be safe)

What this will allow us to do is fire up custom inspectors for currently unsupported file formats by checking the file's extension.