### PR TITLE
Fix for #1277 - Set the base URL for typescript files

### DIFF
--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
@@ -157,6 +157,9 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
             projectFiles.push(Atomic.addTrailingSlash(Atomic.addTrailingSlash(ToolCore.toolEnvironment.toolDataDir) + "TypeScriptSupport") + "Atomic.d.ts");
         }
 
+        // set the base url
+        compilerOptions["baseUrl"] = ToolCore.toolSystem.project.resourcePath;
+
         let tsConfig = {
             compilerOptions: compilerOptions,
             files: projectFiles


### PR DESCRIPTION
 to be the Resources directory so that you can import non-relative modules.  

Should be able to ```import Foo from “Scripts/Foo”``` in addition to using ```import Foo from "./Foo"```