### PR TITLE
Incorrect tab selection when resource editor is closed and then a new…

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,6 +49,8 @@
 
 - Ross Hadden (https://github.com/rosshadden)
 
+- Borislav Parvanov (https://github.com/bparvanov)
+
 ### Contribution Copyright and Licensing
 
 Atomic Game Engine contribution copyrights are held by their authors.  Each author retains the copyright to their contribution and agrees to irrevocably license the contribution under the Atomic Game Engine Contribution License `CONTRIBUTION_LICENSE.md`.  Please see `CONTRIBUTING.md` for more details.

--- a/Source/ThirdParty/TurboBadger/tb_tab_container.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_tab_container.cpp
@@ -20,6 +20,13 @@ void TBTabLayout::OnChildAdded(TBWidget *child)
     }
 }
 
+void TBTabLayout::OnChildRemove(TBWidget *child)
+{
+	int index = GetIndexFromChild(child);
+	if (index < tabContainer_->m_current_page)
+		--tabContainer_->m_current_page;
+}
+
 PreferredSize TBTabLayout::OnCalculatePreferredContentSize(const SizeConstraints &constraints)
 {
     PreferredSize ps = TBLayout::OnCalculatePreferredContentSize(constraints);
@@ -39,6 +46,7 @@ TBTabContainer::TBTabContainer()
     : m_need_page_update(true)
     , m_current_page(-1)
     , m_align(TB_ALIGN_TOP)
+	, m_tab_layout(this)
 {
     AddChild(&m_root_layout);
     // Put the tab layout on top of the content in Z order so their skin can make

--- a/Source/ThirdParty/TurboBadger/tb_tab_container.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_tab_container.cpp
@@ -22,9 +22,9 @@ void TBTabLayout::OnChildAdded(TBWidget *child)
 
 void TBTabLayout::OnChildRemove(TBWidget *child)
 {
-	int index = GetIndexFromChild(child);
-	if (index < tabContainer_->m_current_page)
-		--tabContainer_->m_current_page;
+    int index = GetIndexFromChild(child);
+    if (index < tabContainer_->m_current_page)
+        --tabContainer_->m_current_page;
 }
 
 PreferredSize TBTabLayout::OnCalculatePreferredContentSize(const SizeConstraints &constraints)
@@ -46,7 +46,7 @@ TBTabContainer::TBTabContainer()
     : m_need_page_update(true)
     , m_current_page(-1)
     , m_align(TB_ALIGN_TOP)
-	, m_tab_layout(this)
+    , m_tab_layout(this)
 {
     AddChild(&m_root_layout);
     // Put the tab layout on top of the content in Z order so their skin can make

--- a/Source/ThirdParty/TurboBadger/tb_tab_container.h
+++ b/Source/ThirdParty/TurboBadger/tb_tab_container.h
@@ -20,22 +20,22 @@ public:
     // For safe typecasting
     TBOBJECT_SUBCLASS(TBTabLayout, TBLayout);
 
-	TBTabLayout(TBTabContainer *tabContainer) 
-		: tabContainer_(tabContainer) {}
+    TBTabLayout(TBTabContainer *tabContainer) 
+        : tabContainer_(tabContainer) {}
 
     virtual void OnChildAdded(TBWidget *child);
-	virtual void OnChildRemove(TBWidget *child);
+    virtual void OnChildRemove(TBWidget *child);
 
     virtual PreferredSize OnCalculatePreferredContentSize(const SizeConstraints &constraints);
 private:
-	TBTabContainer *tabContainer_;
+    TBTabContainer *tabContainer_;
 };
 
 /** TBTabContainer - A container with tabs for multiple pages. */
 
 class TBTabContainer : public TBWidget
 {
-	friend class TBTabLayout;
+    friend class TBTabLayout;
 public:
     // For safe typecasting
     TBOBJECT_SUBCLASS(TBTabContainer, TBWidget);

--- a/Source/ThirdParty/TurboBadger/tb_tab_container.h
+++ b/Source/ThirdParty/TurboBadger/tb_tab_container.h
@@ -10,6 +10,8 @@
 
 namespace tb {
 
+class TBTabContainer;
+
 /** TBTabLayout is a TBLayout used in TBTabContainer to apply
     some default properties on any TBButton added to it. */
 class TBTabLayout : public TBLayout
@@ -18,14 +20,22 @@ public:
     // For safe typecasting
     TBOBJECT_SUBCLASS(TBTabLayout, TBLayout);
 
+	TBTabLayout(TBTabContainer *tabContainer) 
+		: tabContainer_(tabContainer) {}
+
     virtual void OnChildAdded(TBWidget *child);
+	virtual void OnChildRemove(TBWidget *child);
+
     virtual PreferredSize OnCalculatePreferredContentSize(const SizeConstraints &constraints);
+private:
+	TBTabContainer *tabContainer_;
 };
 
 /** TBTabContainer - A container with tabs for multiple pages. */
 
 class TBTabContainer : public TBWidget
 {
+	friend class TBTabLayout;
 public:
     // For safe typecasting
     TBOBJECT_SUBCLASS(TBTabContainer, TBWidget);


### PR DESCRIPTION
… one is opened

Steps to reproduce:

1. open a resource in Atomic Editor
2. open another one (after this step we have two tabs)
3. close the first tab without selecting it (just press the X)
4. open another resource

Result: Both tabs are selected and we can see the contents of the tab
created in step 2 instead of the one created in step 4

This happens only when we close tabs that reside on the left hand side
of the currently selected tab.

Reason: TBTabContainer::m_current_page is not updated when tabs are
closed