### PR TITLE
Quick fix for #1301 - TS generated inspector fields blocks

### DIFF
--- a/Source/AtomicJS/Javascript/JSComponentFile.cpp
+++ b/Source/AtomicJS/Javascript/JSComponentFile.cpp
@@ -227,6 +227,11 @@ bool JSComponentFile::BeginLoad(Deserializer& source)
                 added = true;
                 eval = line.Substring(5) + "\n";
             }
+            else if (line.StartsWith("_this.inspectorFields"))
+            {
+                added = true;
+                eval = line.Substring(6) + "\n";
+            }
             else if (line.StartsWith("var inspectorFields"))
             {
                 added = true;


### PR DESCRIPTION
TS now generates the inspector field blocks as ```_this.inspectorFields``` instead of ```this.inspectorFields```.  This looks for this additional pattern when trying to find inspector fields.