### PR TITLE
Toggle to Play camera

### DIFF
--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.h
@@ -78,6 +78,8 @@ private:
     bool GetChangingCameraSpeed();
     void ToggleGrid();
 
+    void TogglePlayCamera();
+
     void HandleMouseMove(StringHash eventType, VariantMap& eventData);
 
     void UpdateDragNode(int mouseX, int mouseY);
@@ -116,6 +118,9 @@ private:
     bool enabled_;
     bool gridEnabled_;
 
+    //Checks if we are in play camera mode
+    bool isOnPlayCamera_;
+    bool lookCamera_;
     // Checks whether your switching from an orthographic view
     bool fromOrthographic_;
 
@@ -126,6 +131,8 @@ private:
     Vector3 cameraMoveTarget_;
 
     SharedPtr<Camera> camera_;
+    SharedPtr<Node> activeCameraNode_;
+    SharedPtr<Node> defaultCameraNode_;
     SharedPtr<DebugRenderer> debugRenderer_;
     SharedPtr<Octree> octree_;
 


### PR DESCRIPTION
press C key to change between the __atomic_sceneview3d_camera and scene camera. Select a camera and press C to chage to that camera, if you dont select a camere, we change to the first camera compoment in the scene, if there is no camera switch to default (__atomic_sceneview3d_camera), lock the camera pos, rot with L key. Every time it is passed to a user's camera, it is blocked