### PR TITLE
Virtual DPad JS script is throwing exception

### DIFF
--- a/Source/Atomic/Input/Input.cpp
+++ b/Source/Atomic/Input/Input.cpp
@@ -2758,6 +2758,10 @@ void Input::HandleScreenJoystickTouch(StringHash eventType, VariantMap& eventDat
 }
 
 // ATOMIC BEGIN
+void Input::BindButton(UIButton* touchButton, int button)
+{
+    touchButton->SetEmulationButton(button);
+}
 
 void Input::SimulateButtonDown(int button)
 {

--- a/Source/Atomic/Input/Input.h
+++ b/Source/Atomic/Input/Input.h
@@ -27,6 +27,7 @@
 #include "../Core/Object.h"
 #include "../Container/List.h"
 #include "../Input/InputEvents.h"
+#include "../UI/UIButton.h"
 
 // ATOMIC BEGIN
 // #include "../UI/Cursor.h"
@@ -50,6 +51,7 @@ class Graphics;
 class Serializer;
 class UIWidget;
 class XMLFile;
+class UIButton;
 
 const IntVector2 MOUSE_POSITION_OFFSCREEN = IntVector2(M_MIN_INT, M_MIN_INT);
 
@@ -330,6 +332,9 @@ public:
     bool IsMinimized() const;
 
 // ATOMIC BEGIN
+    /// Binds UIButton element to the given button
+    void BindButton(UIButton* touchButton, int button);
+
     void SimulateButtonDown(int button);
     void SimulateButtonUp(int button);
     


### PR DESCRIPTION
Tracked it down to Input::BindButton() being evaporated from the source, this restores it.

Tested successfully on Android and on Desktop with Atomic.input.touchEmulation = true; 