### PR TITLE
Adds C# inspector tooltips for editable attributes

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/AttributeInfoEdit.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/AttributeInfoEdit.ts
@@ -65,6 +65,10 @@ class AttributeInfoEdit extends Atomic.UILayout {
 
         this.editWidget.subscribeToEvent(this.editWidget, "WidgetEvent", (data) => this.handleWidgetEvent(data));
 
+        if (this.attrInfo.tooltip) {
+            this.editWidget.tooltip = this.attrInfo.tooltip;
+        }
+
         var attr = this.attrInfo;
         var attrNameLP = AttributeInfoEdit.attrNameLP;
 
@@ -94,6 +98,10 @@ class AttributeInfoEdit extends Atomic.UILayout {
                 name.text = bname;
 
             name.fontDescription = AttributeInfoEdit.fontDesc;
+
+            if (this.attrInfo.tooltip) {
+               name.tooltip = this.attrInfo.tooltip;
+            }
 
             this.addChild(name);
 

--- a/Script/AtomicNET/AtomicNET/Scene/InspectorAttribute.cs
+++ b/Script/AtomicNET/AtomicNET/Scene/InspectorAttribute.cs
@@ -8,9 +8,21 @@ namespace AtomicEngine
     {
         public InspectorAttribute(string DefaultValue = "")
         {
+            this.DefaultValue = DefaultValue;
         }
 
         public readonly string DefaultValue;
+
+        // Tooltip which will be displayed in editor
+        public string Tooltip
+        {
+            get { return tooltip; }
+            set { tooltip = value; }
+        }
+
+        private string tooltip;
+
     }
+
 
 }

--- a/Script/TypeScript/AtomicWork.d.ts
+++ b/Script/TypeScript/AtomicWork.d.ts
@@ -269,7 +269,8 @@ declare module Atomic {
         enumNames: string[];
         resourceTypeName: string;
         dynamic: boolean;
-
+        tooltip: string;
+        
     }
 
     export interface ShaderParameter {

--- a/Source/Atomic/Script/ScriptComponentFile.cpp
+++ b/Source/Atomic/Script/ScriptComponentFile.cpp
@@ -27,6 +27,7 @@ namespace Atomic
 {
 
 FieldMap ScriptComponentFile::emptyFieldMap_;
+FieldTooltipMap ScriptComponentFile::emptyFieldTooltipMap_;
 EnumMap ScriptComponentFile::emptyEnumMap_;
 VariantMap ScriptComponentFile::emptyDefaultValueMap_;
 
@@ -52,10 +53,16 @@ void ScriptComponentFile::AddEnum(const String& enumName, const EnumInfo& enumIn
     enumValues.Push(enumInfo);
 }
 
-void ScriptComponentFile::AddField(const String& fieldName, VariantType variantType, const String &classname)
+void ScriptComponentFile::AddField(const String& fieldName, VariantType variantType, const String &classname, const String& tooltip)
 {
     FieldMap& fields = classFields_[classname];
     fields[fieldName] = variantType;
+
+    if (tooltip.Length())
+    {
+        FieldTooltipMap& tooltips = classFieldTooltips_[classname];
+        tooltips[fieldName] = tooltip;
+    }
 }
 
 void ScriptComponentFile::AddDefaultValue(const String& fieldName, const Variant& value, const String& classname)
@@ -67,6 +74,7 @@ void ScriptComponentFile::AddDefaultValue(const String& fieldName, const Variant
 void ScriptComponentFile::Clear()
 {
     classFields_.Clear();
+    classFieldTooltips_.Clear();
     classDefaultFieldValues_.Clear();
     classEnums_.Clear();
 }
@@ -80,6 +88,18 @@ const FieldMap& ScriptComponentFile::GetFields(const String& classname) const
 
     return emptyFieldMap_;
 }
+
+const FieldTooltipMap& ScriptComponentFile::GetFieldTooltips(const String& classname) const
+{
+    FieldTooltipMap* fieldTooltipMap = classFieldTooltips_[classname];
+
+    if (fieldTooltipMap)
+        return *fieldTooltipMap;
+
+    return emptyFieldTooltipMap_;
+}
+
+
 const VariantMap& ScriptComponentFile::GetDefaultFieldValues(const String& classname) const
 {
     VariantMap *vmap = classDefaultFieldValues_[classname];

--- a/Source/Atomic/Script/ScriptComponentFile.h
+++ b/Source/Atomic/Script/ScriptComponentFile.h
@@ -41,17 +41,21 @@ struct EnumInfo
     Variant value_;
 };
 
+// TODO: these should be broken out into some class info structs, getting unwieldy
 typedef HashMap<String, VariantType> FieldMap;
 typedef HashMap<String, Vector<EnumInfo>> EnumMap;
+typedef HashMap<String, String> FieldTooltipMap;
 
 typedef HashMap<StringHash, FieldMap> ClassFieldMap;
+typedef HashMap<StringHash, FieldTooltipMap> ClassFieldTooltipMap;
 typedef HashMap<StringHash, EnumMap> ClassEnumMap;
 typedef HashMap<StringHash, VariantMap> ClassDefaultValueMap;
+
 
 /// NET Assembly resource.
 class ATOMIC_API ScriptComponentFile : public Resource
 {
-    ATOMIC_OBJECT(ScriptComponentFile, Resource);
+    ATOMIC_OBJECT(ScriptComponentFile, Resource)
 
 public:
 
@@ -66,6 +70,7 @@ public:
     virtual const Vector<String>& GetClassNames() { return classNames_; }
     const EnumMap& GetEnums(const String& classname = String::EMPTY) const;
     const FieldMap& GetFields(const String& classname = String::EMPTY) const;
+    const FieldTooltipMap& GetFieldTooltips(const String& classname = String::EMPTY) const;
     const VariantMap& GetDefaultFieldValues(const String& classname = String::EMPTY) const;
 
     void GetDefaultFieldValue(const String& name, Variant& v,const String& classname = String::EMPTY) const;
@@ -75,7 +80,7 @@ protected:
     void Clear();
 
     void AddEnum(const String& enumName, const EnumInfo& enumInfo, const String& classname = String::EMPTY);
-    void AddField(const String& fieldName, VariantType variantType, const String& classname = String::EMPTY);
+    void AddField(const String& fieldName, VariantType variantType, const String& classname = String::EMPTY, const String& tooltip = String::EMPTY);
     void AddDefaultValue(const String& fieldName, const Variant& value, const String& classname = String::EMPTY);
 
     // only valid in editor
@@ -84,10 +89,12 @@ protected:
 private:
 
     ClassFieldMap classFields_;
+    ClassFieldTooltipMap classFieldTooltips_;
     ClassDefaultValueMap classDefaultFieldValues_;
     ClassEnumMap classEnums_;
 
     static FieldMap emptyFieldMap_;
+    static FieldTooltipMap emptyFieldTooltipMap_;
     static EnumMap emptyEnumMap_;
     static VariantMap emptyDefaultValueMap_;
 

--- a/Source/AtomicJS/Javascript/JSSceneSerializable.cpp
+++ b/Source/AtomicJS/Javascript/JSSceneSerializable.cpp
@@ -241,7 +241,8 @@ static int Serializable_GetAttribute(duk_context* ctx)
 
 static void GetDynamicAttributes(duk_context* ctx, unsigned& count, const VariantMap& defaultFieldValues,
                                  const FieldMap& fields,
-                                 const EnumMap& enums)
+                                 const EnumMap& enums, 
+                                 const FieldTooltipMap& tooltips)
 {
     if (fields.Size())
     {
@@ -280,6 +281,12 @@ static void GetDynamicAttributes(duk_context* ctx, unsigned& count, const Varian
 
             duk_push_boolean(ctx, 1);
             duk_put_prop_string(ctx, -2, "dynamic");
+
+            if (tooltips.Contains(itr->first_))
+            {
+                duk_push_string(ctx, tooltips[itr->first_]->CString());
+                duk_put_prop_string(ctx, -2, "tooltip");
+            }
 
             duk_push_array(ctx);
 
@@ -426,9 +433,10 @@ static int Serializable_GetAttributes(duk_context* ctx)
             const String& className = jsc->GetComponentClassName();
             const VariantMap& defaultFieldValues = file->GetDefaultFieldValues(className);
             const FieldMap& fields =  file->GetFields(className);
+            const FieldTooltipMap& fieldTooltips = file->GetFieldTooltips(className);
             const EnumMap& enums = file->GetEnums(className);
 
-            GetDynamicAttributes(ctx, count, defaultFieldValues, fields, enums);
+            GetDynamicAttributes(ctx, count, defaultFieldValues, fields, enums, fieldTooltips);
         }
     }
 

--- a/Source/AtomicNET/NETScript/CSComponentAssembly.cpp
+++ b/Source/AtomicNET/NETScript/CSComponentAssembly.cpp
@@ -94,6 +94,7 @@ namespace Atomic
                 String typeName = jfield.Get("typeName").GetString();
                 String fieldName = jfield.Get("name").GetString();
                 String defaultValue = jfield.Get("defaultValue").GetString();
+                String tooltip;
 
                 if (!defaultValue.Length())
                 {
@@ -102,11 +103,18 @@ namespace Atomic
                         defaultValue = caPos[0].GetString();
                 }
 
+                JSONObject caNamed = jfield.Get("caNamed").GetObject();
+
                 if (!defaultValue.Length())
-                {
-                    JSONObject caNamed = jfield.Get("caNamed").GetObject();
+                {                    
                     if (caNamed.Contains("DefaultValue"))
                         defaultValue = caNamed["DefaultValue"].GetString();
+                }
+
+                // tooltip
+                if (caNamed.Contains("Tooltip"))
+                {
+                    tooltip = caNamed["Tooltip"].GetString();
                 }
 
                 if (isEnum && assemblyEnums_.Contains(typeName) && !enumsAdded.Contains(fieldName))
@@ -171,7 +179,7 @@ namespace Atomic
                     AddDefaultValue(fieldName, value, className);
                 }
 
-                AddField(fieldName, varType, className);
+                AddField(fieldName, varType, className, tooltip);
 
             }
 


### PR DESCRIPTION
This PR makes it possible to define editor tooltips for C# component inspector fields, for example:

```csharp
public class Spinner : CSComponent
{
    [Inspector(Tooltip = "Sets the yaw rotation speed for the node")]
    float Speed = 1.0f;    

    void Update(float timeStep)
    {
        Node.Yaw(Speed * timeStep * 75.0f);
    }
}
```

![inspectorattrtooltips](https://cloud.githubusercontent.com/assets/376203/21327708/4a54901a-c5e5-11e6-9c17-233bb23ae1d0.PNG)


Closes #1194
