### PR TITLE
Default AssetImporter.requiresCacheFile to false

### DIFF
--- a/Source/ToolCore/Assets/AssetImporter.cpp
+++ b/Source/ToolCore/Assets/AssetImporter.cpp
@@ -31,7 +31,7 @@ namespace ToolCore
 
 AssetImporter::AssetImporter(Context* context, Asset *asset) : Object(context),
     asset_(asset),
-    requiresCacheFile_(true)
+    requiresCacheFile_(false)
 {
     SetDefaults();
 }

--- a/Source/ToolCore/Assets/CSharpImporter.cpp
+++ b/Source/ToolCore/Assets/CSharpImporter.cpp
@@ -37,7 +37,6 @@ namespace ToolCore
 
     CSharpImporter::CSharpImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
     {
-        requiresCacheFile_ = false;
     }
 
     CSharpImporter::~CSharpImporter()

--- a/Source/ToolCore/Assets/JSONImporter.cpp
+++ b/Source/ToolCore/Assets/JSONImporter.cpp
@@ -37,7 +37,6 @@ namespace ToolCore
 
 JSONImporter::JSONImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
 {
-    requiresCacheFile_ = false;
 }
 
 JSONImporter::~JSONImporter()

--- a/Source/ToolCore/Assets/JavascriptImporter.cpp
+++ b/Source/ToolCore/Assets/JavascriptImporter.cpp
@@ -37,7 +37,6 @@ namespace ToolCore
 
 JavascriptImporter::JavascriptImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
 {
-    requiresCacheFile_ = false;
     isComponentFile_ = false;
 }
 

--- a/Source/ToolCore/Assets/MaterialImporter.cpp
+++ b/Source/ToolCore/Assets/MaterialImporter.cpp
@@ -33,7 +33,6 @@ namespace ToolCore
 
 MaterialImporter::MaterialImporter(Context* context, Asset* asset) : AssetImporter(context, asset)
 {
-    requiresCacheFile_ = false;
 }
 
 MaterialImporter::~MaterialImporter()

--- a/Source/ToolCore/Assets/ModelImporter.cpp
+++ b/Source/ToolCore/Assets/ModelImporter.cpp
@@ -47,6 +47,8 @@ namespace ToolCore
 /// Node + Model (static or animated)
 ModelImporter::ModelImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
 {
+    requiresCacheFile_ = true;
+
     SetDefaults();
 }
 

--- a/Source/ToolCore/Assets/NETAssemblyImporter.cpp
+++ b/Source/ToolCore/Assets/NETAssemblyImporter.cpp
@@ -41,7 +41,6 @@ namespace ToolCore
 
     NETAssemblyImporter::NETAssemblyImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
     {
-        requiresCacheFile_ = false;
         resultHandler_ = new NETAssemblyImporterResultHandler(context, this);
     }
 

--- a/Source/ToolCore/Assets/PrefabImporter.cpp
+++ b/Source/ToolCore/Assets/PrefabImporter.cpp
@@ -37,6 +37,8 @@ namespace ToolCore
 PrefabImporter::PrefabImporter(Context* context, Asset* asset) : AssetImporter(context, asset),
     lastFileStamp_(0xFFFFFFFF)
 {
+    requiresCacheFile_ = true;
+
     SubscribeToEvent(E_PREFABSAVE, ATOMIC_HANDLER(PrefabImporter, HandlePrefabSave));
 }
 

--- a/Source/ToolCore/Assets/SpriterImporter.cpp
+++ b/Source/ToolCore/Assets/SpriterImporter.cpp
@@ -36,7 +36,6 @@ namespace ToolCore
 
 SpriterImporter::SpriterImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
 {
-    requiresCacheFile_ = false;
 }
 
 SpriterImporter::~SpriterImporter()

--- a/Source/ToolCore/Assets/TextureImporter.cpp
+++ b/Source/ToolCore/Assets/TextureImporter.cpp
@@ -39,6 +39,8 @@ namespace ToolCore
     TextureImporter::TextureImporter(Context* context, Asset *asset) : AssetImporter(context, asset),
         compressTextures_(false), compressedSize_(0)
 {
+    requiresCacheFile_ = true;
+
     ApplyProjectImportConfig();
 }
 

--- a/Source/ToolCore/Assets/TypeScriptImporter.cpp
+++ b/Source/ToolCore/Assets/TypeScriptImporter.cpp
@@ -34,7 +34,6 @@ namespace ToolCore
 
 TypeScriptImporter::TypeScriptImporter(Context* context, Asset *asset) : AssetImporter(context, asset)
 {
-    requiresCacheFile_ = false;
     isComponentFile_ = false;
 }
 


### PR DESCRIPTION
Following @JohnnyWahib's change to allow non-recognized assets to be imported, we ran into an issue with our modified (async) cache code. RequiresCache defaults to true, which is inappropriate for these unrecognized assets, which hits an assert when we collect the details of expected cache files per asset.

The fix for this (defaulting requiresCacheFile to false and setting it to true in appropriate cases) isn't strictly necessary for default Atomic, but it does seem to be the correct approach, so PRing it as well.