### PR TITLE
EngineConfig issues with deployed applications #1276

### DIFF
--- a/Source/AtomicApp/AppBase.cpp
+++ b/Source/AtomicApp/AppBase.cpp
@@ -61,6 +61,11 @@ namespace Atomic
 
             arguments_ = GetArguments();
         }
+        
+        // Seed the default Settings path
+        FileSystem* fileSystem = GetSubsystem<FileSystem>();
+        String settingspath = fileSystem->GetProgramDir() + "Settings/";
+        AddEngineConfigSearchPath(settingspath);
 
     }
 
@@ -158,12 +163,16 @@ namespace Atomic
 
             String filename = AddTrailingSlash(path) + "Engine.json";
 
-            if (!fileSystem->FileExists(filename))
-                return;
-
-            if (EngineConfig::LoadFromFile(context_, filename))
+            // take the 1st Engine.json found in the paths
+            if (fileSystem->FileExists(filename))
             {
-                EngineConfig::ApplyConfig(engineParameters_);
+
+                if (EngineConfig::LoadFromFile(context_, filename))
+                {
+                    EngineConfig::ApplyConfig(engineParameters_);
+                }
+
+                return;
             }
         }
 

--- a/Source/ToolCore/Build/BuildMac.cpp
+++ b/Source/ToolCore/Build/BuildMac.cpp
@@ -138,6 +138,19 @@ void BuildMac::Build(const String& buildPath)
     if (!BuildCopyFile(appSrcPath + "/Contents/MacOS/AtomicPlayer", buildPath_ + "/Contents/MacOS/AtomicPlayer"))
         return;
 
+    if (!BuildCreateDirectory(buildPath_ + "/Contents/MacOS/Settings"))
+        return;
+
+    String engineJSON(GetSettingsDirectory() + "/Engine.json");
+    
+    if (fileSystem->FileExists(engineJSON))
+    {
+
+        if (!BuildCopyFile(engineJSON, buildPath_ + "/Contents/MacOS/Settings/Engine.json"))
+            return;
+
+    }
+
 #ifdef ATOMIC_PLATFORM_OSX
     Vector<String> args;
     args.Push("+x");


### PR DESCRIPTION
There are TWO versions of ReadEngineConfig()
Version 1 is simple, it looks only in <programdir>/Settings/Engine.json, the classes that use this are : AtomicPlayerApp, NETAtomicPlayer
Version 2 of ReadEngineConfig() searches the engineConfigSearchPaths looking for an existing directory, then looks to see if it has an existing Engine.json if no existing Engine.json it returns!  Classes that will use this are  : AppBase, AEEditorApp, IPCClientApp, NETServiceApplication, PlayerApp, IPCPlayerApp, AEPlayerApplication, NETIPCPlayerApp
IPCPlayerApp is the only class that fills the engineConfigSearchPaths , so it and AEPlayerApplication, NETIPCPlayerApp will seach somewhere.
These classes dont have any paths to search : AppBase, AEEditorApp, IPCClientApp, NETServiceApplication, PlayerApp.

Fixed Version 2 of ReadEngineConfig() to search ALL paths and take the 1st found Engine.json, and in AppBase, seed a default path (the same path as version 1) so all the classes that aren't searching will search for Engine.json 

Also added copying Settings/Engine.json for OSX, but I am unable to test this.



