### PR TITLE
Fixes #1305 - Convert constants to enums

### DIFF
--- a/Script/AtomicEditor/ui/modal/info/NewBuildWindow.ts
+++ b/Script/AtomicEditor/ui/modal/info/NewBuildWindow.ts
@@ -45,8 +45,8 @@ class NewBuildWindow extends ModalWindow {
 
         if (!showCheck) {
 
-            this.getWidget("newbuild_check_text").visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
-            this.newBuildCheck.visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
+            this.getWidget("newbuild_check_text").visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
+            this.newBuildCheck.visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
         }
 
         this.resizeToFitContent();

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -367,7 +367,7 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
         while (valsIter != values.End())
         {
             String name = (*valsIter).first_;
-            source_ += "   /** Deprecated - use: [[" + _enum->GetName() + "." + name + "]] */\n";
+            source_ += "   /** Deprecated - use: [[" + _enum->GetName() + "." + name + "]]\n@deprecated */\n";
             source_ += "   export var " + name + ": number;\n";
             valsIter++;
         }

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -340,7 +340,7 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
         JSBEnum* _enum = *enumIter;
 
         source_ += "   /** enum " + _enum->GetName() + "*/\n";
-        source_ += "   export const enum " + _enum->GetName() + " {\n";
+        source_ += "   export enum " + _enum->GetName() + " {\n";
 
         HashMap<String, String>& values = _enum->GetValues();
 
@@ -349,28 +349,8 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
         while (valsIter != values.End())
         {
             String name = (*valsIter).first_;
-            String value = (*valsIter).second_;
 
-            // BodyType2D enum order is assigned in RigidBody2D.h in incorrect order
-            if (_enum->GetName() == "BodyType2D")
-            {
-                if (name == "BT_STATIC")
-                    value = "0";
-                else if (name == "BT_KINEMATIC")
-                    value = "1";
-                else if (name == "BT_DYNAMIC")
-                    value = "2";
-            }
-
-            //source_ += "   export var " + name + ": " +  _enum->GetName() + ";\n";
-            source_ += "       /** TypeScript Only - For vanilla JavaScript, use: [[" + package_->GetName() + "." + name + "]] */\n";
-            if (value != "")
-            {
-                source_ += "       " + name + " = " + value;
-            } else {
-                source_ += "       " + name;
-            }
-
+            source_ += "       " + name;
             valsIter++;
 
             if (valsIter != values.End())
@@ -381,13 +361,13 @@ void JSBTypeScript::ExportModuleEnums(JSBModule* module)
         source_ += "    }\n";
         source_ += "\n";
 
-        // legacy support
+        // legacy support - This should be removed in a couple releases
         source_ += "   // Legacy JS Access for enum:  " + _enum->GetName() + "\n";
         valsIter = values.Begin();
         while (valsIter != values.End())
         {
             String name = (*valsIter).first_;
-            source_ += "   /** JavaScript Only - For TypeScript, use: [[" + _enum->GetName() + "." + name + "]] */\n";
+            source_ += "   /** Deprecated - use: [[" + _enum->GetName() + "." + name + "]] */\n";
             source_ += "   export var " + name + ": number;\n";
             valsIter++;
         }

--- a/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
+++ b/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
@@ -234,7 +234,7 @@ void JSModuleWriter::WriteModulePreInit(String& source)
         while (itr != values.End())
         {
             String name = (*itr).first_;
-            source.AppendWithFormat("duk_push_number(ctx, (double) %s);\n", name.CString());
+            source.AppendWithFormat("duk_push_number(ctx, %s);\n", name.CString());
             source.AppendWithFormat("duk_put_prop_string(ctx, -2, \"%s\");\n",name.CString());
             itr++;
         }
@@ -247,7 +247,7 @@ void JSModuleWriter::WriteModulePreInit(String& source)
         while (itr != values.End())
         {
             String name = (*itr).first_;
-            source.AppendWithFormat("duk_push_number(ctx, (double) %s);\n", name.CString());
+            source.AppendWithFormat("duk_push_number(ctx, %s);\n", name.CString());
             source.AppendWithFormat("duk_put_prop_string(ctx, -2, \"%s\");\n",name.CString());
             itr++;
         }

--- a/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
+++ b/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
@@ -230,6 +230,7 @@ void JSModuleWriter::WriteModulePreInit(String& source)
 
         HashMap<String, String>::ConstIterator itr = values.Begin();
 
+        // Legacy mode - this should be removed at some point
         while (itr != values.End())
         {
             String name = (*itr).first_;
@@ -237,6 +238,20 @@ void JSModuleWriter::WriteModulePreInit(String& source)
             source.AppendWithFormat("duk_put_prop_string(ctx, -2, \"%s\");\n",name.CString());
             itr++;
         }
+
+        // Preferred way - built-in enum
+        itr = values.Begin();
+        source.Append("duk_push_object(ctx);\n");
+        source.Append("duk_dup(ctx, -1);\n");
+        source.AppendWithFormat("duk_put_prop_string(ctx, -3, \"%s\");\n", jenum->GetName().CString());
+        while (itr != values.End())
+        {
+            String name = (*itr).first_;
+            source.AppendWithFormat("duk_push_number(ctx, (double) %s);\n", name.CString());
+            source.AppendWithFormat("duk_put_prop_string(ctx, -2, \"%s\");\n",name.CString());
+            itr++;
+        }
+        source.Append("duk_pop(ctx);\n");
     }
 
     source += "// constants\n";


### PR DESCRIPTION
This PR adds new JS object literals to the Atomic namespace that allows for more proper enums instead of having to use constants.  Now, in both TS and JS, instead of using:
```
Atomic.BT_STATIC
```

you can use
```
Atomic.BodyType2D.BT_STATIC
```


The original constants are still present in the Atomic namespace so existing code doesn't break, but it is flagged to be removed.  I also left the existing constants in the ```d.ts```, but am contemplating removing it.  The repercussions would be that existing TS that uses the constants would have transpilation errors and would have to be converted to use the enums, but the JS would work fine.  Also, it would clean up the auto-generated documentations and not have all those extra constants.  Thoughts?

Each of the existing legacy constants has a comment stating that it is deprecated and points to the corresponding enum.