### PR TITLE
emcc snprintf missing

### DIFF
--- a/Source/Atomic/Metrics/Metrics.cpp
+++ b/Source/Atomic/Metrics/Metrics.cpp
@@ -24,6 +24,11 @@
 
 #include "../Metrics/Metrics.h"
 
+#ifdef ATOMIC_PLATFORM_WEB
+#include <stdio.h>
+#include <stdlib.h>
+#endif
+
 
 namespace Atomic
 {


### PR DESCRIPTION
I fixed this only for ATOMIC_PLATFORM_WEB (emcc), the other platform's compilers were able to find these include files.