### PR TITLE
Convert to TS style enums

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -67,7 +67,7 @@ class Preferences {
 
     addColorHistory(path: string): void {
         var index = this._prefs.colorHistory.indexOf(path);   // search array for entry
-        if (index >= 0) {                                     // if its in there, 
+        if (index >= 0) {                                     // if its in there,
             this._prefs.colorHistory.splice(index, 1);        // REMOVE it.
         }
         this._prefs.colorHistory.unshift(path);               // now add it to beginning of array
@@ -103,7 +103,7 @@ class Preferences {
         }
 
         //Read file
-        jsonFile = new Atomic.File(filePath, Atomic.FILE_READ);
+        jsonFile = new Atomic.File(filePath, Atomic.FileMode.FILE_READ);
 
         var prefs = null;
 
@@ -134,7 +134,7 @@ class Preferences {
 
     write(): boolean {
         var filePath = this.getPreferencesFullPath();
-        var jsonFile = new Atomic.File(filePath, Atomic.FILE_WRITE);
+        var jsonFile = new Atomic.File(filePath, Atomic.FileMode.FILE_WRITE);
         if (!jsonFile.isOpen()) return false;
         jsonFile.writeString(JSON.stringify(this._prefs, null, 2));
     }
@@ -199,7 +199,7 @@ class Preferences {
     loadUserPrefs() {
         const prefsFileLoc = ToolCore.toolSystem.project.userPrefsFullPath;
         if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
-            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
+            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FileMode.FILE_READ);
             try {
                 let prefs = JSON.parse(prefsFile.readText());
                 this._cachedProjectPreferences = prefs;
@@ -246,7 +246,7 @@ class Preferences {
         let prefs = {};
 
         if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
-            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
+            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FileMode.FILE_READ);
             try {
                 prefs = JSON.parse(prefsFile.readText());
             } finally {
@@ -257,7 +257,7 @@ class Preferences {
         prefs[settingsGroup] = prefs[settingsGroup] || {};
         prefs[settingsGroup][preferenceName] = value;
 
-        let saveFile = new Atomic.File(prefsFileLoc, Atomic.FILE_WRITE);
+        let saveFile = new Atomic.File(prefsFileLoc, Atomic.FileMode.FILE_WRITE);
         try {
             saveFile.writeString(JSON.stringify(prefs, null, "  "));
         } finally {
@@ -283,7 +283,7 @@ class Preferences {
         let prefs = {};
 
         if (Atomic.fileSystem.fileExists(prefsFileLoc)) {
-            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FILE_READ);
+            let prefsFile = new Atomic.File(prefsFileLoc, Atomic.FileMode.FILE_READ);
             try {
                 prefs = JSON.parse(prefsFile.readText());
             } finally {
@@ -296,7 +296,7 @@ class Preferences {
             prefs[settingsGroup][preferenceName] = groupPreferenceValues[preferenceName];
         }
 
-        let saveFile = new Atomic.File(prefsFileLoc, Atomic.FILE_WRITE);
+        let saveFile = new Atomic.File(prefsFileLoc, Atomic.FileMode.FILE_WRITE);
         try {
             saveFile.writeString(JSON.stringify(prefs, null, "  "));
         } finally {

--- a/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
+++ b/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
@@ -75,7 +75,7 @@ export default class ProjectBasedExtensionLoader implements Editor.HostExtension
                         console.log(`Searching for project based include: ${path}`);
                         // we have a project based require
                         if (Atomic.fileSystem.fileExists(path)) {
-                            let include = new Atomic.File(path, Atomic.FILE_READ);
+                            let include = new Atomic.File(path, Atomic.FileMode.FILE_READ);
                             try {
                                 return include.readText();
                             } finally {

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts
@@ -115,7 +115,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
         if (Atomic.fileSystem.fileExists(tsconfigFn)) {
             // load up the tsconfig file and parse out the files block and compare it to what we have
             // in resources
-            const file = new Atomic.File(tsconfigFn, Atomic.FILE_READ);
+            const file = new Atomic.File(tsconfigFn, Atomic.FileMode.FILE_READ);
             try {
                 const savedTsConfig = JSON.parse(file.readText());
                 if (savedTsConfig["files"]) {
@@ -368,7 +368,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
       Atomic.getFileSystem().copy(typescriptSupportDir + "Atomic.d.ts", projectDirTypings + "Atomic.d.ts");
 
       // Generate a tsconfig.json file
-      const tsconfigFile = new Atomic.File(projectDir + "tsconfig.json", Atomic.FILE_WRITE);
+      const tsconfigFile = new Atomic.File(projectDir + "tsconfig.json", Atomic.FileMode.FILE_WRITE);
       let tsconfig = {
         compilerOptions: defaultCompilerOptions
       };
@@ -390,7 +390,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
 
      const tasksDir = Atomic.addTrailingSlash(projectDir + ".vscode");
      Atomic.fileSystem.createDir(tasksDir);
-     const tasksFile = new Atomic.File(tasksDir + "tasks.json", Atomic.FILE_WRITE);
+     const tasksFile = new Atomic.File(tasksDir + "tasks.json", Atomic.FileMode.FILE_WRITE);
      tasksFile.writeString(JSON.stringify(tasks, null, 4));
      tasksFile.close();
 

--- a/Script/AtomicEditor/resources/ProjectTemplates.ts
+++ b/Script/AtomicEditor/resources/ProjectTemplates.ts
@@ -50,7 +50,7 @@ export function getNewProjectTemplateDefinition(projectType: string): ProjectTem
     let exampleInfoDir = env.toolDataDir + "ExampleInfo/";
     var projectTemplateFolder = env.toolDataDir + "ProjectTemplates/";
     var projectTemplateJsonFile = projectTemplateFolder + "ProjectTemplates.json";
-    let jsonFile = new Atomic.File(projectTemplateJsonFile, Atomic.FILE_READ);
+    let jsonFile = new Atomic.File(projectTemplateJsonFile, Atomic.FileMode.FILE_READ);
 
     if (!jsonFile.isOpen()) {
         return null;
@@ -90,7 +90,7 @@ export function getExampleProjectTemplateDefinitions(): [ProjectTemplateDefiniti
     let fileSystem = Atomic.fileSystem;
     let exampleInfoDir = env.toolDataDir + "ExampleInfo/";
     let exampleJsonFile = exampleInfoDir + "Examples.json";
-    let jsonFile = new Atomic.File(exampleJsonFile, Atomic.FILE_READ);
+    let jsonFile = new Atomic.File(exampleJsonFile, Atomic.FileMode.FILE_READ);
 
     if (!jsonFile.isOpen()) {
         return;
@@ -127,7 +127,7 @@ export function getExampleProjectTemplateDefinitions(): [ProjectTemplateDefiniti
             return;
         }
 
-        jsonFile = new Atomic.File(exampleJsonFilename, Atomic.FILE_READ);
+        jsonFile = new Atomic.File(exampleJsonFilename, Atomic.FileMode.FILE_READ);
 
         if (!jsonFile.isOpen()) {
             console.log("Unable to open example json", exampleJsonFilename);
@@ -205,7 +205,7 @@ var atomicNETProjectInfo:AtomicNETProjectInfo;
  */
 function processAtomicNETTemplate(filename:string, templateFilename:string) : boolean {
 
-    let file = new Atomic.File(templateFilename, Atomic.FILE_READ);
+    let file = new Atomic.File(templateFilename, Atomic.FileMode.FILE_READ);
 
     if (!file.isOpen()) {
         console.log("Failed to open: ", templateFilename);
@@ -229,7 +229,7 @@ function processAtomicNETTemplate(filename:string, templateFilename:string) : bo
     text = text.split("$$APPLICATION_APPDELEGATECLASS$$").join(appDelegateClass);
     text = text.split("$$APPLICATION_NAMESPACE$$").join(_namespace);
 
-    let fileOut = new Atomic.File(filename, Atomic.FILE_WRITE);
+    let fileOut = new Atomic.File(filename, Atomic.FileMode.FILE_WRITE);
 
     if (!fileOut.isOpen()) {
         console.log("Failed to open for write: ", filename);

--- a/Script/AtomicEditor/resources/ResourceOps.ts
+++ b/Script/AtomicEditor/resources/ResourceOps.ts
@@ -63,7 +63,7 @@ class ResourceOps extends Atomic.ScriptObject {
                 return;
             }
 
-            var jsonFile = new Atomic.File(exampleInfoPath, Atomic.FILE_READ);
+            var jsonFile = new Atomic.File(exampleInfoPath, Atomic.FileMode.FILE_READ);
 
             if (!jsonFile.isOpen()) {
                 return;
@@ -160,7 +160,7 @@ export function CreateNewComponent(resourcePath: string, componentName: string, 
 
     }
 
-    var out = new Atomic.File(resourcePath, Atomic.FILE_WRITE);
+    var out = new Atomic.File(resourcePath, Atomic.FileMode.FILE_WRITE);
     var success = out.copy(file);
     out.close();
 
@@ -200,7 +200,7 @@ export function CreateNewScript(resourcePath: string, scriptName: string, templa
 
     }
 
-    var out = new Atomic.File(resourcePath, Atomic.FILE_WRITE);
+    var out = new Atomic.File(resourcePath, Atomic.FileMode.FILE_WRITE);
     var success = out.copy(file);
     out.close();
 
@@ -240,7 +240,7 @@ export function CreateNewScene(resourcePath: string, sceneName: string, reportEr
 
     }
 
-    var out = new Atomic.File(resourcePath, Atomic.FILE_WRITE);
+    var out = new Atomic.File(resourcePath, Atomic.FileMode.FILE_WRITE);
     var success = out.copy(file);
     out.close();
 
@@ -280,7 +280,7 @@ export function CreateNewMaterial(resourcePath: string, materialName: string, re
 
     }
 
-    var out = new Atomic.File(resourcePath, Atomic.FILE_WRITE);
+    var out = new Atomic.File(resourcePath, Atomic.FileMode.FILE_WRITE);
     var success = out.copy(file);
     out.close();
 

--- a/Script/AtomicEditor/ui/AnimationToolbar.ts
+++ b/Script/AtomicEditor/ui/AnimationToolbar.ts
@@ -78,7 +78,7 @@ class AnimationToolbar extends Atomic.UIWidget {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
             if (this.animationController != null) {
 
                 if (ev.target.id == "play_left") {

--- a/Script/AtomicEditor/ui/MainToolbar.ts
+++ b/Script/AtomicEditor/ui/MainToolbar.ts
@@ -125,7 +125,7 @@ class MainToolbar extends Atomic.UIWidget {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK && ev.target) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK && ev.target) {
 
             if (ev.target.id == "3d_translate" || ev.target.id == "3d_rotate" || ev.target.id == "3d_scale") {
 

--- a/Script/AtomicEditor/ui/ScriptWidget.ts
+++ b/Script/AtomicEditor/ui/ScriptWidget.ts
@@ -42,7 +42,7 @@ class ScriptWidget extends Atomic.UIWidget {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             return this.onEventClick(ev.target, ev.refid);
 

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -161,7 +161,7 @@ class Shortcuts extends Atomic.ScriptObject {
         var editor = EditorUI.getCurrentResourceEditor();
 
         if (editor && editor instanceof Editor.SceneEditor3D) {
-            var mode = editor.getGizmo().axisMode ? Editor.AXIS_WORLD : Editor.AXIS_LOCAL;
+            var mode = editor.getGizmo().axisMode ? Editor.AxisMode.AXIS_WORLD : Editor.AxisMode.AXIS_LOCAL;
             this.sendEvent("GizmoAxisModeChanged", { mode: mode });
         }
     }
@@ -184,11 +184,11 @@ class Shortcuts extends Atomic.ScriptObject {
             if (!Atomic.ui.focusedWidget && !this.cmdKeyDown()) {
 
                 if (ev.key == Atomic.KEY_W) {
-                    this.invokeGizmoEditModeChanged(Editor.EDIT_MOVE);
+                    this.invokeGizmoEditModeChanged(Editor.EditMode.EDIT_MOVE);
                 } else if (ev.key == Atomic.KEY_E) {
-                    this.invokeGizmoEditModeChanged(Editor.EDIT_ROTATE);
+                    this.invokeGizmoEditModeChanged(Editor.EditMode.EDIT_ROTATE);
                 } else if (ev.key == Atomic.KEY_R) {
-                    this.invokeGizmoEditModeChanged(Editor.EDIT_SCALE);
+                    this.invokeGizmoEditModeChanged(Editor.EditMode.EDIT_SCALE);
                 } else if (ev.key == Atomic.KEY_X) {
                     this.toggleGizmoAxisMode();
                 } else if (ev.key == Atomic.KEY_F) {
@@ -219,8 +219,7 @@ class Shortcuts extends Atomic.ScriptObject {
 
         var cmdKey = this.cmdKeyDown();
 
-        if ( !cmdKey && ev.qualifiers > 0 ) // check the event, the qualifier may have been programmitically set
-        {
+        if ( !cmdKey && ev.qualifiers > 0 ) { // check the event, the qualifier may have been programmitically set
             cmdKey = ( ev.qualifiers == Atomic.QUAL_CTRL );
         }
 

--- a/Script/AtomicEditor/ui/frames/HierarchyFrame.ts
+++ b/Script/AtomicEditor/ui/frames/HierarchyFrame.ts
@@ -49,7 +49,7 @@ class HierarchyFrame extends Atomic.UIWidget {
 
         this.load("AtomicEditor/editor/ui/hierarchyframe.tb.txt");
 
-        this.gravity = Atomic.UI_GRAVITY_TOP_BOTTOM;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_TOP_BOTTOM;
 
         this.searchEdit = <Atomic.UIEditField>this.getWidget("filter");
 
@@ -423,7 +423,7 @@ class HierarchyFrame extends Atomic.UIWidget {
 
         if (!this.scene) return;
 
-        if (data.type == Atomic.UI_EVENT_TYPE_KEY_UP) {
+        if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_KEY_UP) {
 
             // activates search while user is typing in search widget
             if (data.target == this.searchEdit) {
@@ -441,7 +441,7 @@ class HierarchyFrame extends Atomic.UIWidget {
                 this.sceneEditor.selection.delete();
             }
 
-        } else if (data.type == Atomic.UI_EVENT_TYPE_POINTER_DOWN) {
+        } else if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_POINTER_DOWN) {
 
             if (data.target == this.hierList.rootList) {
 
@@ -457,7 +457,7 @@ class HierarchyFrame extends Atomic.UIWidget {
 
             }
 
-        } else if (data.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        } else if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (this.menu.handleNodeContextMenu(data.target, data.refid, this.sceneEditor)) {
                 return true;
@@ -505,7 +505,7 @@ class HierarchyFrame extends Atomic.UIWidget {
             }
 
 
-        } else if (data.type == Atomic.UI_EVENT_TYPE_RIGHT_POINTER_UP) {
+        } else if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_RIGHT_POINTER_UP) {
 
             var id = data.target.id;
             var node: Atomic.Node;

--- a/Script/AtomicEditor/ui/frames/MainFrame.ts
+++ b/Script/AtomicEditor/ui/frames/MainFrame.ts
@@ -46,7 +46,7 @@ class MainFrame extends ScriptWidget {
 
         this.inspectorlayout = <Atomic.UILayout> this.getWidget("inspectorlayout");
 
-        this.getWidget("consolecontainer").visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+        this.getWidget("consolecontainer").visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
 
         this.inspectorframe = new InspectorFrame();
         this.inspectorlayout.addChild(this.inspectorframe);
@@ -96,13 +96,13 @@ class MainFrame extends ScriptWidget {
 
         if (show) {
             this.showInspectorFrame(false);
-            this.welcomeFrame.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
-            this.resourceframe.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.welcomeFrame.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
+            this.resourceframe.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
         }
         else {
             this.showInspectorFrame(true);
-            this.resourceframe.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
-            this.welcomeFrame.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.resourceframe.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
+            this.welcomeFrame.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
         }
 
     }
@@ -111,13 +111,13 @@ class MainFrame extends ScriptWidget {
 
         if (show) {
 
-            this.inspectorlayout.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
-            this.inspectorframe.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+            this.inspectorlayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
+            this.inspectorframe.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
 
         } else {
 
-            this.inspectorframe.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
-            this.inspectorlayout.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.inspectorframe.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
+            this.inspectorlayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
 
         }
 
@@ -143,13 +143,13 @@ class MainFrame extends ScriptWidget {
     }
 
     disableProjectMenus() {
-        this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
-        this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE_DISABLED);
+        this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE.UI_WIDGET_STATE_DISABLED);
+        this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE.UI_WIDGET_STATE_DISABLED);
     }
 
     enableProjectMenus() {
-        this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
-        this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE_NONE);
+        this.getWidget("menu edit").setStateRaw(Atomic.UI_WIDGET_STATE.UI_WIDGET_STATE_NONE);
+        this.getWidget("menu build").setStateRaw(Atomic.UI_WIDGET_STATE.UI_WIDGET_STATE_NONE);
     }
 
     shutdown() {

--- a/Script/AtomicEditor/ui/frames/ProjectFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ProjectFrame.ts
@@ -51,7 +51,7 @@ class ProjectFrame extends ScriptWidget {
 
         this.load("AtomicEditor/editor/ui/projectframe.tb.txt");
 
-        this.gravity = Atomic.UI_GRAVITY_TOP_BOTTOM;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_TOP_BOTTOM;
 
         this.searchEdit = <Atomic.UIEditField>this.getWidget("filter");
 
@@ -167,19 +167,19 @@ class ProjectFrame extends ScriptWidget {
 
         if (!ToolCore.toolSystem.project) return;
 
-        if (data.type == Atomic.UI_EVENT_TYPE_KEY_UP) {
+        if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_KEY_UP) {
 
             // Activates search while user is typing in search widget
             if (data.target == this.searchEdit) {
 
-                if (data.type == Atomic.UI_EVENT_TYPE_KEY_UP) {
+                if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_KEY_UP) {
                     this.search = true;
                     this.refreshContent(this.currentFolder);
                 }
             }
         }
 
-        if (data.type == Atomic.UI_EVENT_TYPE_RIGHT_POINTER_UP) {
+        if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_RIGHT_POINTER_UP) {
 
             var id = data.target.id;
             var db = ToolCore.getAssetDatabase();
@@ -200,7 +200,7 @@ class ProjectFrame extends ScriptWidget {
 
         }
 
-        if (data.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (data.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = data.target.id;
 
@@ -366,7 +366,7 @@ class ProjectFrame extends ScriptWidget {
             else {
                 var destFilename = Atomic.addTrailingSlash(asset.path);
                 destFilename += node.name + ".prefab";
-                var file = new Atomic.File(destFilename, Atomic.FILE_WRITE);
+                var file = new Atomic.File(destFilename, Atomic.FileMode.FILE_WRITE);
                 node.saveXML(file);
                 file.close();
             }
@@ -529,7 +529,7 @@ class ProjectFrame extends ScriptWidget {
         var blayout = new Atomic.UILayout();
         blayout.id = asset.guid;
 
-        blayout.gravity = Atomic.UI_GRAVITY_LEFT;
+        blayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT;
 
         var spacer = new Atomic.UIWidget();
         spacer.rect = [0, 0, 8, 8];
@@ -561,11 +561,11 @@ class ProjectFrame extends ScriptWidget {
         fd.id = "Vera";
         fd.size = 11;
 
-        button.gravity = Atomic.UI_GRAVITY_LEFT;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT;
 
         var image = new Atomic.UISkinImage(bitmapID);
         image.rect = [0, 0, 12, 12];
-        image.gravity = Atomic.UI_GRAVITY_RIGHT;
+        image.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_RIGHT;
         blayout.addChild(image);
         image["asset"] = asset;
 

--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -210,7 +210,7 @@ class ResourceFrame extends ScriptWidget {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_TAB_CHANGED && ev.target == this.tabcontainer) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_TAB_CHANGED && ev.target == this.tabcontainer) {
 
             var w = <EditorRootContentWidget> this.tabcontainer.currentPageWidget;
 
@@ -232,7 +232,7 @@ class ResourceFrame extends ScriptWidget {
 
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_POINTER_UP) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_POINTER_UP) {
             this.wasClosed = false;
         }
 
@@ -268,7 +268,7 @@ class ResourceFrame extends ScriptWidget {
 
         this.load("AtomicEditor/editor/ui/resourceframe.tb.txt");
 
-        this.gravity = Atomic.UI_GRAVITY_ALL;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
 
         this.resourceViewContainer = <Atomic.UILayout> parent.getWidget("resourceviewcontainer");
         this.tabcontainer = <Atomic.UITabContainer> this.getWidget("tabcontainer");

--- a/Script/AtomicEditor/ui/frames/WelcomeFrame.ts
+++ b/Script/AtomicEditor/ui/frames/WelcomeFrame.ts
@@ -45,7 +45,7 @@ class WelcomeFrame extends ScriptWidget {
         this.examplesJavaScript.onClick = () => { this.handleExampleFilter(); };
         this.examplesTypeScript.onClick = () => { this.handleExampleFilter(); };
 
-        this.gravity = Atomic.UI_GRAVITY_ALL;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
 
         this.recentList = new Atomic.UIListView();
         this.recentList.rootList.id = "recentList";
@@ -116,9 +116,9 @@ class WelcomeFrame extends ScriptWidget {
 
         var exampleLayout = new Atomic.UILayout();
         exampleLayout.skinBg = "StarCondition";
-        exampleLayout.axis = Atomic.UI_AXIS_Y;
-        exampleLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        exampleLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
+        exampleLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        exampleLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        exampleLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
 
         // IMAGE BUTTON
 
@@ -149,7 +149,7 @@ class WelcomeFrame extends ScriptWidget {
 
         nameField.rect = nameRect;
 
-        nameField.gravity = Atomic.UI_GRAVITY_BOTTOM;
+        nameField.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_BOTTOM;
 
         image.addChild(nameField);
 
@@ -161,7 +161,7 @@ class WelcomeFrame extends ScriptWidget {
 
         button.layoutParams = lp;
 
-        button.gravity = Atomic.UI_GRAVITY_LEFT;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT;
 
         exampleLayout.addChild(button);
 
@@ -217,13 +217,13 @@ class WelcomeFrame extends ScriptWidget {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_RIGHT_POINTER_UP) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_RIGHT_POINTER_UP) {
             if (ev.target.id == "recentList") {
                 this.openFrameMenu(ev.x, ev.y);
             }
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/frames/inspector/ArrayEditWidget.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/ArrayEditWidget.ts
@@ -33,12 +33,12 @@ class ArrayEditWidget extends Atomic.UILayout {
 
         this.spacing = 4;
 
-        this.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        this.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        this.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        this.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         this.layoutParams = nlp;
-        this.axis = Atomic.UI_AXIS_Y;
+        this.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
-        this.gravity = Atomic.UI_GRAVITY_ALL;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
 
         var countEdit = this.countEdit = InspectorUtils.createAttrEditField(title, this);
 

--- a/Script/AtomicEditor/ui/frames/inspector/AssemblyInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/AssemblyInspector.ts
@@ -54,13 +54,13 @@ class AssemblyInspector extends InspectorWidget {
         var assemblyFile = <AtomicNETScript.CSComponentAssembly> asset.importer.getResource();
 
         var container = InspectorUtils.createContainer();
-        container.gravity = Atomic.UI_GRAVITY_ALL;
+        container.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
         assemblyLayout.addChild(container);
 
         var panel = new Atomic.UILayout();
-        panel.axis = Atomic.UI_AXIS_Y;
-        panel.layoutSize = Atomic.UI_LAYOUT_SIZE_PREFERRED;
-        panel.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        panel.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        panel.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_PREFERRED;
+        panel.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         container.addChild(panel);
 
         var label = InspectorUtils.createAttrName("CSComponents:");

--- a/Script/AtomicEditor/ui/frames/inspector/AttributeInfoEdit.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/AttributeInfoEdit.ts
@@ -72,19 +72,19 @@ class AttributeInfoEdit extends Atomic.UILayout {
         var attr = this.attrInfo;
         var attrNameLP = AttributeInfoEdit.attrNameLP;
 
-        this.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        this.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
-        if (attr.type == Atomic.VAR_VECTOR3 || attr.type == Atomic.VAR_COLOR ||
-            attr.type == Atomic.VAR_QUATERNION) {
-            this.axis = Atomic.UI_AXIS_Y;
-            this.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        if (attr.type == Atomic.VariantType.VAR_VECTOR3 || attr.type == Atomic.VariantType.VAR_COLOR ||
+            attr.type == Atomic.VariantType.VAR_QUATERNION) {
+            this.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+            this.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
             this.skinBg = "InspectorVectorAttrLayout";
         }
 
         if (!this.hideName) {
 
             var name = new Atomic.UITextField();
-            name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+            name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
             name.skinBg = "InspectorTextAttrName";
             name.layoutParams = attrNameLP;
             var bname = attr.name;
@@ -210,7 +210,7 @@ class BoolAttributeEdit extends AttributeInfoEdit {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             this.editType.onAttributeInfoEdited(this.attrInfo, this.editWidget.value ? true : false);
             this.refresh();
@@ -229,7 +229,7 @@ class StringAttributeEdit extends AttributeInfoEdit {
     createEditWidget() {
 
         var field = new Atomic.UIEditField();
-        field.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        field.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         field.skinBg = "TBAttrEditorField";
         field.fontDescription = AttributeInfoEdit.fontDesc;
         var lp = new Atomic.UILayoutParams();
@@ -271,7 +271,7 @@ class StringAttributeEdit extends AttributeInfoEdit {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             return true;
         }
@@ -313,7 +313,7 @@ class IntAttributeEdit extends AttributeInfoEdit {
 
 
             var field = new Atomic.UIEditField();
-            field.textAlign = Atomic.UI_TEXT_ALIGN_CENTER;
+            field.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_CENTER;
             field.skinBg = "TBAttrEditorField";
             field.fontDescription = AttributeInfoEdit.fontDesc;
             var lp = new Atomic.UILayoutParams();
@@ -366,12 +366,12 @@ class IntAttributeEdit extends AttributeInfoEdit {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             return true;
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = this.attrInfo.name + " enum popup";
 
@@ -409,7 +409,7 @@ class FloatAttributeEdit extends AttributeInfoEdit {
         var attrInfo = this.attrInfo;
 
         var field = new Atomic.UIEditField();
-        field.textAlign = Atomic.UI_TEXT_ALIGN_CENTER;
+        field.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_CENTER;
         field.skinBg = "TBAttrEditorField";
         field.fontDescription = AttributeInfoEdit.fontDesc;
         var lp = new Atomic.UILayoutParams();
@@ -464,7 +464,7 @@ class FloatAttributeEdit extends AttributeInfoEdit {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             return true;
         }
@@ -570,7 +570,7 @@ class NumberArrayAttributeEdit extends AttributeInfoEdit {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             var captured = false;
             for (var i in this.selects) {
@@ -641,9 +641,9 @@ class ColorAttributeEdit extends AttributeInfoEdit {
         var colorWidget = this.colorWidget = o.colorWidget;
         var selectButton = o.selectButton;
 
-        layout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-        layout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        layout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+        layout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
 
         var lp = new Atomic.UILayoutParams();
@@ -844,7 +844,7 @@ class ResourceRefAttributeEdit extends AttributeInfoEdit {
 
                 this.editField.subscribeToEvent(this.editField, "WidgetEvent", (ev: Atomic.UIWidgetEvent) => {
 
-                    if (ev.type == Atomic.UI_EVENT_TYPE_POINTER_DOWN) {
+                    if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_POINTER_DOWN) {
 
                         resource = <Atomic.Resource>object.getAttribute(this.attrInfo.name);
 
@@ -887,9 +887,9 @@ class ResourceRefAttributeEdit extends AttributeInfoEdit {
         var o = InspectorUtils.createAttrEditFieldWithSelectButton("", layout);
         this.editField = o.editField;
 
-        layout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-        layout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        layout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+        layout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var lp = new Atomic.UILayoutParams();
         lp.width = 140;
@@ -995,12 +995,12 @@ class ResourceRefListAttributeEdit extends AttributeInfoEdit {
 
         var layout = this.layout = new Atomic.UILayout();
 
-        layout.axis = Atomic.UI_AXIS_Y;
+        layout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
         layout.spacing = 2;
-        layout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-        layout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        layout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+        layout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var lp = new Atomic.UILayoutParams();
         lp.width = 304;
@@ -1081,11 +1081,11 @@ class ResourceRefListAttributeEdit extends AttributeInfoEdit {
         var object = this.editType.getFirstObject();
 
         if (!object) {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             return;
         }
 
-        this.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+        this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
 
         var maxLength = -1;
         var i;
@@ -1104,7 +1104,7 @@ class ResourceRefListAttributeEdit extends AttributeInfoEdit {
         this.sizeEdit.text = maxLength.toString();
 
         if (maxLength == -1) {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             return;
         }
 
@@ -1119,11 +1119,11 @@ class ResourceRefListAttributeEdit extends AttributeInfoEdit {
             var refEdit = this.refEdits[i];
 
             if (i < maxLength) {
-                refEdit.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+                refEdit.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
                 refEdit.refresh();
             }
             else {
-                refEdit.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+                refEdit.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             }
 
         }
@@ -1133,18 +1133,18 @@ class ResourceRefListAttributeEdit extends AttributeInfoEdit {
 
 
 
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_BOOL] = BoolAttributeEdit;
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_INT] = IntAttributeEdit;
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_FLOAT] = FloatAttributeEdit;
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_STRING] = StringAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_BOOL] = BoolAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_INT] = IntAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_FLOAT] = FloatAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_STRING] = StringAttributeEdit;
 
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_VECTOR2] = Vector2AttributeEdit;
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_VECTOR3] = Vector3AttributeEdit;
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_QUATERNION] = QuaternionAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_VECTOR2] = Vector2AttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_VECTOR3] = Vector3AttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_QUATERNION] = QuaternionAttributeEdit;
 
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_COLOR] = ColorAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_COLOR] = ColorAttributeEdit;
 
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_RESOURCEREF] = ResourceRefAttributeEdit;
-AttributeInfoEdit.standardAttrEditTypes[Atomic.VAR_RESOURCEREFLIST] = ResourceRefListAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_RESOURCEREF] = ResourceRefAttributeEdit;
+AttributeInfoEdit.standardAttrEditTypes[Atomic.VariantType.VAR_RESOURCEREFLIST] = ResourceRefListAttributeEdit;
 
 export = AttributeInfoEdit;

--- a/Script/AtomicEditor/ui/frames/inspector/CSComponentClassSelector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/CSComponentClassSelector.ts
@@ -35,21 +35,21 @@ class CSComponentClassSelector extends Atomic.UIWindow {
         this.rect = [0, 0, 400, 512];
 
         var mainLayout = new Atomic.UILayout();
-        mainLayout.gravity = Atomic.UI_GRAVITY_ALL;
-        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
-        mainLayout.axis = Atomic.UI_AXIS_Y;
+        mainLayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
+        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
+        mainLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
         this.contentRoot.addChild(mainLayout);
 
         // really want a grid container
         var scrollContainer = new Atomic.UIScrollContainer();
-        scrollContainer.gravity = Atomic.UI_GRAVITY_ALL;
-        scrollContainer.scrollMode = Atomic.UI_SCROLL_MODE_Y_AUTO;
+        scrollContainer.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
+        scrollContainer.scrollMode = Atomic.UI_SCROLL_MODE.UI_SCROLL_MODE_Y_AUTO;
         scrollContainer.adaptContentSize = true;
 
         var scrollLayout = new Atomic.UILayout();
-        scrollLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        scrollLayout.layoutDistributionPosition = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
-        scrollLayout.axis = Atomic.UI_AXIS_Y;
+        scrollLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        scrollLayout.layoutDistributionPosition = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+        scrollLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
         scrollContainer.contentRoot.addChild(scrollLayout);
 
@@ -82,7 +82,7 @@ class CSComponentClassSelector extends Atomic.UIWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target != this && !this.isAncestorOf(ev.target)) {
 

--- a/Script/AtomicEditor/ui/frames/inspector/ColorChooser.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/ColorChooser.ts
@@ -144,7 +144,7 @@ class ColorChooser extends Atomic.UIWindow {
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
         let changed = false;
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
             let hsltargets = ["colorwheel", "lslider"];
             let rgbtargets = {
                 "redselect" : 0,
@@ -177,7 +177,7 @@ class ColorChooser extends Atomic.UIWindow {
             }
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if ( ev.target.id == "history0" || ev.target.id == "history1"
                     || ev.target.id == "history2" || ev.target.id == "history3"

--- a/Script/AtomicEditor/ui/frames/inspector/ComponentAttributeUI.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/ComponentAttributeUI.ts
@@ -33,9 +33,9 @@ class LightCascadeAttributeEdit extends AttributeInfoEdit {
     createEditWidget() {
 
         var panel = new Atomic.UILayout();
-        panel.axis = Atomic.UI_AXIS_Y;
-        panel.layoutSize = Atomic.UI_LAYOUT_SIZE_PREFERRED;
-        panel.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        panel.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        panel.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_PREFERRED;
+        panel.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
 
         var lp = new Atomic.UILayoutParams();
         lp.width = 180;
@@ -108,7 +108,7 @@ class LightCascadeAttributeEdit extends AttributeInfoEdit {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             return true;
         }
@@ -239,7 +239,7 @@ class SubmeshAttributeEdit extends AttributeInfoEdit {
 
         o.editField.subscribeToEvent(o.editField, "WidgetEvent", (ev: Atomic.UIWidgetEvent) => {
 
-            if (ev.type == Atomic.UI_EVENT_TYPE_POINTER_DOWN && o.editField.text != "") {
+            if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_POINTER_DOWN && o.editField.text != "") {
 
                 var pathName = materialEdit.pathReference;
                 this.sendEvent(EditorEvents.InspectorProjectReference, { "path": pathName });
@@ -255,18 +255,18 @@ class SubmeshAttributeEdit extends AttributeInfoEdit {
     createEditWidget() {
 
         var mainLayout = this.mainLayout = new Atomic.UILayout();
-        mainLayout.axis = Atomic.UI_AXIS_Y;
-        mainLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-        mainLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        mainLayout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        mainLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        mainLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+        mainLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        mainLayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var cb = InspectorUtils.createAttrCheckBox(this.name, mainLayout);
         this.enabledCheckBox = cb.checkBox;
 
         cb.checkBox.subscribeToEvent(cb.checkBox, "WidgetEvent", (ev: Atomic.UIWidgetEvent) => {
 
-            if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+            if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
                 var scene: Atomic.Scene;
 
@@ -312,11 +312,11 @@ class SubmeshAttributeEdit extends AttributeInfoEdit {
         var object = this.editType.getFirstObject();
 
         if (!object) {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             return;
         }
 
-        this.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+        this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
 
         var enabled = (<Atomic.StaticModel>object).getGeometryVisible(this.name);
         var mixed = false;
@@ -417,19 +417,19 @@ class SubmeshListAttributeEdit extends AttributeInfoEdit {
 
         var layout = this.layout = new Atomic.UILayout();
 
-        layout.axis = Atomic.UI_AXIS_Y;
+        layout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
         layout.spacing = 2;
-        layout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        layout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        layout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        layout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var lp = new Atomic.UILayoutParams();
         lp.width = 304;
         layout.layoutParams = lp;
 
         var name = new Atomic.UITextField();
-        name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         name.skinBg = "InspectorTextAttrName";
         name.layoutParams = AttributeInfoEdit.attrNameLP;
         name.text = "Submeshes";
@@ -449,11 +449,11 @@ class SubmeshListAttributeEdit extends AttributeInfoEdit {
         var object = this.editType.getFirstObject();
 
         if (!object) {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             return;
         }
 
-        this.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+        this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
 
         var name: string;
         for (var i in editType.objects) {

--- a/Script/AtomicEditor/ui/frames/inspector/CreateComponentButton.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/CreateComponentButton.ts
@@ -147,7 +147,7 @@ class CreateComponentButton extends Atomic.UIButton {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type != Atomic.UI_EVENT_TYPE_CLICK)
+        if (ev.type != Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK)
             return;
 
         if (ev.target && ev.target.id == "create component popup") {

--- a/Script/AtomicEditor/ui/frames/inspector/InspectorFrame.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorFrame.ts
@@ -48,7 +48,7 @@ class InspectorFrame extends ScriptWidget {
 
         super();
 
-        this.gravity = Atomic.UI_GRAVITY_TOP_BOTTOM;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_TOP_BOTTOM;
 
         this.load("AtomicEditor/editor/ui/inspectorframe.tb.txt");
 

--- a/Script/AtomicEditor/ui/frames/inspector/InspectorUtils.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorUtils.ts
@@ -34,7 +34,7 @@ class InspectorUtils {
 
     var sep = new Atomic.UISeparator();
 
-    sep.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
+    sep.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
     sep.skinBg = "AESeparator";
 
     parent.addChild(sep);
@@ -55,7 +55,7 @@ class InspectorUtils {
   static createAttrName(name:string):Atomic.UITextField {
 
     var nameField = new Atomic.UITextField();
-    nameField.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+    nameField.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
     nameField.skinBg = "InspectorTextAttrName";
     nameField.text = name;
     nameField.fontDescription = InspectorUtils.attrFontDesc;
@@ -72,7 +72,7 @@ class InspectorUtils {
 
     var edit = new Atomic.UIEditField();
     edit.id = "editfield";
-    edit.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+    edit.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
     edit.skinBg = "TBAttrEditorField";
     edit.fontDescription = InspectorUtils.attrFontDesc;
     var lp = new Atomic.UILayoutParams();
@@ -103,9 +103,9 @@ class InspectorUtils {
 
     var attrLayout = new Atomic.UILayout();
 
-    attrLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-    attrLayout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+    attrLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+    attrLayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
     var _name = InspectorUtils.createAttrName(name);
     attrLayout.addChild(_name);
@@ -123,9 +123,9 @@ class InspectorUtils {
 
     var attrLayout = new Atomic.UILayout();
 
-    attrLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
-    attrLayout.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
-    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+    attrLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
+    attrLayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
+    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
     var _name = InspectorUtils.createAttrName(name);
     attrLayout.addChild(_name);
@@ -143,7 +143,7 @@ class InspectorUtils {
   static createAttrEditFieldWithSelectButton(name:string, parent:Atomic.UIWidget):{editField:Atomic.UIEditField, selectButton:Atomic.UIButton} {
 
     var attrLayout = new Atomic.UILayout();
-    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
 
     if (name) {
       var _name = InspectorUtils.createAttrName(name);
@@ -151,7 +151,7 @@ class InspectorUtils {
     }
 
     var fieldLayout = new Atomic.UILayout();
-    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
 
     var edit = InspectorUtils.createEditField();
 
@@ -172,7 +172,7 @@ class InspectorUtils {
   static createAttrColorFieldWithSelectButton(name:string, parent:Atomic.UIWidget):{colorWidget:Atomic.UIColorWidget, selectButton:Atomic.UIButton} {
 
     var attrLayout = new Atomic.UILayout();
-    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
 
     if (name) {
       var _name = InspectorUtils.createAttrName(name);
@@ -180,7 +180,7 @@ class InspectorUtils {
     }
 
     var fieldLayout = new Atomic.UILayout();
-    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
+    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
 
     var colorWidget = InspectorUtils.createColorWidget();
 

--- a/Script/AtomicEditor/ui/frames/inspector/InspectorWidget.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorWidget.ts
@@ -40,12 +40,12 @@ class InspectorWidget extends ScriptWidget {
         var layout = this.rootLayout = new Atomic.UILayout();
         layout.spacing = 4;
 
-        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        layout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        layout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         layout.layoutParams = nlp;
-        layout.axis = Atomic.UI_AXIS_Y;
+        layout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
-        this.gravity = Atomic.UI_GRAVITY_ALL;
+        this.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
         this.addChild(layout);
 
         this.subscribeToEvent("WidgetEvent", (data) => this.handleWidgetEvent(data));
@@ -59,7 +59,7 @@ class InspectorWidget extends ScriptWidget {
     createAttrName(name:string):Atomic.UITextField {
 
       var nameField = new Atomic.UITextField();
-      nameField.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+      nameField.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
       nameField.skinBg = "InspectorTextAttrName";
       nameField.text = name;
       nameField.fontDescription = this.attrFontDesc;
@@ -84,10 +84,10 @@ class InspectorWidget extends ScriptWidget {
 
     createVerticalAttrLayout():Atomic.UILayout {
 
-      var layout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+      var layout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
       layout.spacing = 3;
-      layout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-      layout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
+      layout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+      layout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
 
       return layout;
 
@@ -97,7 +97,7 @@ class InspectorWidget extends ScriptWidget {
 
       var button = new Atomic.UIButton();
       button.fontDescription = this.attrFontDesc;
-      button.gravity = Atomic.UI_GRAVITY_RIGHT;
+      button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_RIGHT;
       button.text = "Apply";
 
       button.onClick = function() {
@@ -113,7 +113,7 @@ class InspectorWidget extends ScriptWidget {
     createAttrCheckBox(name:string, parent:Atomic.UIWidget):Atomic.UICheckBox {
 
       var attrLayout = new Atomic.UILayout();
-      attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+      attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
       var _name = this.createAttrName(name);
       attrLayout.addChild(_name);
@@ -130,13 +130,13 @@ class InspectorWidget extends ScriptWidget {
     createAttrEditField(name:string, parent:Atomic.UIWidget):Atomic.UIEditField {
 
       var attrLayout = new Atomic.UILayout();
-      attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+      attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
       var _name = this.createAttrName(name);
       attrLayout.addChild(_name);
 
       var edit = new Atomic.UIEditField();
-      edit.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+      edit.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
       edit.skinBg = "TBAttrEditorField";
       edit.fontDescription = this.attrFontDesc;
       var lp = new Atomic.UILayoutParams();
@@ -160,7 +160,7 @@ class InspectorWidget extends ScriptWidget {
 
         var button = new Atomic.UIButton();
         button.fontDescription = this.attrFontDesc;
-        button.gravity = Atomic.UI_GRAVITY_RIGHT;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_RIGHT;
         button.text = "Preview Animation";
 
         button.onClick = function () {

--- a/Script/AtomicEditor/ui/frames/inspector/MaterialInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/MaterialInspector.ts
@@ -103,10 +103,10 @@ class MaterialInspector extends ScriptWidget {
         section.value = 1;
         section.fontDescription = this.fd;
 
-        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
         attrsVerticalLayout.spacing = 3;
-        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
+        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
 
         section.contentRoot.addChild(attrsVerticalLayout);
 
@@ -115,10 +115,10 @@ class MaterialInspector extends ScriptWidget {
         for (var i in params) {
 
             var attrLayout = new Atomic.UILayout();
-            attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+            attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
             var name = new Atomic.UITextField();
-            name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+            name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
             name.skinBg = "InspectorTextAttrName";
 
             name.text = params[i].name;
@@ -127,7 +127,7 @@ class MaterialInspector extends ScriptWidget {
             attrLayout.addChild(name);
 
             var field = new Atomic.UIEditField();
-            field.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+            field.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
             field.skinBg = "TBAttrEditorField";
             field.fontDescription = this.fd;
             var lp = new Atomic.UILayoutParams();
@@ -139,7 +139,7 @@ class MaterialInspector extends ScriptWidget {
 
             field.subscribeToEvent(field, "WidgetEvent", function (ev: Atomic.UIWidgetEvent) {
 
-                if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+                if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
                     var field = <Atomic.UIEditField>ev.target;
                     this.material.setShaderParameter(field.id, field.text);
@@ -233,7 +233,7 @@ class MaterialInspector extends ScriptWidget {
 
             button.subscribeToEvent(button, "WidgetEvent", function (ev: Atomic.UIWidgetEvent) {
 
-                if (ev.type != Atomic.UI_EVENT_TYPE_CLICK)
+                if (ev.type != Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK)
                     return;
 
                 if (ev.target && ev.target.id == "technique popup") {
@@ -334,15 +334,15 @@ class MaterialInspector extends ScriptWidget {
         section.value = 1;
         section.fontDescription = this.fd;
 
-        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
         attrsVerticalLayout.spacing = 3;
-        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
+        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
 
         section.contentRoot.addChild(attrsVerticalLayout);
 
         // TODO: Filter on technique
-        var textureUnits = [Atomic.TU_DIFFUSE, Atomic.TU_NORMAL, Atomic.TU_SPECULAR, Atomic.TU_EMISSIVE];
+        var textureUnits = [Atomic.TextureUnit.TU_DIFFUSE, Atomic.TextureUnit.TU_NORMAL, Atomic.TextureUnit.TU_SPECULAR, Atomic.TextureUnit.TU_EMISSIVE];
 
         for (var i in textureUnits) {
 
@@ -351,10 +351,10 @@ class MaterialInspector extends ScriptWidget {
             var tunitName = Atomic.Material.getTextureUnitName(tunit);
 
             var attrLayout = new Atomic.UILayout();
-            attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+            attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
             var name = new Atomic.UITextField();
-            name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+            name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
             name.skinBg = "InspectorTextAttrName";
 
             name.text = tunitName;
@@ -513,10 +513,10 @@ class MaterialInspector extends ScriptWidget {
         var materialLayout = new Atomic.UILayout();
         materialLayout.spacing = 4;
 
-        materialLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        materialLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        materialLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        materialLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         materialLayout.layoutParams = mlp;
-        materialLayout.axis = Atomic.UI_AXIS_Y;
+        materialLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
         // node attr layout
 
@@ -526,17 +526,17 @@ class MaterialInspector extends ScriptWidget {
         materialSection.fontDescription = this.fd;
         materialLayout.addChild(materialSection);
 
-        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
         attrsVerticalLayout.spacing = 3;
-        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_PREFERRED;
+        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_PREFERRED;
 
         // NAME
         var nameLayout = new Atomic.UILayout();
-        nameLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        nameLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var name = new Atomic.UITextField();
-        name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         name.skinBg = "InspectorTextAttrName";
 
         name.text = "Name";
@@ -545,7 +545,7 @@ class MaterialInspector extends ScriptWidget {
         nameLayout.addChild(name);
 
         var field = new Atomic.UIEditField();
-        field.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        field.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         field.skinBg = "TBAttrEditorField";
         field.fontDescription = this.fd;
         var lp = new Atomic.UILayoutParams();
@@ -561,11 +561,11 @@ class MaterialInspector extends ScriptWidget {
         // TECHNIQUE LAYOUT
 
         var techniqueLayout = new Atomic.UILayout();
-        techniqueLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_GRAVITY;
-        techniqueLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_PREFERRED;
+        techniqueLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_GRAVITY;
+        techniqueLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_PREFERRED;
 
         name = new Atomic.UITextField();
-        name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         name.skinBg = "InspectorTextAttrName";
 
         name.text = "Technique";
@@ -586,7 +586,7 @@ class MaterialInspector extends ScriptWidget {
 
         var button = new Atomic.UIButton();
         button.fontDescription = this.fd;
-        button.gravity = Atomic.UI_GRAVITY_RIGHT;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_RIGHT;
         button.text = "Save";
 
         button.onClick = function () {

--- a/Script/AtomicEditor/ui/frames/inspector/ModelInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/ModelInspector.ts
@@ -125,11 +125,11 @@ class ModelInspector extends InspectorWidget {
 
         animLayout.spacing = 4;
 
-        animLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        animLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        animLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        animLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         animLayout.layoutParams = nlp;
-        animLayout.axis = Atomic.UI_AXIS_Y;
-        animLayout.gravity = Atomic.UI_GRAVITY_ALL;
+        animLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        animLayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
 
         animationLayout.addChild(animLayout);
 

--- a/Script/AtomicEditor/ui/frames/inspector/PrefabInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/PrefabInspector.ts
@@ -65,13 +65,13 @@ class PrefabInspector extends InspectorWidget {
         var prefabLayout = this.createSection(rootLayout, "Prefab", 1);
 
         var container = InspectorUtils.createContainer();
-        container.gravity = Atomic.UI_GRAVITY_ALL;
+        container.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
         prefabLayout.addChild(container);
 
         var panel = new Atomic.UILayout();
-        panel.axis = Atomic.UI_AXIS_Y;
-        panel.layoutSize = Atomic.UI_LAYOUT_SIZE_PREFERRED;
-        panel.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        panel.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        panel.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_PREFERRED;
+        panel.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         container.addChild(panel);
 
         // Name Edit

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
@@ -262,25 +262,25 @@ class SelectionInspector extends ScriptWidget {
         var lp = new Atomic.UILayoutParams();
         lp.width = 304;
 
-        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        mainLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        mainLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         mainLayout.layoutParams = lp;
-        mainLayout.axis = Atomic.UI_AXIS_Y;
+        mainLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
         this.addChild(mainLayout);
 
         var noticeLayout = this.multipleSelectNotice = new Atomic.UILayout();
-        noticeLayout.axis = Atomic.UI_AXIS_Y;
+        noticeLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
         noticeLayout.layoutParams = lp;
         var noticeText = new Atomic.UITextField();
-        noticeText.textAlign = Atomic.UI_TEXT_ALIGN_CENTER;
+        noticeText.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_CENTER;
         noticeText.skinBg = "InspectorTextAttrName";
         noticeText.text = "Multiple Selection - Some components are hidden";
         noticeText.fontDescription = SelectionSection.fontDesc;
-        noticeText.gravity = Atomic.UI_GRAVITY_LEFT_RIGHT;
+        noticeText.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_LEFT_RIGHT;
         noticeText.layoutParams = lp;
         noticeLayout.addChild(noticeText);
-        noticeLayout.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+        noticeLayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
         mainLayout.addChild(noticeLayout);
 
         this.createComponentButton = new CreateComponentButton();
@@ -347,7 +347,7 @@ class SelectionInspector extends ScriptWidget {
 
     suppressSections() {
 
-        this.multipleSelectNotice.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+        this.multipleSelectNotice.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
 
         for (var i in this.sections) {
 
@@ -368,7 +368,7 @@ class SelectionInspector extends ScriptWidget {
             }
 
             if (suppressed)
-                this.multipleSelectNotice.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+                this.multipleSelectNotice.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
 
             section.suppress(suppressed);
 

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionPrefabWidget.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionPrefabWidget.ts
@@ -41,12 +41,12 @@ class SelectionPrefabWidget extends Atomic.UILayout {
         var widgetLayout = this.widgetLayout = new Atomic.UILayout();
         var noticeLayout = this.noticeLayout = new Atomic.UILayout();
 
-        this.axis = Atomic.UI_AXIS_Y;
-        widgetLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        noticeLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        this.axis = Atomic.UI_AXIS.UI_AXIS_Y;
+        widgetLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        noticeLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var name = new Atomic.UITextField();
-        name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         name.skinBg = "InspectorPrefabTextAttrName";
         name.text = "Prefab";
         name.fontDescription = fd;
@@ -95,13 +95,13 @@ class SelectionPrefabWidget extends Atomic.UILayout {
         });
 
         var noticeName = new Atomic.UITextField();
-        noticeName.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        noticeName.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         noticeName.skinBg = "InspectorTextAttrName";
         noticeName.text = "Prefab";
         noticeName.fontDescription = fd;
 
         var noticeText = new Atomic.UITextField();
-        noticeText.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        noticeText.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         noticeText.skinBg = "InspectorTextAttrName";
         noticeText.text = "Multiple Selection";
         noticeText.fontDescription = fd;
@@ -117,7 +117,7 @@ class SelectionPrefabWidget extends Atomic.UILayout {
         this.addChild(this.widgetLayout);
         this.addChild(this.noticeLayout);
 
-        this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+        this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
 
     }
 
@@ -150,20 +150,20 @@ class SelectionPrefabWidget extends Atomic.UILayout {
         }
 
         if (!hasPrefab) {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             return;
         }
 
-        this.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+        this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
 
         if (nodes.length > 1) {
-            this.noticeLayout.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
-            this.widgetLayout.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.noticeLayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
+            this.widgetLayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
             return;
         }
 
-        this.noticeLayout.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
-        this.widgetLayout.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+        this.noticeLayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
+        this.widgetLayout.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
         this.node = nodes[0];
 
     }
@@ -179,7 +179,7 @@ class ConfirmPrefabBreak extends Atomic.UIWindow {
 
         this.node = node;
 
-        this.settings = Atomic.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
+        this.settings = Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
 
         this.text = "Break Prefab Connection";
         this.load("AtomicEditor/editor/ui/breakprefab.tb.txt");
@@ -198,7 +198,7 @@ class ConfirmPrefabBreak extends Atomic.UIWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionSection.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionSection.ts
@@ -75,9 +75,9 @@ abstract class SelectionSection extends Atomic.UISection {
 
         this.suppressed = value;
         if (value) {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
         } else {
-            this.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+            this.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
         }
 
     }
@@ -149,10 +149,10 @@ abstract class SelectionSection extends Atomic.UISection {
 
     createUI() {
 
-        var attrLayout = this.attrLayout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+        var attrLayout = this.attrLayout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
         attrLayout.spacing = 3;
-        attrLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        attrLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
+        attrLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        attrLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
 
         this.contentRoot.addChild(attrLayout);
 

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionSectionCoreUI.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionSectionCoreUI.ts
@@ -37,7 +37,7 @@ class CollisionShapeSectionUI extends SelectionSectionUI {
 
         var button = new Atomic.UIButton();
         button.fontDescription = InspectorUtils.attrFontDesc;
-        button.gravity = Atomic.UI_GRAVITY_RIGHT;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_RIGHT;
         button.text = "Set from StaticModel";
 
         button.onClick = () => {
@@ -70,7 +70,7 @@ class CubemapGeneratorSectionUI extends SelectionSectionUI {
 
         var button = new Atomic.UIButton();
         button.fontDescription = InspectorUtils.attrFontDesc;
-        button.gravity = Atomic.UI_GRAVITY_RIGHT;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_RIGHT;
         button.text = "Render Cubemap";
 
         button.onClick = () => {

--- a/Script/AtomicEditor/ui/frames/inspector/SerializableEditType.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SerializableEditType.ts
@@ -51,7 +51,7 @@ class SerializableEditType {
                 value = object.getAttribute(attrInfo.name);
                 if (index >= 0) {
 
-                    if (attrInfo.type == Atomic.VAR_RESOURCEREFLIST) {
+                    if (attrInfo.type == Atomic.VariantType.VAR_RESOURCEREFLIST) {
 
                         value = value.resources[index];
 
@@ -64,7 +64,7 @@ class SerializableEditType {
 
                 var value2 = object.getAttribute(attrInfo.name);
                 if (index >= 0) {
-                    if (attrInfo.type == Atomic.VAR_RESOURCEREFLIST) {
+                    if (attrInfo.type == Atomic.VariantType.VAR_RESOURCEREFLIST) {
 
                         value2 = value2.resources[index];
 
@@ -97,7 +97,7 @@ class SerializableEditType {
 
                 var idxValue = object.getAttribute(attrInfo.name);
 
-                if (attrInfo.type == Atomic.VAR_RESOURCEREFLIST) {
+                if (attrInfo.type == Atomic.VariantType.VAR_RESOURCEREFLIST) {
 
                     idxValue.resources[index] = value;
                     object.setAttribute(attrInfo.name, idxValue);

--- a/Script/AtomicEditor/ui/frames/inspector/TextureInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/TextureInspector.ts
@@ -75,15 +75,15 @@ class TextureInspector extends InspectorWidget {
         section.value = 1;
         section.fontDescription = this.fd;
 
-        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
         attrsVerticalLayout.spacing = 3;
-        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_CENTER;
-        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_AVAILABLE;
+        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_CENTER;
+        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_AVAILABLE;
 
         section.contentRoot.addChild(attrsVerticalLayout);
 
         var attrLayout = new Atomic.UILayout();
-        attrLayout.layoutDistribution = Atomic.UI_LAYOUT_POSITION_CENTER;
+        attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_PREFERRED;
 
         var textureWidget = new Atomic.UITextureWidget();
 
@@ -119,10 +119,10 @@ class TextureInspector extends InspectorWidget {
         var textureLayout = new Atomic.UILayout();
         textureLayout.spacing = 4;
 
-        textureLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
-        textureLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
+        textureLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        textureLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
         textureLayout.layoutParams = mlp;
-        textureLayout.axis = Atomic.UI_AXIS_Y;
+        textureLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
         var textureSection = new Atomic.UISection();
         textureSection.text = "Texture";
@@ -130,17 +130,17 @@ class TextureInspector extends InspectorWidget {
         textureSection.fontDescription = this.fd;
         textureLayout.addChild(textureSection);
 
-        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS_Y);
+        var attrsVerticalLayout = new Atomic.UILayout(Atomic.UI_AXIS.UI_AXIS_Y);
         attrsVerticalLayout.spacing = 3;
-        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE_PREFERRED;
+        attrsVerticalLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        attrsVerticalLayout.layoutSize = Atomic.UI_LAYOUT_SIZE.UI_LAYOUT_SIZE_PREFERRED;
 
         // NAME
         var nameLayout = new Atomic.UILayout();
-        nameLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        nameLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         var name = new Atomic.UITextField();
-        name.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        name.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         name.skinBg = "InspectorTextAttrName";
 
         name.text = "Name";
@@ -149,7 +149,7 @@ class TextureInspector extends InspectorWidget {
         nameLayout.addChild(name);
 
         var field = new Atomic.UIEditField();
-        field.textAlign = Atomic.UI_TEXT_ALIGN_LEFT;
+        field.textAlign = Atomic.UI_TEXT_ALIGN.UI_TEXT_ALIGN_LEFT;
         field.skinBg = "TBAttrEditorField";
         field.fontDescription = this.fd;
         var lp = new Atomic.UILayoutParams();
@@ -163,7 +163,7 @@ class TextureInspector extends InspectorWidget {
         attrsVerticalLayout.addChild(nameLayout);
 
         var maxSizeLayout = new Atomic.UILayout();
-        maxSizeLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_GRAVITY;
+        maxSizeLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_GRAVITY;
 
         //COMPRESSION SIZE
         var maxSize = InspectorUtils.createAttrName("Max Size");

--- a/Script/AtomicEditor/ui/frames/inspector/TextureSelector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/TextureSelector.ts
@@ -31,20 +31,20 @@ class TextureSelector extends Atomic.UIWindow {
         this.rect = [0, 0, 320, 512];
 
         var mainLayout = new Atomic.UILayout();
-        mainLayout.gravity = Atomic.UI_GRAVITY_ALL;
-        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
-        mainLayout.axis = Atomic.UI_AXIS_Y;
+        mainLayout.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
+        mainLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
+        mainLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
         this.contentRoot.addChild(mainLayout);
 
         // really want a grid container
         var scrollContainer = new Atomic.UIScrollContainer();
-        scrollContainer.gravity = Atomic.UI_GRAVITY_ALL;
-        scrollContainer.scrollMode = Atomic.UI_SCROLL_MODE_Y_AUTO;
+        scrollContainer.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
+        scrollContainer.scrollMode = Atomic.UI_SCROLL_MODE.UI_SCROLL_MODE_Y_AUTO;
         scrollContainer.adaptContentSize = true;
 
         var scrollLayout = new Atomic.UILayout();
-        scrollLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION_LEFT_TOP;
-        scrollLayout.axis = Atomic.UI_AXIS_Y;
+        scrollLayout.layoutPosition = Atomic.UI_LAYOUT_POSITION.UI_LAYOUT_POSITION_LEFT_TOP;
+        scrollLayout.axis = Atomic.UI_AXIS.UI_AXIS_Y;
 
         scrollContainer.contentRoot.addChild(scrollLayout);
 
@@ -81,7 +81,7 @@ class TextureSelector extends Atomic.UIWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target != this && !this.isAncestorOf(ev.target)) {
 

--- a/Script/AtomicEditor/ui/modal/About.ts
+++ b/Script/AtomicEditor/ui/modal/About.ts
@@ -69,7 +69,7 @@ class About extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/modal/CreateProject.ts
+++ b/Script/AtomicEditor/ui/modal/CreateProject.ts
@@ -52,7 +52,7 @@ class CreateProject extends ModalWindow {
         this.html5Button = this.addPlatformButton("html5", "AtomicEditor/editor/images/HTML5128.png");
 
         if (!projectTemplate.screenshot)
-            this.image.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.image.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
         else
             this.image.image = projectTemplate.screenshot;
 
@@ -106,7 +106,7 @@ class CreateProject extends ModalWindow {
 
         button.layoutParams = lp;
 
-        button.gravity = Atomic.UI_GRAVITY_ALL;
+        button.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
 
         var image = new Atomic.UIImageWidget();
         image.image = platformLogo;
@@ -119,7 +119,7 @@ class CreateProject extends ModalWindow {
             greenplus.image = "AtomicEditor/editor/images/green_plus.png";
             rect = [size - 18, 2, size - 2, 18];
             greenplus.rect = rect;
-            greenplus.visibility = Atomic.UI_WIDGET_VISIBILITY_INVISIBLE;
+            greenplus.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_INVISIBLE;
             button.addChild(greenplus);
             button["greenPlus"] = greenplus;
         }
@@ -222,7 +222,7 @@ class CreateProject extends ModalWindow {
                 fileSystem.rename(folder + fileResults[0], folder + name + ".atomic");
             } else {
                 // Just create the file.  We either don't have one existing, or we have more than one and don't know which one to rename
-                var file = new Atomic.File(folder + name + ".atomic", Atomic.FILE_WRITE);
+                var file = new Atomic.File(folder + name + ".atomic", Atomic.FileMode.FILE_WRITE);
                 file.close();
             }
 
@@ -249,7 +249,7 @@ class CreateProject extends ModalWindow {
                 platforms : platforms
             };
 
-            var jsonFile = new Atomic.File(folder + "Settings/Project.json", Atomic.FILE_WRITE);
+            var jsonFile = new Atomic.File(folder + "Settings/Project.json", Atomic.FileMode.FILE_WRITE);
             if (jsonFile.isOpen()) {
                 jsonFile.writeString(JSON.stringify(projectSettings, null, 2));
                 jsonFile.flush();
@@ -295,14 +295,14 @@ class CreateProject extends ModalWindow {
 
         if (selectedLanguage == "CSharp" || selectedLanguage == "C#") {
 
-            this.html5Button["greenPlus"].visibility = Atomic.UI_WIDGET_VISIBILITY_INVISIBLE;
+            this.html5Button["greenPlus"].visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_INVISIBLE;
             this.html5Button.value = 0;
             this.html5Button.disable();
 
         } else {
 
             this.html5Button.enable();
-            this.html5Button["greenPlus"].visibility = this.html5Button.value == 1 ? Atomic.UI_WIDGET_VISIBILITY_VISIBLE : Atomic.UI_WIDGET_VISIBILITY_INVISIBLE;
+            this.html5Button["greenPlus"].visibility = this.html5Button.value == 1 ? Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE : Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_INVISIBLE;
 
         }
 
@@ -310,7 +310,7 @@ class CreateProject extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -340,7 +340,7 @@ class CreateProject extends ModalWindow {
                 return true;
 
             }
-        } else if (ev.type == Atomic.UI_EVENT_TYPE_CHANGED) {
+        } else if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CHANGED) {
 
             // handle language change
             if (ev.target.id == "project_language") {
@@ -353,7 +353,7 @@ class CreateProject extends ModalWindow {
                 this.desktopButton.value = 1;
 
             } else if (ev.target["greenPlus"]) {
-                ev.target["greenPlus"].visibility = ev.target.value == 1 ? Atomic.UI_WIDGET_VISIBILITY_VISIBLE : Atomic.UI_WIDGET_VISIBILITY_INVISIBLE;
+                ev.target["greenPlus"].visibility = ev.target.value == 1 ? Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE : Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_INVISIBLE;
             }
 
 

--- a/Script/AtomicEditor/ui/modal/MessageModal.ts
+++ b/Script/AtomicEditor/ui/modal/MessageModal.ts
@@ -29,7 +29,7 @@ export class MessageModal extends Atomic.ScriptObject {
 
     var mainframe = EditorUI.getMainFrame();
 
-    new Atomic.UIMessageWindow(mainframe, "modal_error").show(title, message, Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 360);
+    new Atomic.UIMessageWindow(mainframe, "modal_error").show(title, message, Atomic.UI_MESSAGEWINDOW_SETTINGS.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 360);
 
   }
 

--- a/Script/AtomicEditor/ui/modal/ModalOps.ts
+++ b/Script/AtomicEditor/ui/modal/ModalOps.ts
@@ -260,7 +260,7 @@ class ModalOps extends Atomic.ScriptObject {
     showError(windowText: string, message: string) {
         var view = EditorUI.getView();
         var window = new Atomic.UIMessageWindow(view, "modal_error");
-        window.show(windowText, message, Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 360);
+        window.show(windowText, message, Atomic.UI_MESSAGEWINDOW_SETTINGS.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 360);
     }
 
     showExtensionWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow {

--- a/Script/AtomicEditor/ui/modal/ModalWindow.ts
+++ b/Script/AtomicEditor/ui/modal/ModalWindow.ts
@@ -29,7 +29,7 @@ class ModalWindow extends Atomic.UIWindow {
         super();
 
         if (disableClose)
-          this.settings = Atomic.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
+          this.settings = Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
 
         var view = EditorUI.getView();
         view.addChild(this);

--- a/Script/AtomicEditor/ui/modal/NewProject.ts
+++ b/Script/AtomicEditor/ui/modal/NewProject.ts
@@ -36,7 +36,7 @@ class NewProject extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             let id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/modal/ProgressModal.ts
+++ b/Script/AtomicEditor/ui/modal/ProgressModal.ts
@@ -28,7 +28,7 @@ class ProgressModal extends Atomic.UIWindow {
 
         super();
 
-        this.settings = Atomic.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
+        this.settings = Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
 
         this.text = title;
         this.load("AtomicEditor/editor/ui/progressmodal.tb.txt");

--- a/Script/AtomicEditor/ui/modal/ResourceSelection.ts
+++ b/Script/AtomicEditor/ui/modal/ResourceSelection.ts
@@ -123,7 +123,7 @@ class ResourceSelection extends ModalWindow {
             }
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_KEY_UP) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_KEY_UP) {
 
             //Activates the search as the user types
             if (ev.target == this.searchEdit)
@@ -131,7 +131,7 @@ class ResourceSelection extends ModalWindow {
 
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
             var id = ev.target.id;
 
             if (id == "select") {

--- a/Script/AtomicEditor/ui/modal/SnapSettingsWindow.ts
+++ b/Script/AtomicEditor/ui/modal/SnapSettingsWindow.ts
@@ -68,7 +68,7 @@ class SnapSettingsWindow extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/modal/UIResourceOps.ts
+++ b/Script/AtomicEditor/ui/modal/UIResourceOps.ts
@@ -49,7 +49,7 @@ export class ResourceDelete extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -97,7 +97,7 @@ export class CreateFolder extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -162,7 +162,7 @@ export class CreateComponent extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -248,7 +248,7 @@ export class CreateScript extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -316,7 +316,7 @@ export class CreateScene extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -368,7 +368,7 @@ export class CreateMaterial extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 
@@ -430,7 +430,7 @@ export class RenameAsset extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/modal/build/BuildComplete.ts
+++ b/Script/AtomicEditor/ui/modal/build/BuildComplete.ts
@@ -39,7 +39,7 @@ class BuildComplete extends Atomic.UIWindow {
         var reveal = <Atomic.UIButton>this.getWidget("reveal");
 
         if (!ev.success)
-            reveal.setState(Atomic.UI_WIDGET_STATE_DISABLED, true);
+            reveal.setState(Atomic.UI_WIDGET_STATE.UI_WIDGET_STATE_DISABLED, true);
 
 
         this.subscribeToEvent(this, "WidgetEvent", (data) => this.handleWidgetEvent(data));
@@ -48,7 +48,7 @@ class BuildComplete extends Atomic.UIWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target.id == "reveal") {
 

--- a/Script/AtomicEditor/ui/modal/build/BuildOutput.ts
+++ b/Script/AtomicEditor/ui/modal/build/BuildOutput.ts
@@ -57,7 +57,7 @@ class BuildOutput extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target.id == "cancel") {
                 this.hide();

--- a/Script/AtomicEditor/ui/modal/build/BuildSettingsWindow.ts
+++ b/Script/AtomicEditor/ui/modal/build/BuildSettingsWindow.ts
@@ -71,7 +71,7 @@ export class BuildSettingsWindow extends ModalWindow {
         lp.maxHeight = myh;
 
         platformSelect.layoutParams = lp;
-        platformSelect.gravity = Atomic.UI_GRAVITY_ALL;
+        platformSelect.gravity = Atomic.UI_GRAVITY.UI_GRAVITY_ALL;
 
         platformcontainer.addChild(platformSelect);
 
@@ -113,7 +113,7 @@ export class BuildSettingsWindow extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var toolSystem = ToolCore.toolSystem;
 
@@ -144,7 +144,7 @@ export class BuildSettingsWindow extends ModalWindow {
 
                 var showMessage = function(target, title, message) {
                     var window = new Atomic.UIMessageWindow(target, "modal_error");
-                    window.show(title, message, Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 260);
+                    window.show(title, message, Atomic.UI_MESSAGEWINDOW_SETTINGS.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 260);
                 };
 
                 for (var name in this.platformInfo) {
@@ -158,14 +158,14 @@ export class BuildSettingsWindow extends ModalWindow {
                         // Do we have a C# project?
                         if (ToolCore.netProjectSystem.solutionAvailable) {
 
-                            if (platform.platformID == ToolCore.PLATFORMID_WEB) {
+                            if (platform.platformID == ToolCore.PlatformID.PLATFORMID_WEB) {
 
                                 showMessage(this, "Platform Info", "\nThe web platform is not available when using C# at this time\n\n");
                                 return true;
 
                             }
 
-                            if (platform.platformID == ToolCore.PLATFORMID_IOS || platform.platformID == ToolCore.PLATFORMID_ANDROID) {
+                            if (platform.platformID == ToolCore.PlatformID.PLATFORMID_IOS || platform.platformID == ToolCore.PlatformID.PLATFORMID_ANDROID) {
 
                                 var ide = Atomic.platform == "Windows" ? "Visual Studio" : "Xamarin Studio";
                                 var message = `Please open the following solution in ${ide}:\n\n ${ToolCore.netProjectSystem.solutionPath}\n\n`;
@@ -177,7 +177,7 @@ export class BuildSettingsWindow extends ModalWindow {
 
                         } else {
 
-                            if (platform.platformID == ToolCore.PLATFORMID_IOS) {
+                            if (platform.platformID == ToolCore.PlatformID.PLATFORMID_IOS) {
 
                                 if (Atomic.platform == "Windows") {
 
@@ -244,14 +244,14 @@ export class BuildSettingsWindow extends ModalWindow {
 
         for (var name in this.platformInfo) {
 
-            this.platformInfo[name].widget.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.platformInfo[name].widget.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
 
         }
 
         if (!platform) return;
 
         var info: { widget: Atomic.UIWidget, index: number, logo: string } = this.platformInfo[platform.name];
-        info.widget.visibility = Atomic.UI_WIDGET_VISIBILITY_VISIBLE;
+        info.widget.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_VISIBLE;
         if (this.platformSelect.value != info.index)
             this.platformSelect.value = info.index;
 

--- a/Script/AtomicEditor/ui/modal/build/BuildWindow.ts
+++ b/Script/AtomicEditor/ui/modal/build/BuildWindow.ts
@@ -64,7 +64,7 @@ class BuildWindow extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target.id == "cancel") {
                 this.hide();
@@ -85,7 +85,7 @@ class BuildWindow extends ModalWindow {
 
               if (!userPrefs.lastBuildPath.length || !Atomic.fileSystem.dirExists(userPrefs.lastBuildPath)) {
 
-                  new Atomic.UIMessageWindow(this, "modal_error").show("Build Folder", "Please select an existing build folder", Atomic.UI_MESSAGEWINDOW_SETTINGS_OK, true, 480, 240);
+                  new Atomic.UIMessageWindow(this, "modal_error").show("Build Folder", "Please select an existing build folder", Atomic.UI_MESSAGEWINDOW_SETTINGS.UI_MESSAGEWINDOW_SETTINGS_OK, true, 480, 240);
                   return true;
               }
 

--- a/Script/AtomicEditor/ui/modal/build/platforms/AndroidSettingsWidget.ts
+++ b/Script/AtomicEditor/ui/modal/build/platforms/AndroidSettingsWidget.ts
@@ -69,7 +69,7 @@ class AndroidSettingsWidget extends Atomic.UIWidget implements BuildSettingsWind
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target.id == "choose_sdk_path") {
 

--- a/Script/AtomicEditor/ui/modal/build/platforms/IOSSettingsWidget.ts
+++ b/Script/AtomicEditor/ui/modal/build/platforms/IOSSettingsWidget.ts
@@ -60,7 +60,7 @@ class IOSSettingsWidget extends Atomic.UIWidget implements BuildSettingsWindow.B
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target.id == "choose_provision_path") {
 

--- a/Script/AtomicEditor/ui/modal/build/platforms/WebSettingsWidget.ts
+++ b/Script/AtomicEditor/ui/modal/build/platforms/WebSettingsWidget.ts
@@ -58,7 +58,7 @@ class WebSettingsWidget extends Atomic.UIWidget implements BuildSettingsWindow.B
             return true;
         }
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             if (ev.target.id == "web_dark") {
                 this.settings.pageTheme = 0;

--- a/Script/AtomicEditor/ui/modal/info/AtomicNETWindow.ts
+++ b/Script/AtomicEditor/ui/modal/info/AtomicNETWindow.ts
@@ -29,7 +29,7 @@ class AtomicNETWindow extends ModalWindow {
 
         super();
 
-        this.settings = Atomic.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
+        this.settings = Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
 
         // we're not calling this.init here as it calls resizeToFitContent
         // and center, which screw up the generated About text being resized
@@ -49,7 +49,7 @@ class AtomicNETWindow extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/modal/info/NewBuildWindow.ts
+++ b/Script/AtomicEditor/ui/modal/info/NewBuildWindow.ts
@@ -30,7 +30,7 @@ class NewBuildWindow extends ModalWindow {
 
         super();
 
-        this.settings = Atomic.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
+        this.settings = Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
 
         // we're not calling this.init here as it calls resizeToFitContent
         // and center, which screw up the generated About text being resized
@@ -50,7 +50,7 @@ class NewBuildWindow extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/modal/license/EULAWindow.ts
+++ b/Script/AtomicEditor/ui/modal/license/EULAWindow.ts
@@ -30,7 +30,7 @@ class EULAWindow extends ModalWindow {
 
         super();
 
-        this.settings = Atomic.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
+        this.settings = Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_DEFAULT & ~Atomic.UI_WINDOW_SETTINGS.UI_WINDOW_SETTINGS_CLOSE_BUTTON;
 
         this.init("License Agreement", "AtomicEditor/editor/ui/eulaagreement.tb.txt");
 
@@ -57,7 +57,7 @@ class EULAWindow extends ModalWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
 
             var id = ev.target.id;
 

--- a/Script/AtomicEditor/ui/playmode/PlayerOutput.ts
+++ b/Script/AtomicEditor/ui/playmode/PlayerOutput.ts
@@ -74,7 +74,7 @@ class PlayerOutput extends Atomic.UIWindow {
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 
-        if (ev.type == Atomic.UI_EVENT_TYPE_CLICK) {
+        if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
             var id = ev.target.id;
             if (id == "closeonstop") {
                 Preferences.getInstance().editorFeatures.closePlayerLog = this.closeOnStop.value > 0 ? true : false;

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -428,40 +428,32 @@ void JSBTypeScript::ExportModuleEvents(JSBModule* module)
             else
                 typeName = cls->GetName();
 
-            if (typeName == "int" || typeName == "float" || typeName == "unsigned" ||
-                typeName == "bool" || typeName == "string" || typeName == "enum" || cls)
+            bool mapped = false;
+
+            if (typeName == "int" || typeName == "float" || typeName == "unsigned" || typeName == "uint")
             {
-
-                bool isEnum = false;
-                if (typeName == "enum")
-                {
-                    isEnum = true;
-                    // Once proper TypeScript enums are in place, uncomment the following.  See: #1268
-                    //if (enumTypeName.Length())
-                    //    typeName = enumTypeName;
-                    //else
+                typeName = "number";
+                mapped = true;
+            } else if (typeName == "bool") {
+                typeName = "boolean";
+                mapped = true;
+            } else if (typeName == "string") {
+                mapped = true;
+            } else if (cls) {
+                typeName = ToString("%s.%s", cls->GetPackage()->GetName().CString(), typeName.CString());
+                mapped = true;
+            } else if (typeName == "enum") {
+                if (enumTypeName.Length())
+                    typeName = enumTypeName;
+                else
                     typeName = "number";
-                }
 
-                if (typeName == "int" || typeName == "float" || typeName == "unsigned")
-                {
-                    typeName = "number";
-                } else if (typeName == "bool") {
-                    typeName = "boolean";
-                } else if (cls) {
-                    typeName = ToString("%s.%s", cls->GetPackage()->GetName().CString(), typeName.CString());
-                }
-
-                if (isEnum && enumTypeName.Length())
-                {
-                    source += ToString("        /** Enum: %s */\n", enumTypeName.CString());
-                    source += ToString("        %s : %s;\n", paramName.CString(), typeName.CString());
-                } else {
-                    source += ToString("        %s : %s;\n", paramName.CString(), typeName.CString());
-                }
+                mapped = true;
             }
-            else
-            {
+
+            if (mapped == true) {
+                source += ToString("        %s : %s;\n", paramName.CString(), typeName.CString());
+            } else {
                 source += ToString("        // Unmapped Native Type:%s \n", typeName.CString());
                 source += ToString("        // %s : any;\n", p.paramName_.ToLower().CString());
             }
@@ -471,7 +463,7 @@ void JSBTypeScript::ExportModuleEvents(JSBModule* module)
 
         // Write the event function signature
 
-        source += ToString("\nexport function %s (callback : Atomic.EventCallback<%s>) : Atomic.EventMetaData;\n\n", scriptEventName.CString(), scriptEventName.CString());
+        source += ToString("\n    export function %s (callback : Atomic.EventCallback<%s>) : Atomic.EventMetaData;\n\n", scriptEventName.CString(), scriptEventName.CString());
 
     }
     source_ += source;

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -339,10 +339,9 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
     {
         JSBEnum* _enum = *enumIter;
 
-        // can't use a TS enum, so use a type alias
-
-        source_ += "\n   // enum " + _enum->GetName() + "\n";
-        source_ += "   export type " + _enum->GetName() + " = number;\n";
+        source_ += "\n";
+        source_ += "   /** enum " + _enum->GetName() + "*/\n";
+        source_ += "   export const enum " + _enum->GetName() + " {\n";
 
         HashMap<String, String>& values = _enum->GetValues();
 
@@ -351,14 +350,37 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
         while (valsIter != values.End())
         {
             String name = (*valsIter).first_;
+            String value = (*valsIter).second_;
 
-            source_ += "   export var " + name + ": " +  _enum->GetName() + ";\n";
+            // BodyType2D enum order is assigned in RigidBody2D.h in incorrect order
+            if (_enum->GetName() == "BodyType2D")
+            {
+                if (name == "BT_STATIC")
+                    value = "0";
+                else if (name == "BT_KINEMATIC")
+                    value = "1";
+                else if (name == "BT_DYNAMIC")
+                    value = "2";
+            }
+
+            //source_ += "   export var " + name + ": " +  _enum->GetName() + ";\n";
+            source_ += "       /** For JS Access, use: Atomic." + name + " */\n";
+            if (value != "")
+            {
+                source_ += "       " + name + " = " + value;
+            } else {
+                source_ += "       " + name;
+            }
 
             valsIter++;
+
+            if (valsIter != values.End())
+                source_ += ",";
+
+            source_ += "\n";
         }
-
+        source_ += "    }\n";
         source_ += "\n";
-
     }
 
 }

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -339,7 +339,6 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
     {
         JSBEnum* _enum = *enumIter;
 
-        source_ += "\n";
         source_ += "   /** enum " + _enum->GetName() + "*/\n";
         source_ += "   export const enum " + _enum->GetName() + " {\n";
 
@@ -364,7 +363,7 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
             }
 
             //source_ += "   export var " + name + ": " +  _enum->GetName() + ";\n";
-            source_ += "       /** For JS Access, use: Atomic." + name + " */\n";
+            source_ += "       /** TypeScript Only - For vanilla JavaScript, use: [[" + package_->GetName() + "." + name + "]] */\n";
             if (value != "")
             {
                 source_ += "       " + name + " = " + value;
@@ -380,6 +379,18 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
             source_ += "\n";
         }
         source_ += "    }\n";
+        source_ += "\n";
+
+        // legacy support
+        source_ += "   // Legacy JS Access for enum:  " + _enum->GetName() + "\n";
+        valsIter = values.Begin();
+        while (valsIter != values.End())
+        {
+            String name = (*valsIter).first_;
+            source_ += "   /** JavaScript Only - For TypeScript, use: [[" + _enum->GetName() + "." + name + "]] */\n";
+            source_ += "   export var " + name + ": number;\n";
+            valsIter++;
+        }
         source_ += "\n";
     }
 
@@ -444,7 +455,7 @@ void JSBTypeScript::ExportModuleEvents(JSBModule* module)
                 mapped = true;
             } else if (typeName == "enum") {
                 if (enumTypeName.Length())
-                    typeName = enumTypeName;
+                    typeName = package_->GetName() + "." + enumTypeName;
                 else
                     typeName = "number";
 


### PR DESCRIPTION
This adds in TS style enums for all of the enumerated types.  It also retains the original JS style constants, but comments them to indicate that they should only be used with vanilla JS.  The Editor code has been updated to take advantage of the TS style enums everywhere.