### PR TITLE
C# code changes require manual recompilation in AtomicEditor #1236

### DIFF
--- a/Script/AtomicEditor/editor/EditorEvents.ts
+++ b/Script/AtomicEditor/editor/EditorEvents.ts
@@ -181,3 +181,11 @@ export interface UserPreferencesChangedEvent {
 
 export const WebViewLoadEnd = "WebViewLoadEnd";
 export const WebMessage = "WebMessage";
+
+// interface to pass modal error messages from core modules
+export const EditorModal = "EditorModal";
+export interface EditorModalEvent {
+    uiType: number;     // EDITOR_ERROR_MODAL, etc)
+    title: string;      // for modal errors, title text
+    message: string;    // for modal errors, error text
+}

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
@@ -69,9 +69,6 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
             menu.addItem(new Atomic.UIMenuItem("Generate Solution", `${this.name}.generatesolution`));
             menu.addItem(new Atomic.UIMenuItem("Package Resources", `${this.name}.packageresources`));
 
-            this.compileOnSaveMenuItem = new Atomic.UIMenuItem(`Compile on Save: ${isCompileOnSave ? "On" : "Off"}`, `${this.name}.compileonsave`);
-            menu.addItem(this.compileOnSaveMenuItem);
-
             this.menuCreated = true;
         }
 
@@ -135,15 +132,6 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
             this.isNETProject = true;
         }
 
-        const isCompileOnSave = this.serviceRegistry.projectServices.getUserPreference(this.name, "CompileOnSave", false);
-
-        if (isCompileOnSave && ToolCore.netProjectSystem) {
-
-            // for now, only support compile on save when not using VS
-            if (!ToolCore.netProjectSystem.iDEAvailable)
-                ToolCore.netProjectSystem.buildAtomicProject();
-        }
-
     }
 
     /*** ProjectService implementation ****/
@@ -204,13 +192,6 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
                     return true;
                 case "packageresources":
                     this.packageResources();
-                    return true;
-                case "compileonsave":
-                    let isCompileOnSave = this.serviceRegistry.projectServices.getUserPreference(this.name, "CompileOnSave", false);
-                    // Toggle
-                    isCompileOnSave = !isCompileOnSave;
-                    this.serviceRegistry.projectServices.setUserPreference(this.name, "CompileOnSave", isCompileOnSave);
-                    this.compileOnSaveMenuItem.string = `Compile on Save: ${isCompileOnSave ? "On" : "Off"}`;
                     return true;
             }
         }

--- a/Script/AtomicEditor/ui/EditorUI.ts
+++ b/Script/AtomicEditor/ui/EditorUI.ts
@@ -110,6 +110,10 @@ class EditorUI extends Atomic.ScriptObject {
     this.subscribeToEvent(EditorEvents.ModalError, (event:EditorEvents.ModalErrorEvent) => {
       this.showModalError(event.title, event.message);
     });
+    
+    this.subscribeToEvent(EditorEvents.EditorModal, (event:EditorEvents.EditorModalEvent) => {
+      this.showModalError(event.title, event.message);
+    });
 
   }
 

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -40,6 +40,11 @@ class Shortcuts extends Atomic.ScriptObject {
     //this should be moved somewhere else...
     invokePlayOrStopPlayer(debug: boolean = false) {
         this.sendEvent(EditorEvents.SaveAllResources);
+
+        if ( ToolCore.netProjectSystem.solutionAvailable)   // are we a csharp project
+            if( ToolCore.netProjectSystem.buildAndRun() )   // do we need to rebuild?
+                return;  // if yes, return, the play event will be reissued after the rebuild
+      
         if (Atomic.editorMode.isPlayerEnabled()) {
             this.sendEvent("IPCPlayerExitRequest");
         } else {
@@ -216,6 +221,11 @@ class Shortcuts extends Atomic.ScriptObject {
     handleUIShortcut(ev: Atomic.UIShortcutEvent) {
 
         var cmdKey = this.cmdKeyDown();
+    
+        if ( !cmdKey && ev.qualifiers > 0 ) // check the event, the qualifier may have been programmitically set
+        {
+            cmdKey = ( ev.qualifiers == Atomic.QUAL_CTRL );
+        }
 
         if (cmdKey) {
 

--- a/Script/Packages/ToolCore/ToolCore.json
+++ b/Script/Packages/ToolCore/ToolCore.json
@@ -4,7 +4,7 @@
 							 "Source/ToolCore/Import", "Source/ToolCore/Assets", "Source/ToolCore/License", "Source/ToolCore/Build",
 						 	 "Source/ToolCore/Subprocess", "Source/ToolCore/NETTools"],
 	"classes" : ["ToolEnvironment", "ToolSystem", "ToolPrefs", "SubprocessSystem", "Subprocess",
-								"Project", "ProjectFile", "Platform", "PlatformMac", "PlatformWeb",
+								"Project", "ProjectSettings", "ProjectFile", "Platform", "PlatformMac", "PlatformWeb",
 							 "PlatformWindows", "PlatformAndroid", "PlatformIOS", "PlatformLinux", "Command", "PlayCmd", "OpenAssetImporter",
 							 "Asset", "AssetDatabase", "AssetImporter", "AudioImporter", "ModelImporter", "MaterialImporter", "AnimationImportInfo",
 							 "PrefabImporter", "JavascriptImporter", "JSONImporter",

--- a/Source/ToolCore/NETTools/NETProjectSystem.h
+++ b/Source/ToolCore/NETTools/NETProjectSystem.h
@@ -68,11 +68,15 @@ namespace ToolCore
         bool GenerateSolution();
         bool GenerateResourcePak();
 
+        /// build csharp dll if sources are dirty and then run
+        bool BuildAndRun();
+        
     private:
 
         void HandleUpdate(StringHash eventType, VariantMap& eventData);
 
         void HandleNETBuildResult(StringHash eventType, VariantMap& eventData);
+        void HandleNETBuildPlay(StringHash eventType, VariantMap& eventData);
 
         void HandleFileChanged(StringHash eventType, VariantMap& eventData);
         void HandleResourceAdded(StringHash eventType, VariantMap& eventData);
@@ -89,6 +93,8 @@ namespace ToolCore
 
         void Clear();
         void Initialize();
+        /// interrogate sources to see if any are younger than the editor dll
+        bool CheckForRebuild();
 
         String idePath_;
 


### PR DESCRIPTION
This PR fixes the Play button for a C# project to always be up to date with the latest saved source files.  There is a check added to the play event handler, which looks to see if the current project is c#, then does a check for out of date sources. If the sources are ok, then no further action is needed, it simply plays the project. If the sources are out of date, then the BuildAndPlay processing starts and it returns out of the play event handler.  The BuildAndPlay function then compiles the project, and in the compile completed event handler, if successful, issues a Play event and the project is played after a short pause. If the compilation fails, only an error is put in the console, and the project is not played. Because of the fine work someone did when c# is compiling, the play button greys out while this compile happens also, giving the user an indication something is happening.
