### PR TITLE
Fixed all occurrences of `typscript` typo, and reverted #1309.

### DIFF
--- a/Script/AtomicEditor/hostExtensions/ServiceLocator.ts
+++ b/Script/AtomicEditor/hostExtensions/ServiceLocator.ts
@@ -23,7 +23,7 @@
 import * as HostExtensionServices from "./HostExtensionServices";
 import * as EditorUI from "../ui/EditorUI";
 import ProjectBasedExtensionLoader from "./coreExtensions/ProjectBasedExtensionLoader";
-import TypescriptLanguageExtension from "./languageExtensions/TypscriptLanguageExtension";
+import TypescriptLanguageExtension from "./languageExtensions/TypescriptLanguageExtension";
 import CSharpLanguageExtension from "./languageExtensions/CSharpLanguageExtension";
 
 /**

--- a/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
+++ b/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
@@ -94,7 +94,7 @@ export default class ProjectBasedExtensionLoader implements Editor.HostExtension
         })(Duktape.modSearch);
     }
     /**
-     * Called when the project is being loaded to allow the typscript language service to reset and
+     * Called when the project is being loaded to allow the typescript language service to reset and
      * possibly compile
      */
     projectLoaded(ev: Editor.EditorEvents.LoadProjectEvent) {

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
@@ -141,7 +141,7 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
     /*** ProjectService implementation ****/
 
     /**
-    * Called when the project is being loaded to allow the typscript language service to reset and
+    * Called when the project is being loaded to allow the typescript language service to reset and
     * possibly compile
     */
     projectLoaded(ev: Editor.EditorEvents.LoadProjectEvent) {

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
@@ -47,7 +47,7 @@ const defaultCompilerOptions = {
  */
 export default class TypescriptLanguageExtension implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener {
     name: string = "HostTypeScriptLanguageExtension";
-    description: string = "This service supports the typscript webview extension.";
+    description: string = "This service supports the typescript webview extension.";
 
     /**
      * Indicates if this project contains typescript files.
@@ -285,7 +285,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
     /*** ProjectService implementation ****/
 
     /**
-     * Called when the project is being loaded to allow the typscript language service to reset and
+     * Called when the project is being loaded to allow the typescript language service to reset and
      * possibly compile
      */
     projectLoaded(ev: Editor.EditorEvents.LoadProjectEvent) {
@@ -370,8 +370,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
       // Generate a tsconfig.json file
       const tsconfigFile = new Atomic.File(projectDir + "tsconfig.json", Atomic.FileMode.FILE_WRITE);
       let tsconfig = {
-        compilerOptions: defaultCompilerOptions,
-        include: [ "Resources", "typings" ]
+        compilerOptions: defaultCompilerOptions
       };
 
       // Don't use fully qualified path in the persistent tsconfig file, just use a relative path from the tsconfig

--- a/Script/tsconfig.json
+++ b/Script/tsconfig.json
@@ -31,7 +31,7 @@
         "./AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts",
         "./AtomicEditor/hostExtensions/HostExtensionServices.ts",
         "./AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts",
-        "./AtomicEditor/hostExtensions/languageExtensions/TypscriptLanguageExtension.ts",
+        "./AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts",
         "./AtomicEditor/hostExtensions/ServiceLocator.ts",
         "./AtomicEditor/main.ts",
         "./AtomicEditor/resources/ProjectTemplates.ts",


### PR DESCRIPTION
Reverted #1309 for the reasons explained [here](https://github.com/AtomicGameEngine/AtomicGameEngine/pull/1309#issuecomment-270283241).  Also fixed all of the places `typescript` was incorrectly spelled `typscript`, including in the filename of the language extension file.