### PR TITLE
Lint ts and fix ATOMIC_PARAMs

### DIFF
--- a/Script/AtomicEditor/resources/ProjectTemplates.ts
+++ b/Script/AtomicEditor/resources/ProjectTemplates.ts
@@ -161,7 +161,7 @@ export function getExampleProjectTemplateDefinitions(): [ProjectTemplateDefiniti
             languages : languages,
             appDelegateClass : exampleJson.appDelegateClass,
             namespace : exampleJson.namespace
-        })
+        });
 
     });
 

--- a/Script/AtomicEditor/resources/ResourceOps.ts
+++ b/Script/AtomicEditor/resources/ResourceOps.ts
@@ -36,7 +36,7 @@ class ResourceOps extends Atomic.ScriptObject {
 
         });
 
-        this.subscribeToEvent(EditorEvents.RequestProjectLoad, (ev: EditorEvents.RequestProjectLoadEvent) => { this.handleRequestProjectLoad(ev); })
+        this.subscribeToEvent(EditorEvents.RequestProjectLoad, (ev: EditorEvents.RequestProjectLoadEvent) => { this.handleRequestProjectLoad(ev); });
 
     }
 
@@ -78,7 +78,7 @@ class ResourceOps extends Atomic.ScriptObject {
 
                 if (projectPath.indexOf(allLanguages[i]) != -1) {
                     language = allLanguages[i];
-                    break
+                    break;
                 }
             }
 
@@ -95,7 +95,7 @@ class ResourceOps extends Atomic.ScriptObject {
                 appDelegateClass : exampleJson.appDelegateClass,
                 namespace : exampleJson.namespace
 
-            }
+            };
 
             var ops = EditorUI.getModelOps();
             ops.showCreateProject(projectDef, projectPath);

--- a/Script/AtomicEditor/ui/frames/HierarchyFrame.ts
+++ b/Script/AtomicEditor/ui/frames/HierarchyFrame.ts
@@ -89,9 +89,9 @@ class HierarchyFrame extends Atomic.UIWidget {
         this.subscribeToEvent("KeyUp", () => {
             this.canReparent = true;
         });
-        
+
         this.subscribeToEvent(EditorEvents.ProjectClosed, (ev) => {
-            
+
             this.scene = null;
             this.populate();
 
@@ -202,7 +202,7 @@ class HierarchyFrame extends Atomic.UIWidget {
 
         if (this.scene)
             this.unsubscribeFromEvents(this.scene);
-        
+
         this.sceneEditor = sceneEditor;
         this.scene = sceneEditor == null ? null : sceneEditor.scene;
 
@@ -235,7 +235,7 @@ class HierarchyFrame extends Atomic.UIWidget {
 
 
         }
-        
+
     }
 
     handleEditorResourceClosed(event) {
@@ -245,7 +245,7 @@ class HierarchyFrame extends Atomic.UIWidget {
         }
 
     }
-    
+
     handleActiveSceneEditorChanged(event: EditorEvents.ActiveSceneEditorChangeEvent) {
 
         this.setSceneEditor(event.sceneEditor);

--- a/Script/AtomicEditor/ui/frames/MainFrame.ts
+++ b/Script/AtomicEditor/ui/frames/MainFrame.ts
@@ -181,7 +181,7 @@ class MainFrame extends ScriptWidget {
             this.animationToolbar = new AnimationToolbar(this.getWidget("animationtoolbarcontainer"), this.getWidget("animationpropertiescontainer"), asset);
         }
         else {
-            this.animationToolbar = new AnimationToolbar(this.getWidget("animationtoolbarcontainer"), this.getWidget("animationpropertiescontainer"), asset)
+            this.animationToolbar = new AnimationToolbar(this.getWidget("animationtoolbarcontainer"), this.getWidget("animationpropertiescontainer"), asset);
         }
     }
 

--- a/Script/AtomicEditor/ui/frames/WelcomeFrame.ts
+++ b/Script/AtomicEditor/ui/frames/WelcomeFrame.ts
@@ -41,9 +41,9 @@ class WelcomeFrame extends ScriptWidget {
         this.examplesJavaScript = <Atomic.UIButton>this.getWidget("examples_javascript");
         this.examplesTypeScript = <Atomic.UIButton>this.getWidget("examples_typescript");
 
-        this.examplesCSharp.onClick = () => { this.handleExampleFilter(); }
-        this.examplesJavaScript.onClick = () => { this.handleExampleFilter(); }
-        this.examplesTypeScript.onClick = () => { this.handleExampleFilter(); }
+        this.examplesCSharp.onClick = () => { this.handleExampleFilter(); };
+        this.examplesJavaScript.onClick = () => { this.handleExampleFilter(); };
+        this.examplesTypeScript.onClick = () => { this.handleExampleFilter(); };
 
         this.gravity = Atomic.UI_GRAVITY_ALL;
 

--- a/Script/AtomicEditor/ui/frames/inspector/InspectorWidget.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorWidget.ts
@@ -21,7 +21,7 @@
 //
 
 import ScriptWidget = require("ui/ScriptWidget");
-import EditorUI = require("ui/EditorUI"); 
+import EditorUI = require("ui/EditorUI");
 
 
 class InspectorWidget extends ScriptWidget {

--- a/Script/AtomicEditor/ui/frames/inspector/TextureInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/TextureInspector.ts
@@ -183,8 +183,7 @@ class TextureInspector extends InspectorWidget {
 
     }
 
-    onApply()
-    {
+    onApply() {
 
         this.importer.setCompressedImageSize(Number(this.compressionSize.text));
         this.asset.import();
@@ -192,26 +191,22 @@ class TextureInspector extends InspectorWidget {
 
     }
 
-    populateCompressionSizeList()
-    {
+    populateCompressionSizeList() {
         this.compressionSize = new Atomic.UISelectDropdown();
         this.compressionSizeSource = new Atomic.UISelectItemSource();
 
-        for (var i = 0; i < this.compressionSizes.length; i ++)
-        {
+        for (var i = 0; i < this.compressionSizes.length; i ++) {
             var size = new Atomic.UISelectItem();
-            size.setString(this.compressionSizes[i].toString());           
+            size.setString(this.compressionSizes[i].toString());
             this.compressionSizeSource.addItem(size);
         }
 
         this.compressionSize.setSource(this.compressionSizeSource);
 
-        if (this.importer.getCompressedImageSize() != 0)
-        {
+        if (this.importer.getCompressedImageSize() != 0) {
             this.compressionSize.setText(this.importer.getCompressedImageSize().toString());
         }
-        else
-        {
+        else {
             this.compressionSize.setText("NONE");
         }
     }

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -276,7 +276,7 @@ class MainFrameMenu extends Atomic.ScriptObject {
                 let logName = refid.indexOf("editor") != -1 ? "AtomicEditor" : "AtomicPlayer";
                 let logFolder = Atomic.fileSystem.getAppPreferencesDir(logName, "Logs");
                 Atomic.fileSystem.systemOpen(logFolder);
-            } 
+            }
 
         } else if (target.id == "menu build popup") {
 
@@ -364,7 +364,7 @@ var toolsItems = {
         "Player Log": ["tools log player"],
         "Editor Log": ["tools log editor"]
     }
-    
+
 
 };
 

--- a/Script/AtomicEditor/ui/modal/CreateProject.ts
+++ b/Script/AtomicEditor/ui/modal/CreateProject.ts
@@ -117,7 +117,7 @@ class CreateProject extends ModalWindow {
         if (platformName != "desktop") {
             var greenplus = new Atomic.UIImageWidget();
             greenplus.image = "AtomicEditor/editor/images/green_plus.png";
-            rect = [size-18, 2, size-2, 18];
+            rect = [size - 18, 2, size - 2, 18];
             greenplus.rect = rect;
             greenplus.visibility = Atomic.UI_WIDGET_VISIBILITY_INVISIBLE;
             button.addChild(greenplus);
@@ -247,7 +247,7 @@ class CreateProject extends ModalWindow {
             var projectSettings = {
                 name : name,
                 platforms : platforms
-            }
+            };
 
             var jsonFile = new Atomic.File(folder + "Settings/Project.json", Atomic.FILE_WRITE);
             if (jsonFile.isOpen()) {
@@ -329,10 +329,8 @@ class CreateProject extends ModalWindow {
             }
             else if (id == "create") {
 
-                if ( this.tryProjectCreate() )
-                {
-                    if ( Preferences.getInstance().editorFeatures.defaultLanguage != this.projectLanguageField.text )
-                    {
+                if ( this.tryProjectCreate() ) {
+                    if ( Preferences.getInstance().editorFeatures.defaultLanguage != this.projectLanguageField.text ) {
                         Preferences.getInstance().editorFeatures.defaultLanguage = this.projectLanguageField.text;
                         Preferences.getInstance().write();
                     }
@@ -381,8 +379,7 @@ class CreateProject extends ModalWindow {
         let csrank = -1;
         let tsrank = -1;
         let ii = 0;
-        for ( ii = 0; ii<this.projectLanguageFieldSource.getItemCount(); ii++ ) // get rankings
-        {
+        for ( ii = 0; ii < this.projectLanguageFieldSource.getItemCount(); ii++ ) { // get rankings
             if ( this.projectLanguageFieldSource.getItemStr( ii ) == "JavaScript" ) jsrank = ii;
             if ( this.projectLanguageFieldSource.getItemStr( ii ) == "CSharp" ) csrank = ii;
             if ( this.projectLanguageFieldSource.getItemStr( ii ) == "TypeScript" ) tsrank = ii;

--- a/Script/AtomicEditor/ui/modal/ModalOps.ts
+++ b/Script/AtomicEditor/ui/modal/ModalOps.ts
@@ -54,8 +54,7 @@ class ModalOps extends Atomic.ScriptObject {
         this.dimmer = new Atomic.UIDimmer();
 
         this.subscribeToEvent("WindowClosed", (e) => {
-            if (e.window == this.opWindow)
-            {
+            if (e.window == this.opWindow) {
                 this.opWindow = null;
                 if (this.dimmer.parent) {
                     this.dimmer.parent.removeChild(this.dimmer, false);

--- a/Script/AtomicEditor/ui/modal/build/BuildSettingsWindow.ts
+++ b/Script/AtomicEditor/ui/modal/build/BuildSettingsWindow.ts
@@ -145,7 +145,7 @@ export class BuildSettingsWindow extends ModalWindow {
                 var showMessage = function(target, title, message) {
                     var window = new Atomic.UIMessageWindow(target, "modal_error");
                     window.show(title, message, Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 260);
-                }
+                };
 
                 for (var name in this.platformInfo) {
 

--- a/Script/AtomicEditor/ui/modal/build/platforms/WebSettingsWidget.ts
+++ b/Script/AtomicEditor/ui/modal/build/platforms/WebSettingsWidget.ts
@@ -56,7 +56,7 @@ class WebSettingsWidget extends Atomic.UIWidget implements BuildSettingsWindow.B
             if ( path.length > 0 )
                 this.faviconName.text = path;
             return true;
-        } 
+        }
 
         if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
 

--- a/Script/AtomicEditor/ui/playmode/PlayerOutput.ts
+++ b/Script/AtomicEditor/ui/playmode/PlayerOutput.ts
@@ -42,7 +42,7 @@ class PlayerOutput extends Atomic.UIWindow {
 
         this.output = <Atomic.UIEditField> this.getWidget("output");
         this.closeOnStop = <Atomic.UICheckBox> this.getWidget("closeonstop");
-        
+
         this.closeOnStop.value = Preferences.getInstance().editorFeatures.closePlayerLog ? 1 : 0;
 
         (<Atomic.UIButton>this.getWidget("closebutton")).onClick = () => {
@@ -73,7 +73,7 @@ class PlayerOutput extends Atomic.UIWindow {
 
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
-    
+
         if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
             var id = ev.target.id;
             if (id == "closeonstop") {

--- a/Source/Atomic/IPC/IPCServer.h
+++ b/Source/Atomic/IPC/IPCServer.h
@@ -29,13 +29,13 @@ namespace Atomic
 {
     ATOMIC_EVENT(E_IPCCMD, IPCCmd)
     {
-        ATOMIC_PARAM(P_COMMAND, Command);
+        ATOMIC_PARAM(P_COMMAND, Command); // string
         ATOMIC_PARAM(P_ID, ID); // unsigned
     }
 
     ATOMIC_EVENT(E_IPCCMDRESULT, IPCCmdResult)
     {
-        ATOMIC_PARAM(P_COMMAND, Command);
+        ATOMIC_PARAM(P_COMMAND, Command); // string
         ATOMIC_PARAM(P_ID, ID); // unsigned
     }
 

--- a/Source/AtomicApp/Player/IPCPlayerAppEvents.h
+++ b/Source/AtomicApp/Player/IPCPlayerAppEvents.h
@@ -49,12 +49,12 @@ namespace Atomic
 
     ATOMIC_EVENT(E_IPCPLAYERWINDOWCHANGED, IPCPlayerWindowChanged)
     {
-        ATOMIC_PARAM(P_POSX, PosX);
-        ATOMIC_PARAM(P_POSY, PosY);
-        ATOMIC_PARAM(P_WIDTH, Width);
-        ATOMIC_PARAM(P_HEIGHT, Height);
-        ATOMIC_PARAM(P_MONITOR, Monitor);
-        ATOMIC_PARAM(P_MAXIMIZED, Maximized);
+        ATOMIC_PARAM(P_POSX, PosX);  // int
+        ATOMIC_PARAM(P_POSY, PosY); // int
+        ATOMIC_PARAM(P_WIDTH, Width); // int
+        ATOMIC_PARAM(P_HEIGHT, Height); // int
+        ATOMIC_PARAM(P_MONITOR, Monitor); // int
+        ATOMIC_PARAM(P_MAXIMIZED, Maximized); // bool
     }
 
     ATOMIC_EVENT(E_PLAYERQUIT, PlayerQuit)

--- a/Source/AtomicEditor/EditorMode/AEEditorEvents.h
+++ b/Source/AtomicEditor/EditorMode/AEEditorEvents.h
@@ -123,7 +123,7 @@ ATOMIC_EVENT(E_EDITORMODAL, EditorModal)
 
 ATOMIC_EVENT(E_EDITORACTIVESCENEEDITORCHANGE, EditorActiveSceneEditorChange)
 {
-    ATOMIC_PARAM(P_SCENEEDITOR, SceneEditor);
+    ATOMIC_PARAM(P_SCENEEDITOR, SceneEditor);  // SceneEditor3D pointer
 }
 
 


### PR DESCRIPTION
Fixes the Typescript lint warnings, so the genscripts works better. Also fixes ATOMIC_PARAM syntax, since the js binding generator actually parses the comment after the definition for the arg type, otherwise it emits an odd warning.