### PR TITLE
Support for constructors in the Web subsystem

### DIFF
--- a/Source/Atomic/Web/Web.cpp
+++ b/Source/Atomic/Web/Web.cpp
@@ -95,15 +95,25 @@ void Web::internalUpdate(StringHash eventType, VariantMap& eventData)
 #endif
 }
 
+#ifndef EMSCRIPTEN
+void Web::setup(WebRequest& webRequest)
+{
+    webRequest.setup(&d->service, d->curlm);
+}
+
+void Web::setup(WebSocket& webSocket)
+{
+    webSocket.setup(&d->service);
+}
+#endif
+
+
 SharedPtr<WebRequest> Web::MakeWebRequest(const String& verb, const String& url, double requestContentSize)
 {
     ATOMIC_PROFILE(MakeWebRequest);
 
     // The initialization of the request will take time, can not know at this point if it has an error or not
     SharedPtr<WebRequest> webRequest(new WebRequest(context_, verb, url, requestContentSize));
-#ifndef EMSCRIPTEN
-    webRequest->setup(&d->service, d->curlm);
-#endif
     return webRequest;
 }
 
@@ -113,9 +123,6 @@ SharedPtr<WebSocket> Web::MakeWebSocket(const String& url)
 
   // The initialization of the WebSocket will take time, can not know at this point if it has an error or not
   SharedPtr<WebSocket> webSocket(new WebSocket(context_, url));
-#ifndef EMSCRIPTEN
-  webSocket->setup(&d->service);
-#endif
   return webSocket;
 }
 

--- a/Source/Atomic/Web/Web.h
+++ b/Source/Atomic/Web/Web.h
@@ -37,6 +37,9 @@ struct WebPrivate;
 /// %Web subsystem. Manages HTTP requests and WebSocket communications.
 class ATOMIC_API Web : public Object
 {
+    friend class WebRequest;
+    friend class WebSocket;
+
     ATOMIC_OBJECT(Web, Object);
 
 public:
@@ -56,6 +59,10 @@ public:
 
 private:
     void internalUpdate(StringHash eventType, VariantMap& eventData);
+#ifndef EMSCRIPTEN
+    void setup(WebRequest& webRequest);
+    void setup(WebSocket& webSocket);
+#endif
     WebPrivate *d;
 };
 

--- a/Source/Atomic/Web/WebRequest.cpp
+++ b/Source/Atomic/Web/WebRequest.cpp
@@ -26,6 +26,7 @@
 #include "../Container/HashMap.h"
 #include "../IO/BufferQueue.h"
 #include "../IO/Log.h"
+#include "../Web/Web.h"
 #include "../Web/WebRequest.h"
 
 #ifdef EMSCRIPTEN
@@ -279,6 +280,8 @@ WebRequest::WebRequest(Context* context, const String& verb, const String& url, 
     is_->isAborted = false;
     is_->isAddedToMulti = false;
 
+    Web* web = GetSubsystem<Web>();
+    web->setup(*this);
 }
 
 WebRequest::~WebRequest()
@@ -400,7 +403,10 @@ void WebRequest::Send()
     {
         is_->es_hold = this;
         curl_easy_setopt(is_->curl, CURLOPT_HTTPHEADER, is_->headers);
-        curl_multi_add_handle(is_->curlm, is_->curl);
+        if (CURLM_OK != curl_multi_add_handle(is_->curlm, is_->curl))
+        {
+            ATOMIC_LOGDEBUG("ERROR SENDING REQUEST!");
+        }
         is_->isAddedToMulti = true;
     }
 }

--- a/Source/Atomic/Web/WebRequest.h
+++ b/Source/Atomic/Web/WebRequest.h
@@ -62,7 +62,7 @@ class WebRequest : public Object
 
 public:
     /// Construct with parameters.
-    WebRequest(Context* context, const String& verb, const String& url, double requestContentSize);
+    WebRequest(Context* context, const String& verb, const String& url, double requestContentSize = 0.0);
     /// Destruct. Release the connection.
     ~WebRequest();
 

--- a/Source/Atomic/Web/WebSocket.cpp
+++ b/Source/Atomic/Web/WebSocket.cpp
@@ -25,6 +25,7 @@
 #include "../Core/Profiler.h"
 #include "../IO/BufferQueue.h"
 #include "../IO/Log.h"
+#include "../Web/Web.h"
 #include "../Web/WebSocket.h"
 
 #ifdef EMSCRIPTEN
@@ -152,6 +153,9 @@ WebSocket::WebSocket(Context* context, const String& url) :
 
     is_->c.clear_access_channels(websocketpp::log::alevel::all);
     is_->c.clear_error_channels(websocketpp::log::elevel::all);
+
+    Web* web = GetSubsystem<Web>();
+    web->setup(*this);
 }
 
 void WebSocket::setup(asio::io_service *service)


### PR DESCRIPTION
This patch adds support for constructors instead of forcing use of the "make" functions of the Web subsystem. When the Web subsystem was initially added constructors were not yet bound automatically. Now that they are, it would be surprising if using the WebRequest and WebSocket didn't work, if they were directly constructed. They probably should have had private constructors, but this patch removes the need for private constructors.