### PR TITLE
JSONFile GetRoot fixes #1383

### DIFF
--- a/Source/Atomic/Atomic2D/SpriteSheet2D.cpp
+++ b/Source/Atomic/Atomic2D/SpriteSheet2D.cpp
@@ -282,7 +282,7 @@ bool SpriteSheet2D::BeginLoadFromJSONFile(Deserializer& source)
 
     SetMemoryUse(source.GetSize());
 
-    JSONValue rootElem = loadJSONFile_->GetRoot();
+    JSONValue& rootElem = loadJSONFile_->GetRoot();
     if (rootElem.IsNull())
     {
         ATOMIC_LOGERROR("Invalid sprite sheet");
@@ -310,7 +310,7 @@ bool SpriteSheet2D::EndLoadFromJSONFile()
         return false;
     }
 
-    JSONValue rootVal = loadJSONFile_->GetRoot();
+    JSONValue& rootVal = loadJSONFile_->GetRoot();
     JSONArray subTextureArray = rootVal.Get("subtextures").GetArray();
 
     for (unsigned i = 0; i < subTextureArray.Size(); i++)

--- a/Source/Atomic/Scene/Scene.cpp
+++ b/Source/Atomic/Scene/Scene.cpp
@@ -481,7 +481,7 @@ bool Scene::LoadAsyncJSON(File* file, LoadMode mode)
 
     if (mode > LOAD_RESOURCES_ONLY)
     {
-        JSONValue rootVal = json->GetRoot();
+        JSONValu& rootVal = json->GetRoot();
 
         // Preload resources if appropriate
         if (mode != LOAD_SCENE)

--- a/Source/Atomic/Scene/Scene.cpp
+++ b/Source/Atomic/Scene/Scene.cpp
@@ -481,7 +481,7 @@ bool Scene::LoadAsyncJSON(File* file, LoadMode mode)
 
     if (mode > LOAD_RESOURCES_ONLY)
     {
-        JSONValu& rootVal = json->GetRoot();
+        JSONValue& rootVal = json->GetRoot();
 
         // Preload resources if appropriate
         if (mode != LOAD_SCENE)
@@ -1371,6 +1371,7 @@ void Scene::PreloadResources(File* file, bool isSceneFile)
 
 void Scene::PreloadResourcesXML(const XMLElement& element)
 {
+
     // If not threaded, can not background load resources, so rather load synchronously later when needed
 #ifdef ATOMIC_THREADING
     ResourceCache* cache = GetSubsystem<ResourceCache>();

--- a/Source/ToolCore/Assets/Asset.cpp
+++ b/Source/ToolCore/Assets/Asset.cpp
@@ -172,7 +172,7 @@ bool Asset::Load()
     json_->Load(*file);
     file->Close();
 
-    JSONValue root = json_->GetRoot();
+    JSONValue& root = json_->GetRoot();
 
     assert(root.Get("version").GetInt() == ASSET_VERSION);
 

--- a/Source/ToolCore/Assets/AssetDatabase.cpp
+++ b/Source/ToolCore/Assets/AssetDatabase.cpp
@@ -441,7 +441,7 @@ void AssetDatabase::Scan()
             json->Load(*file);
             file->Close();
 
-            JSONValue root = json->GetRoot();
+            JSONValue& root = json->GetRoot();
 
             assert(root.Get("version").GetInt() == ASSET_VERSION);
 

--- a/Source/ToolCore/Build/BuildBase.cpp
+++ b/Source/ToolCore/Build/BuildBase.cpp
@@ -515,7 +515,7 @@ void BuildBase::BuildFilteredProjectResourceEntries()
             json->Load(*file);
             file->Close();
 
-            JSONValue root = json->GetRoot();
+            JSONValue& root = json->GetRoot();
             int test = root.Get("version").GetInt();
             assert(root.Get("version").GetInt() == ASSET_VERSION);
 

--- a/Source/ToolCore/JSBind/JSBModule.cpp
+++ b/Source/ToolCore/JSBind/JSBModule.cpp
@@ -144,7 +144,7 @@ void JSBModule::ProcessOverloads()
 {
     // overloads
 
-    JSONValue root = moduleJSON_->GetRoot();
+    JSONValue& root = moduleJSON_->GetRoot();
 
     JSONValue overloads = root.Get("overloads");
 
@@ -256,7 +256,7 @@ void JSBModule::ProcessExcludes()
 {
     // excludes
 
-    JSONValue root = moduleJSON_->GetRoot();
+    JSONValue& root = moduleJSON_->GetRoot();
 
     JSONValue excludes = root.Get("excludes");
 
@@ -268,7 +268,7 @@ void JSBModule::ProcessExcludes()
 
 void JSBModule::ProcessClassExcludes()
 {
-    JSONValue root = moduleJSON_->GetRoot();
+    JSONValue& root = moduleJSON_->GetRoot();
 
     JSONValue excludes = root.Get("classExcludes");
 
@@ -302,7 +302,7 @@ void JSBModule::ProcessTypeScriptDecl()
 {
     // TypeScript declarations
 
-    JSONValue root = moduleJSON_->GetRoot();
+    JSONValue& root = moduleJSON_->GetRoot();
 
     JSONValue decl = root.Get("typescript_decl");
 
@@ -335,7 +335,7 @@ void JSBModule::ProcessHaxeDecl()
 {
     // Haxe declarations
 
-    JSONValue root = moduleJSON_->GetRoot();
+    JSONValue& root = moduleJSON_->GetRoot();
 
     JSONValue decl = root.Get("haxe_decl");
 
@@ -689,7 +689,7 @@ bool JSBModule::Load(const String& jsonFilename)
         return false;
     }
 
-    JSONValue root = moduleJSON_->GetRoot();
+    JSONValue& root = moduleJSON_->GetRoot();
 
     name_ = root.Get("name").GetString();
 

--- a/Source/ToolCore/JSBind/JSBPackage.cpp
+++ b/Source/ToolCore/JSBind/JSBPackage.cpp
@@ -226,7 +226,7 @@ bool JSBPackage::Load(const String& packageFolder)
         return false;
     }
 
-    JSONValue root = packageJSON->GetRoot();
+    JSONValue& root = packageJSON->GetRoot();
 
     // first load dependencies
     JSONValue deps = root.Get("dependencies");

--- a/Source/ToolCore/Project/ProjectBuildSettings.cpp
+++ b/Source/ToolCore/Project/ProjectBuildSettings.cpp
@@ -241,7 +241,7 @@ bool ProjectBuildSettings::Load(const String& path)
     if (!result)
         return false;
 
-    JSONValue root = jsonFile->GetRoot();
+    JSONValue& root = jsonFile->GetRoot();
     if (!root.IsObject())
         return false;
 

--- a/Source/ToolCore/Project/ProjectFile.cpp
+++ b/Source/ToolCore/Project/ProjectFile.cpp
@@ -47,7 +47,7 @@ void ProjectFile::WriteNewProject(const String& fullpath)
 {
     SharedPtr<JSONFile> jsonFile(new JSONFile(context_));
 
-    JSONValue root = jsonFile->GetRoot();
+    JSONValue& root = jsonFile->GetRoot();
 
     root.Set("version", PROJECTFILE_VERSION);
 
@@ -71,7 +71,7 @@ void ProjectFile::Save(Project* project)
 
     SharedPtr<JSONFile> jsonFile(new JSONFile(context_));
 
-    JSONValue root = jsonFile->GetRoot();
+    JSONValue& root = jsonFile->GetRoot();
 
     root.Set("version", PROJECTFILE_VERSION);
 
@@ -104,7 +104,7 @@ bool ProjectFile::Load(Project* project)
         if (!jsonFile->BeginLoad(*file))
             return false;
 
-        JSONValue root = jsonFile->GetRoot();
+        JSONValue& root = jsonFile->GetRoot();
 
         int version = root.Get("version").GetInt();
 

--- a/Source/ToolCore/Project/ProjectSettings.cpp
+++ b/Source/ToolCore/Project/ProjectSettings.cpp
@@ -116,7 +116,7 @@ namespace ToolCore
             return false;
         }
 
-        JSONValue root = jsonFile->GetRoot();
+        JSONValue& root = jsonFile->GetRoot();
         if (!root.IsObject())
         {
             ATOMIC_LOGERRORF("No root object in platform settings: %s", path.CString());

--- a/Source/ToolCore/ToolPrefs.cpp
+++ b/Source/ToolCore/ToolPrefs.cpp
@@ -88,7 +88,7 @@ void ToolPrefs::Load()
     if (!result)
         return;
 
-    JSONValue root = jsonFile->GetRoot();
+    JSONValue& root = jsonFile->GetRoot();
     if (!root.IsObject())
         return;
 


### PR DESCRIPTION
Fixes for JSONFile->GetRoot() returning a JSONValue&. I started out fixing the original #1383 issue, but though, if this mistake was made once, how many more times as it made? And here is your answer. It's too bad cppcheck couldn't find it.