### PR TITLE
[Network] Resurrect additions for master server/client #1269

### DIFF
--- a/Source/Atomic/Network/Connection.h
+++ b/Source/Atomic/Network/Connection.h
@@ -234,6 +234,23 @@ public:
     unsigned char timeStamp_;
     /// Identity map.
     VariantMap identity_;
+    
+// ATOMIC BEGIN
+
+    /// Expose control methods for current controls
+    void SetControlButtons(unsigned buttons, bool down = true);
+
+    /// Check if a button is held down.
+    bool IsControlButtonDown(unsigned button) const;
+
+    void SetControlDataInt(const String& key, int value);
+
+    int GetControlDataInt(const String& key);
+
+    /// Send a message.
+    void SendStringMessage(const String& message);
+    
+// ATOMIC END
 
 private:
     /// Handle scene loaded event.
@@ -274,6 +291,14 @@ private:
     void OnPackageDownloadFailed(const String& name);
     /// Handle all packages loaded successfully. Also called directly on MSG_LOADSCENE if there are none.
     void OnPackagesReady();
+
+// ATOMIC BEGIN
+
+    void ProcessStringMessage(int msgID, MemoryBuffer& msg);
+
+    void HandleComponentRemoved(StringHash eventType, VariantMap& eventData);
+
+// ATOMIC END
 
     /// kNet message connection.
     kNet::SharedPtr<kNet::MessageConnection> connection_;

--- a/Source/Atomic/Network/Network.cpp
+++ b/Source/Atomic/Network/Network.cpp
@@ -40,6 +40,7 @@
 
 // ATOMIC BEGIN
 #include <kNet/include/kNet.h>
+#include <kNet/include/kNet/EndPoint.h>
 // ATOMIC END
 
 #include "../DebugNew.h"

--- a/Source/Atomic/Network/Network.h
+++ b/Source/Atomic/Network/Network.h
@@ -185,6 +185,8 @@ private:
     String packageCacheDir_;
 
     // ATOMIC BEGIN
+    
+    void HandleClientConnected(StringHash eventType, VariantMap& eventData);
 
     kNet::Network* GetKnetNetwork() { return network_; }
 

--- a/Source/Atomic/Network/NetworkEvents.h
+++ b/Source/Atomic/Network/NetworkEvents.h
@@ -115,6 +115,13 @@ ATOMIC_EVENT(E_MASTERMESSAGE, MasterServerMessage)
     ATOMIC_PARAM(P_DATA, Data);                    // Buffer
 }
 
+/// Unhandled master message received.
+ATOMIC_EVENT(E_NETWORKSTRINGMESSAGE, NetworkStringMessage)
+{
+    ATOMIC_PARAM(P_CONNECTION, Connection);      // Connection pointer
+    ATOMIC_PARAM(P_DATA, Data);                  // Buffer
+}
+
 // ATOMIC END
 
 }

--- a/Source/Atomic/Network/Protocol.h
+++ b/Source/Atomic/Network/Protocol.h
@@ -64,6 +64,13 @@ static const int MSG_REMOTENODEEVENT = 0x15;
 /// Server->client: info about package.
 static const int MSG_PACKAGEINFO = 0x16;
 
+// ATOMIC BEGIN
+
+// Server->client, Client->server: string message
+static const int MSG_STRING = 0x17;
+
+// ATOMIC END
+
 /// Fixed content ID for client controls update.
 static const unsigned CONTROLS_CONTENT_ID = 1;
 /// Package file fragment size.


### PR DESCRIPTION
Restored functionality, all wrapped in // ATOMIC guards
Tested on linux with the multiplayer spacegame example. 
A note about the master server, the list of included servers is getting pretty large, it needs some aging or unregistering functions.