### PR TITLE
Tagged Bone nodes as "Atomic_Temporary" 

### DIFF
--- a/Source/Atomic/Graphics/AnimatedModel.cpp
+++ b/Source/Atomic/Graphics/AnimatedModel.cpp
@@ -823,6 +823,8 @@ void AnimatedModel::SetSkeleton(const Skeleton& skeleton, bool createBones)
         if ((createBones && !dontCreateBonesHack)|| boneCreationOverride_)
         {
 // ATOMIC END
+            //Remove this tag once new prefabs no longer depend on the temporary flag
+            String tempTag = "Atomic_Temporary";
 
             for (Vector<Bone>::Iterator i = bones.Begin(); i != bones.End(); ++i)
             {
@@ -832,6 +834,14 @@ void AnimatedModel::SetSkeleton(const Skeleton& skeleton, bool createBones)
                 boneNode->SetTransform(i->initialPosition_, i->initialRotation_, i->initialScale_);
                 // Copy the model component's temporary status
                 boneNode->SetTemporary(IsTemporary());
+
+                //Rather mark the nodes as temporary once new prefabs no longer depend on the temporary flag
+                if (boneCreationOverride_)
+                {
+                    if(boneNode->GetScene() != NULL)
+                        boneNode->AddTag(tempTag);
+                }
+
                 i->node_ = boneNode;
             }
 

--- a/Source/Atomic/Scene/Node.cpp
+++ b/Source/Atomic/Scene/Node.cpp
@@ -218,6 +218,9 @@ bool Node::SaveXML(XMLElement& dest) const
         Node* node = children_[i];
         if (node->IsTemporary())
             continue;
+        // Can remove this check once bone nodes use temporary flag instead and new prefabs no longer use temporary flag.
+        if (node->HasTag("Atomic_Temporary"))
+            continue;
 
         XMLElement childElem = dest.CreateChild("node");
         if (!node->SaveXML(childElem))


### PR DESCRIPTION
Prevents tagged bone nodes from being serialized with the scene.