### PR TITLE
Inspector array/vector support for dynamic defined arrays

### DIFF
--- a/Script/AtomicEditor/ui/frames/inspector/AssemblyInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/AssemblyInspector.ts
@@ -21,7 +21,6 @@
 //
 
 import InspectorWidget = require("./InspectorWidget");
-import ArrayEditWidget = require("./ArrayEditWidget");
 import InspectorUtils = require("./InspectorUtils");
 
 class AssemblyInspector extends InspectorWidget {

--- a/Script/AtomicEditor/ui/frames/inspector/InspectorUtils.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/InspectorUtils.ts
@@ -143,7 +143,7 @@ class InspectorUtils {
   static createAttrEditFieldWithSelectButton(name:string, parent:Atomic.UIWidget):{editField:Atomic.UIEditField, selectButton:Atomic.UIButton} {
 
     var attrLayout = new Atomic.UILayout();
-    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
+    attrLayout.layoutDistributionPosition = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
 
     if (name) {
       var _name = InspectorUtils.createAttrName(name);
@@ -151,7 +151,7 @@ class InspectorUtils {
     }
 
     var fieldLayout = new Atomic.UILayout();
-    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
+    fieldLayout.layoutDistributionPosition = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
 
     var edit = InspectorUtils.createEditField();
 
@@ -172,7 +172,7 @@ class InspectorUtils {
   static createAttrColorFieldWithSelectButton(name:string, parent:Atomic.UIWidget):{colorWidget:Atomic.UIColorWidget, selectButton:Atomic.UIButton} {
 
     var attrLayout = new Atomic.UILayout();
-    attrLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
+    attrLayout.layoutDistributionPosition = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
 
     if (name) {
       var _name = InspectorUtils.createAttrName(name);
@@ -180,7 +180,7 @@ class InspectorUtils {
     }
 
     var fieldLayout = new Atomic.UILayout();
-    fieldLayout.layoutDistribution = Atomic.UI_LAYOUT_DISTRIBUTION.UI_LAYOUT_DISTRIBUTION_AVAILABLE;
+    fieldLayout.layoutDistributionPosition = Atomic.UI_LAYOUT_DISTRIBUTION_POSITION.UI_LAYOUT_DISTRIBUTION_POSITION_LEFT_TOP;
 
     var colorWidget = InspectorUtils.createColorWidget();
 

--- a/Script/AtomicEditor/ui/frames/inspector/PrefabInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/PrefabInspector.ts
@@ -21,7 +21,6 @@
 //
 
 import InspectorWidget = require("./InspectorWidget");
-import ArrayEditWidget = require("./ArrayEditWidget");
 import InspectorUtils = require("./InspectorUtils");
 
 class PrefabInspector extends InspectorWidget {

--- a/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/SelectionInspector.ts
@@ -238,7 +238,7 @@ class CSComponentSection extends ComponentSection {
         if (object) {
             var value = object.getAttribute("Class");
             if (value)
-                this.text = value;
+                this.text = value + " - C#";
         }
     }
 

--- a/Script/AtomicNET/AtomicNETService/AssemblyInspector.cs
+++ b/Script/AtomicNET/AtomicNETService/AssemblyInspector.cs
@@ -228,6 +228,7 @@ namespace AtomicTools
             var dict = new Dictionary<string, object>();
 
             dict["isEnum"] = IsEnum;
+            dict["isArray"] = IsArray;
             dict["typeName"] = TypeName;
             dict["name"] = Name;
             dict["defaultValue"] = DefaultValue;
@@ -240,6 +241,7 @@ namespace AtomicTools
         }
 
         public bool IsEnum = false;
+        public bool IsArray = false;
 
         public string TypeName;
 

--- a/Script/AtomicNET/AtomicNETService/Program.cs
+++ b/Script/AtomicNET/AtomicNETService/Program.cs
@@ -8,6 +8,16 @@ namespace AtomicTools
     {
         public static void Main(string[] args)
         {
+            for (uint i = 0; i < args.Length; i++)
+            {
+                if (args[i] == "--debugassembly" && i + 1 < args.Length)
+                {
+                    var assemblyJSON = AtomicTools.InspectAssembly(args[i + 1]);
+                    Console.WriteLine(assemblyJSON);
+                    return;
+                }
+            }
+
             // create the service
             var app = NETServiceApplication.Create();
 

--- a/Script/Packages/Atomic/Scene.json
+++ b/Script/Packages/Atomic/Scene.json
@@ -31,8 +31,8 @@
 
 		"Serializable" : [
 			"getAttributes():AttributeInfo[];",
-			"getAttribute(name:string):any;",
-			"setAttribute(name:string, value:any):void;"
+			"getAttribute(name:string, index?:number):any;",
+			"setAttribute(name:string, value:any, index?:number):void;"
 		],
 		"Node" : [
 			"saveXML(file:File):boolean;",

--- a/Script/TypeScript/AtomicWork.d.ts
+++ b/Script/TypeScript/AtomicWork.d.ts
@@ -121,7 +121,7 @@ declare module Atomic {
         resourceTypeName: string;
         dynamic: boolean;
         tooltip: string;
-
+        isArray:boolean;
     }
 
     export interface ShaderParameter {

--- a/Source/Atomic/Graphics/AnimatedModel.cpp
+++ b/Source/Atomic/Graphics/AnimatedModel.cpp
@@ -324,26 +324,7 @@ void AnimatedModel::UpdateBatches(const FrameInfo& frame)
 
     // Handle mesh hiding
     if (geometryDisabled_)
-    {
-        for (unsigned i = 0; i < batches_.Size(); ++i)
-        {
-            SourceBatch* batch = &batches_[i];
-            StaticModelGeometryData* data = &geometryData_[i];
-
-            if (batch->geometry_)
-                data->batchGeometry_ = batch->geometry_;
-
-            if (data->enabled_ && !batch->geometry_)
-            {
-                batch->geometry_ = data->batchGeometry_;
-            }
-            else if (!data->enabled_ && batch->geometry_)
-            {
-                data->batchGeometry_ = batch->geometry_;
-                batch->geometry_ = 0;
-            }
-        }
-    }
+        UpdateBatchesHideGeometry();
 
     // ATOMIC END
 

--- a/Source/Atomic/Graphics/StaticModel.h
+++ b/Source/Atomic/Graphics/StaticModel.h
@@ -116,6 +116,9 @@ public:
     /// Hide a named submesh
     void HideGeometry(const String& name);
 
+    /// Returns true if any geometry is hidden in the model
+    bool GetGeometryHidden() const { return geometryDisabled_; }
+
     void SetGeometryEnabledAttr(const VariantVector& value);
     const VariantVector& GetGeometryEnabledAttr() const;
 
@@ -145,6 +148,10 @@ protected:
     mutable ResourceRefList materialsAttr_;
 
     // ATOMIC BEGIN
+
+    // Apply geometry hiding when updating batches
+    void UpdateBatchesHideGeometry();
+
     mutable VariantVector geometryEnabled_;
     /// true if any geometry has been disabled
     mutable bool geometryDisabled_;

--- a/Source/Atomic/Script/ScriptComponentFile.cpp
+++ b/Source/Atomic/Script/ScriptComponentFile.cpp
@@ -53,10 +53,11 @@ void ScriptComponentFile::AddEnum(const String& enumName, const EnumInfo& enumIn
     enumValues.Push(enumInfo);
 }
 
-void ScriptComponentFile::AddField(const String& fieldName, VariantType variantType, const String &classname, const String& tooltip)
+void ScriptComponentFile::AddField(const String& fieldName, VariantType variantType, bool isArray, const String &classname, const String& tooltip)
 {
     FieldMap& fields = classFields_[classname];
-    fields[fieldName] = variantType;
+    FieldInfo finfo(fieldName, variantType, isArray);
+    fields[fieldName] = finfo;
 
     if (tooltip.Length())
     {
@@ -145,11 +146,17 @@ void ScriptComponentFile::GetDefaultFieldValue(const String& name, Variant& v,co
     if (!fieldMap)
         return;
 
-    const VariantType* variantType = (*fieldMap)[name];
+    const FieldInfo* finfo = (*fieldMap)[name];
+
+    if (!finfo || finfo->isArray_)
+        return;
+
+    VariantType variantType = finfo->variantType_;
+
     if (!variantType)
         return;
 
-    switch (*variantType)
+    switch (variantType)
     {
     case VAR_BOOL:
         v = false;

--- a/Source/Atomic/Script/ScriptComponentFile.h
+++ b/Source/Atomic/Script/ScriptComponentFile.h
@@ -29,6 +29,28 @@
 namespace Atomic
 {
 
+
+struct FieldInfo
+{
+    FieldInfo()
+    {
+        name_ = "UNINITIALIZED_FIELDINFO";
+        variantType_ = VAR_NONE;
+        isArray_ = false;
+    }
+
+    FieldInfo(const String& name, VariantType variantType, bool isArray = false)
+    {
+        name_ = name;
+        variantType_ = variantType;
+        isArray_ = isArray;
+    }
+
+    String name_;
+    VariantType variantType_;
+    bool isArray_;
+};
+
 struct EnumInfo
 {
     EnumInfo(const String& name = String::EMPTY, const Variant& v = Variant::EMPTY)
@@ -42,7 +64,7 @@ struct EnumInfo
 };
 
 // TODO: these should be broken out into some class info structs, getting unwieldy
-typedef HashMap<String, VariantType> FieldMap;
+typedef HashMap<String, FieldInfo> FieldMap;
 typedef HashMap<String, Vector<EnumInfo>> EnumMap;
 typedef HashMap<String, String> FieldTooltipMap;
 
@@ -80,7 +102,7 @@ protected:
     void Clear();
 
     void AddEnum(const String& enumName, const EnumInfo& enumInfo, const String& classname = String::EMPTY);
-    void AddField(const String& fieldName, VariantType variantType, const String& classname = String::EMPTY, const String& tooltip = String::EMPTY);
+    void AddField(const String& fieldName, VariantType variantType, bool isArray, const String& classname = String::EMPTY, const String& tooltip = String::EMPTY);
     void AddDefaultValue(const String& fieldName, const Variant& value, const String& classname = String::EMPTY);
 
     // only valid in editor

--- a/Source/Atomic/Script/ScriptVariant.h
+++ b/Source/Atomic/Script/ScriptVariant.h
@@ -42,34 +42,67 @@ namespace Atomic
 
         }
 
+        ScriptVariant(const Variant& source) : RefCounted()
+        {
+            variant_ = source;
+        }
+
         virtual ~ScriptVariant()
         {
 
         }
 
-        const Variant& GetVariant() { return variant_; }
+        const Variant& GetVariant() const { return variant_; }
 
         void SetVariant(const Variant& value) { variant_ = value; }
 
-        Vector2 GetVector2() { return variant_.GetVector2(); }
+        bool GetBool() const { return variant_.GetBool(); }
+
+        void SetBool(bool value) { variant_ = value; }
+
+        int GetInt() const { return variant_.GetInt(); }
+
+        void SetInt(int value) { variant_ = value; }
+
+        unsigned GetUInt() const { return variant_.GetUInt(); }
+
+        void SetUInt(unsigned value) { variant_ = value; }
+
+        float GetFloat() const { return variant_.GetFloat(); }
+
+        void SetFloat(float value) { variant_ = value; }
+
+        const Vector2& GetVector2() const { return variant_.GetVector2(); }
 
         void SetVector2(const Vector2& value) { variant_ = value; }
 
-        Vector3 GetVector3() { return variant_.GetVector3(); }
+        const Vector3& GetVector3() const { return variant_.GetVector3(); }
 
         void SetVector3(const Vector3& value) { variant_ = value; }
 
-        Vector4 GetVector4() { return variant_.GetVector4(); }
+        const Quaternion& GetQuaternion() const { return variant_.GetQuaternion(); }
+
+        void SetQuaternion(const Quaternion& value) { variant_ = value; }
+
+        const Vector4& GetVector4() const { return variant_.GetVector4(); }
 
         void SetVector4(const Vector4& value) { variant_ = value; }
 
-        Color GetColor() { return variant_.GetColor(); }
+        const Color& GetColor() const { return variant_.GetColor(); }
 
         void SetColor(const Color& value) { variant_ = value; }
 
-        String GetString() { return variant_.GetString(); }
+        const String& GetString() const { return variant_.GetString(); }
 
         void SetString(const String& value) { variant_ = value; }
+
+        const VariantVector& GetVariantVector() const { return variant_.GetVariantVector(); }
+
+        void SetVariantVector(const VariantVector& value) { variant_ = value; }
+
+        const VariantMap& GetVariantMap() const { return variant_.GetVariantMap(); }
+
+        void SetVariantMap(const VariantMap& value) { variant_ = value; }
 
     private:
 

--- a/Source/Atomic/Script/ScriptVariantMap.h
+++ b/Source/Atomic/Script/ScriptVariantMap.h
@@ -147,6 +147,20 @@ public:
 
     }
 
+    const VariantVector& GetVariantVector(StringHash key) const
+    {
+        static VariantVector empty;
+
+        Variant* variant = vmap_[key];
+
+        if (!variant)
+            return empty;
+
+        return variant->GetVariantVector();
+
+    }
+
+
     VariantType GetVariantType(StringHash key) const
     {
         Variant* variant = vmap_[key];

--- a/Source/AtomicJS/Javascript/JSAPI.cpp
+++ b/Source/AtomicJS/Javascript/JSAPI.cpp
@@ -22,6 +22,7 @@
 
 #include <Atomic/Core/Context.h>
 #include <Atomic/Resource/ResourceCache.h>
+#include <Atomic/Script/ScriptVector.h>
 
 #include "JSAPI.h"
 #include "JSVM.h"
@@ -47,658 +48,756 @@
 namespace Atomic
 {
 
-void js_class_get_prototype(duk_context* ctx, const char* package, const char *classname)
-{
-    duk_get_global_string(ctx, package);
-    duk_get_prop_string(ctx, -1, classname);
-    duk_get_prop_string(ctx, -1, "prototype");
-    duk_remove(ctx, -2); // remove class object
-    duk_remove(ctx, -2); // remove Atomic object
-}
-
-void js_class_get_constructor(duk_context* ctx, const char* package, const char *classname)
-{
-    duk_get_global_string(ctx, package);
-    duk_get_prop_string(ctx, -1, classname);
-    duk_remove(ctx, -2); // remove package
-}
-
-void js_constructor_basecall(duk_context* ctx, const char* package, const char* baseclass)
-{
-    int top = duk_get_top(ctx);
-    duk_get_global_string(ctx, package);
-    duk_get_prop_string(ctx, -1, baseclass);
-    assert(duk_is_function(ctx, -1));
-    duk_push_this(ctx);
-    duk_call_method(ctx, 0);
-    duk_pop_n(ctx, 2);
-    assert (top == duk_get_top(ctx));
-}
-
-void js_class_declare_internal(JSVM* vm, void* uniqueClassID, const char* package, const char* classname, duk_c_function constructor)
-{
-    duk_context* ctx = vm->GetJSContext();
-
-    // uniqueClassID must be non-null
-    assert(uniqueClassID);
-
-    // stash a lookup from the uniqueID to the package and class name
-
-    duk_push_heap_stash(ctx);
-    duk_push_pointer(ctx, uniqueClassID);
-
-    duk_push_object(ctx);
-    duk_push_string(ctx, package);
-    duk_put_prop_index(ctx, -2, 0);
-    duk_push_string(ctx, classname);
-    duk_put_prop_index(ctx, -2, 1);
-
-    // store class object into uniqueClassID key
-    duk_put_prop(ctx, -3);
-
-    // pop heap stash
-    duk_pop(ctx);
-
-    // store the constructor
-    duk_get_global_string(ctx, package);
-    duk_push_c_function(ctx, constructor, DUK_VARARGS);
-    duk_put_prop_string(ctx, -2, classname);
-    duk_pop(ctx);
-}
-
-void js_class_push_propertyobject(JSVM* vm, const char* package, const char* classname)
-{
-    duk_context* ctx = vm->GetJSContext();
-    String pname;
-    pname.AppendWithFormat("__%s__Properties", classname);
-
-    duk_get_global_string(ctx, package);
-    duk_push_object(ctx);
-    duk_dup(ctx, -1);
-    duk_put_prop_string(ctx, -3, pname.CString());
-    duk_remove(ctx, -2); // remove Atomic object
-}
-
-void js_setup_prototype(JSVM* vm, const char* package, const char* classname, const char* basePackage, const char* basename, bool hasProperties)
-{
-    duk_context* ctx = vm->GetJSContext();
-
-    String pname;
-    pname.AppendWithFormat("__%s__Properties", classname);
-
-    int top = duk_get_top(ctx);
-
-    duk_get_global_string(ctx,package);
-    duk_get_prop_string(ctx, -1, classname);
-    assert(duk_is_c_function(ctx, -1));
-
-    if (!strlen(basename))
-    {
-        // prototype
-        duk_push_object(ctx);
-        duk_dup(ctx, -2); // AObject constructor function
-        duk_put_prop_string(ctx, -2, "constructor");
-        duk_put_prop_string(ctx, -2, "prototype");
-
-        duk_pop_n(ctx, 2);
-
-        assert (top == duk_get_top(ctx));
-
-        return;
-
-    }
-
-    // prototype
-    duk_get_global_string(ctx, "Object");
-    duk_get_prop_string(ctx, -1, "create");
-
-    assert(duk_is_function(ctx, -1));
-
-    duk_remove(ctx, -2); // remove Object
-
-    duk_get_global_string(ctx, basePackage);
-    duk_get_prop_string(ctx, -1, basename);
-    assert(duk_is_function(ctx, -1));
-    duk_get_prop_string(ctx, -1, "prototype");
-
-    assert(duk_is_object(ctx, -1));
-
-    duk_remove(ctx, -2); // remove basename
-
-    int numargs = 1;
-    if (hasProperties)
+    void js_class_get_prototype(duk_context* ctx, const char* package, const char *classname)
     {
         duk_get_global_string(ctx, package);
-        duk_get_prop_string(ctx, -1, pname.CString());
-        assert(duk_is_object(ctx, -1));
-        duk_remove(ctx, -2);
-        duk_remove(ctx, -3); // remove package
-        numargs++;
-    }
-    else
-        duk_remove(ctx, -2); // remove package
-
-    duk_call(ctx, numargs);
-
-    assert(duk_is_object(ctx, -1));
-
-    duk_dup(ctx, -2);
-    duk_put_prop_string(ctx, -2, "constructor");
-
-    //duk_dup(ctx, -1);
-    duk_put_prop_string(ctx, -2, "prototype");
-
-    // pop the classname object
-    duk_pop(ctx);
-
-    // pop the Atomic Object
-    duk_pop(ctx);
-
-    assert (top == duk_get_top(ctx));
-}
-
-
-// When subscribing to native event, this method will be called
-// to provide the event meta data (type and callback)
-static int js_push_native_event_metadata(duk_context* ctx) {
-
-    duk_push_current_function(ctx);
-
-    duk_push_object(ctx);
-    duk_get_prop_string(ctx, -2, "_eventType");
-    duk_put_prop_string(ctx, -2, "_eventType");
-    duk_dup(ctx, 0);
-    duk_put_prop_string(ctx, -2, "_callback");
-
-    return 1;
-}
-
-void js_define_native_event(duk_context* ctx, const String& eventType, const String &eventName)
-{
-    // push c function which takes 1 argument, the callback
-    duk_push_c_function(ctx, js_push_native_event_metadata, 1);
-
-    // store the event type in the function object
-    duk_push_string(ctx, eventType.CString());
-    duk_put_prop_string(ctx, -2, "_eventType");
-
-    // store to module object
-    duk_put_prop_string(ctx, -2, eventName.CString());
-
-}
-
-void js_object_to_variantmap(duk_context* ctx, int objIdx, VariantMap &v)
-{
-    v.Clear();
-
-    duk_enum(ctx, objIdx, DUK_ENUM_OWN_PROPERTIES_ONLY);
-
-    while (duk_next(ctx, -1 /*enum_index*/, 1 /*get_value*/)) {
-
-        /* [ ... enum key ] */
-
-        const char* key = duk_to_string(ctx, -2);
-
-        if (duk_is_number(ctx, -1)) {
-
-            v[key] = (float) duk_to_number(ctx, -1);
-
-        } else if (duk_is_boolean(ctx, -1)) {
-
-            v[key] = duk_to_boolean(ctx, -1) ? true : false;
-
-        }
-        else if (duk_is_string(ctx, -1)) {
-
-            v[key] = duk_to_string(ctx, -1);
-
-        } else if (duk_get_heapptr(ctx, -1)) {
-
-            v[key] = js_to_class_instance<Object>(ctx, -1, 0);
-
-        }
-
-        duk_pop_2(ctx);  /* pop_key & value*/
+        duk_get_prop_string(ctx, -1, classname);
+        duk_get_prop_string(ctx, -1, "prototype");
+        duk_remove(ctx, -2); // remove class object
+        duk_remove(ctx, -2); // remove Atomic object
     }
 
-    duk_pop(ctx);  /* pop enum object */
-
-}
-
-duk_bool_t js_check_is_buffer_and_get_data(duk_context* ctx, duk_idx_t idx, void** data, duk_size_t* size)
-{
-    void* temp;
-    if (duk_is_buffer(ctx, idx))
+    void js_class_get_constructor(duk_context* ctx, const char* package, const char *classname)
     {
-        temp = duk_get_buffer_data(ctx, idx, size);
+        duk_get_global_string(ctx, package);
+        duk_get_prop_string(ctx, -1, classname);
+        duk_remove(ctx, -2); // remove package
+    }
+
+    void js_constructor_basecall(duk_context* ctx, const char* package, const char* baseclass)
+    {
+        int top = duk_get_top(ctx);
+        duk_get_global_string(ctx, package);
+        duk_get_prop_string(ctx, -1, baseclass);
+        assert(duk_is_function(ctx, -1));
+        duk_push_this(ctx);
+        duk_call_method(ctx, 0);
+        duk_pop_n(ctx, 2);
+        assert(top == duk_get_top(ctx));
+    }
+
+    void js_class_declare_internal(JSVM* vm, void* uniqueClassID, const char* package, const char* classname, duk_c_function constructor)
+    {
+        duk_context* ctx = vm->GetJSContext();
+
+        // uniqueClassID must be non-null
+        assert(uniqueClassID);
+
+        // stash a lookup from the uniqueID to the package and class name
+
+        duk_push_heap_stash(ctx);
+        duk_push_pointer(ctx, uniqueClassID);
+
+        duk_push_object(ctx);
+        duk_push_string(ctx, package);
+        duk_put_prop_index(ctx, -2, 0);
+        duk_push_string(ctx, classname);
+        duk_put_prop_index(ctx, -2, 1);
+
+        // store class object into uniqueClassID key
+        duk_put_prop(ctx, -3);
+
+        // pop heap stash
+        duk_pop(ctx);
+
+        // store the constructor
+        duk_get_global_string(ctx, package);
+        duk_push_c_function(ctx, constructor, DUK_VARARGS);
+        duk_put_prop_string(ctx, -2, classname);
+        duk_pop(ctx);
+    }
+
+    void js_class_push_propertyobject(JSVM* vm, const char* package, const char* classname)
+    {
+        duk_context* ctx = vm->GetJSContext();
+        String pname;
+        pname.AppendWithFormat("__%s__Properties", classname);
+
+        duk_get_global_string(ctx, package);
+        duk_push_object(ctx);
+        duk_dup(ctx, -1);
+        duk_put_prop_string(ctx, -3, pname.CString());
+        duk_remove(ctx, -2); // remove Atomic object
+    }
+
+    void js_setup_prototype(JSVM* vm, const char* package, const char* classname, const char* basePackage, const char* basename, bool hasProperties)
+    {
+        duk_context* ctx = vm->GetJSContext();
+
+        String pname;
+        pname.AppendWithFormat("__%s__Properties", classname);
+
+        int top = duk_get_top(ctx);
+
+        duk_get_global_string(ctx, package);
+        duk_get_prop_string(ctx, -1, classname);
+        assert(duk_is_c_function(ctx, -1));
+
+        if (!strlen(basename))
+        {
+            // prototype
+            duk_push_object(ctx);
+            duk_dup(ctx, -2); // AObject constructor function
+            duk_put_prop_string(ctx, -2, "constructor");
+            duk_put_prop_string(ctx, -2, "prototype");
+
+            duk_pop_n(ctx, 2);
+
+            assert(top == duk_get_top(ctx));
+
+            return;
+
+        }
+
+        // prototype
+        duk_get_global_string(ctx, "Object");
+        duk_get_prop_string(ctx, -1, "create");
+
+        assert(duk_is_function(ctx, -1));
+
+        duk_remove(ctx, -2); // remove Object
+
+        duk_get_global_string(ctx, basePackage);
+        duk_get_prop_string(ctx, -1, basename);
+        assert(duk_is_function(ctx, -1));
+        duk_get_prop_string(ctx, -1, "prototype");
+
+        assert(duk_is_object(ctx, -1));
+
+        duk_remove(ctx, -2); // remove basename
+
+        int numargs = 1;
+        if (hasProperties)
+        {
+            duk_get_global_string(ctx, package);
+            duk_get_prop_string(ctx, -1, pname.CString());
+            assert(duk_is_object(ctx, -1));
+            duk_remove(ctx, -2);
+            duk_remove(ctx, -3); // remove package
+            numargs++;
+        }
+        else
+            duk_remove(ctx, -2); // remove package
+
+        duk_call(ctx, numargs);
+
+        assert(duk_is_object(ctx, -1));
+
+        duk_dup(ctx, -2);
+        duk_put_prop_string(ctx, -2, "constructor");
+
+        //duk_dup(ctx, -1);
+        duk_put_prop_string(ctx, -2, "prototype");
+
+        // pop the classname object
+        duk_pop(ctx);
+
+        // pop the Atomic Object
+        duk_pop(ctx);
+
+        assert(top == duk_get_top(ctx));
+    }
+
+
+    // When subscribing to native event, this method will be called
+    // to provide the event meta data (type and callback)
+    static int js_push_native_event_metadata(duk_context* ctx) {
+
+        duk_push_current_function(ctx);
+
+        duk_push_object(ctx);
+        duk_get_prop_string(ctx, -2, "_eventType");
+        duk_put_prop_string(ctx, -2, "_eventType");
+        duk_dup(ctx, 0);
+        duk_put_prop_string(ctx, -2, "_callback");
+
+        return 1;
+    }
+
+    void js_define_native_event(duk_context* ctx, const String& eventType, const String &eventName)
+    {
+        // push c function which takes 1 argument, the callback
+        duk_push_c_function(ctx, js_push_native_event_metadata, 1);
+
+        // store the event type in the function object
+        duk_push_string(ctx, eventType.CString());
+        duk_put_prop_string(ctx, -2, "_eventType");
+
+        // store to module object
+        duk_put_prop_string(ctx, -2, eventName.CString());
+
+    }
+
+    void js_object_to_variantmap(duk_context* ctx, int objIdx, VariantMap &v)
+    {
+        v.Clear();
+
+        duk_enum(ctx, objIdx, DUK_ENUM_OWN_PROPERTIES_ONLY);
+
+        while (duk_next(ctx, -1 /*enum_index*/, 1 /*get_value*/)) {
+
+            /* [ ... enum key ] */
+
+            const char* key = duk_to_string(ctx, -2);
+
+            if (duk_is_number(ctx, -1)) {
+
+                v[key] = (float)duk_to_number(ctx, -1);
+
+            }
+            else if (duk_is_boolean(ctx, -1)) {
+
+                v[key] = duk_to_boolean(ctx, -1) ? true : false;
+
+            }
+            else if (duk_is_string(ctx, -1)) {
+
+                v[key] = duk_to_string(ctx, -1);
+
+            }
+            else if (duk_get_heapptr(ctx, -1)) {
+
+                v[key] = js_to_class_instance<Object>(ctx, -1, 0);
+
+            }
+
+            duk_pop_2(ctx);  /* pop_key & value*/
+        }
+
+        duk_pop(ctx);  /* pop enum object */
+
+    }
+
+    duk_bool_t js_check_is_buffer_and_get_data(duk_context* ctx, duk_idx_t idx, void** data, duk_size_t* size)
+    {
+        void* temp;
+        if (duk_is_buffer(ctx, idx))
+        {
+            temp = duk_get_buffer_data(ctx, idx, size);
+            if (data)
+            {
+                *data = temp;
+            }
+            return true;
+        }
+        if (!(duk_is_object(ctx, idx) &&
+            duk_has_prop_string(ctx, idx, "length") &&
+            duk_has_prop_string(ctx, idx, "byteLength") &&
+            duk_has_prop_string(ctx, idx, "byteOffset") &&
+            duk_has_prop_string(ctx, idx, "BYTES_PER_ELEMENT")))
+        {
+            if (data)
+            {
+                *data = nullptr;
+            }
+            if (size)
+            {
+                *size = 0;
+            }
+            return false;
+        }
+        temp = duk_require_buffer_data(ctx, idx, size);
         if (data)
         {
             *data = temp;
         }
         return true;
     }
-    if (!(duk_is_object(ctx, idx) &&
-        duk_has_prop_string(ctx, idx, "length") &&
-        duk_has_prop_string(ctx, idx, "byteLength") &&
-        duk_has_prop_string(ctx, idx, "byteOffset") &&
-        duk_has_prop_string(ctx, idx, "BYTES_PER_ELEMENT")))
+
+    void js_push_default_variant(duk_context* ctx, VariantType variantType, Variant& value)
     {
-        if (data)
+        value = Variant::EMPTY;
+        
+        switch (variantType)
         {
-            *data = nullptr;
-        }
-        if (size)
-        {
-            *size = 0;
-        }
-        return false;
-    }
-    temp = duk_require_buffer_data(ctx, idx, size);
-    if (data)
-    {
-        *data = temp;
-    }
-    return true;
-}
 
-void js_to_variant(duk_context* ctx, int variantIdx, Variant &v, VariantType variantType)
-{
-    v.Clear();
+        case VAR_NONE:
+            break;
 
-    // convert to abs index
-    if (variantIdx < 0)
-        variantIdx = duk_get_top(ctx) + variantIdx;
+        case VAR_INT:
+            value = 0;
+            break;
 
-    if (duk_is_boolean(ctx, variantIdx))
-    {
-        v = duk_to_boolean(ctx, variantIdx) ? true : false;
-        return;
-    }
+        case VAR_BOOL:
+            value = false;
+            break;
 
-    if (duk_is_string(ctx, variantIdx))
-    {
-        v = duk_to_string(ctx, variantIdx);
-        return;
-    }
+        case VAR_FLOAT:
+            value = 0.0f;
+            break;
 
-    if (duk_is_number(ctx, variantIdx))
-    {
-        v = (float) duk_to_number(ctx, variantIdx);
-        return;
-    }
+        case VAR_VECTOR2:
+            value = Vector2::ZERO;
+            break;
 
-    if (duk_is_pointer(ctx, variantIdx))
-    {
-        v = (RefCounted*) duk_get_pointer(ctx, variantIdx);
-        return;
-    }
+        case VAR_VECTOR3:
+            value = Vector3::ZERO;
+            break;
 
-    if (duk_is_array(ctx, variantIdx))
-    {
-        if (duk_get_length(ctx, variantIdx) == 2)
-        {
-            Vector2 v2;
-            duk_get_prop_index(ctx, variantIdx, 0);
-            v2.x_ = duk_to_number(ctx, -1);
-            duk_get_prop_index(ctx, variantIdx, 1);
-            v2.y_ = duk_to_number(ctx, -1);
-            duk_pop_n(ctx, 2);
-            v = v2;
-            return;
-        }
-        else if (duk_get_length(ctx, variantIdx) == 3)
-        {
-            Vector3 v3;
-            duk_get_prop_index(ctx, variantIdx, 0);
-            v3.x_ = duk_to_number(ctx, -1);
-            duk_get_prop_index(ctx, variantIdx, 1);
-            v3.y_ = duk_to_number(ctx, -1);
-            duk_get_prop_index(ctx, variantIdx, 2);
-            v3.z_ = duk_to_number(ctx, -1);
-            duk_pop_n(ctx, 3);
-            v = v3;
-            return;
-        }
-        else if (duk_get_length(ctx, variantIdx) == 4)
-        {
-            Vector4 v4;
-            duk_get_prop_index(ctx, variantIdx, 0);
-            v4.x_ = duk_to_number(ctx, -1);
-            duk_get_prop_index(ctx, variantIdx, 1);
-            v4.y_ = duk_to_number(ctx, -1);
-            duk_get_prop_index(ctx, variantIdx, 2);
-            v4.z_ = duk_to_number(ctx, -1);
-            duk_get_prop_index(ctx, variantIdx, 3);
-            v4.w_ = duk_to_number(ctx, -1);
-            duk_pop_n(ctx, 4);
-            v = v4;
-            return;
-        }
+        case VAR_VECTOR4:
+            value = Vector4::ZERO;
+            break;
 
+        case VAR_QUATERNION:
+            value = Quaternion::IDENTITY;
+            break;
 
-        return;
-    }
+        case VAR_COLOR:
+            value = Color::WHITE;
+            break;
 
-    {
-        void* bufferData;
-        duk_size_t bufferSize;
-        if (js_check_is_buffer_and_get_data(ctx, variantIdx, &bufferData, &bufferSize))
-        {
-            // copy the buffer into the variant
-            v.SetBuffer(bufferData, (unsigned)bufferSize);
-            return;
-        }
-    }
+        case VAR_STRING:
+            value = "";
+            break;
 
-    // object check after array and buffer object check
-    if (duk_is_object(ctx, variantIdx))
-    {
-        if (variantType == VAR_RESOURCEREFLIST)
-        {
-            ResourceRefList refList;
+        case VAR_INTRECT:
+            value = IntRect::ZERO;
+            break;
 
-            duk_get_prop_string(ctx, variantIdx, "typeName");
-            refList.type_ = duk_to_string(ctx, -1);
+        case VAR_INTVECTOR2:
+            value = IntVector2::ZERO;
+            break;
 
-            duk_get_prop_string(ctx, variantIdx, "resources");
-            int length = duk_get_length(ctx, -1);
+        case VAR_DOUBLE:
+            // set float here too, so standard edits work
+            value = 0.0f;
+            break;
 
-            for (int i = 0; i < length; i++) {
-
-                duk_get_prop_index(ctx, -1, i);
-
-                Resource* resource = NULL;
-
-                if (duk_is_object(ctx, -1))
-                {
-                     resource = js_to_class_instance<Resource>(ctx, -1, 0);
-
-                }
-
-                if (resource) {
-                    refList.names_.Push(resource->GetName());
-                }
-                else
-                    refList.names_.Push(String::EMPTY);
-
-                duk_pop(ctx);
-            }
-
-            duk_pop_n(ctx, 2);
-
-            v = refList;
-        }
-        else
-        {
-            RefCounted* o = js_to_class_instance<RefCounted>(ctx, variantIdx, 0);
-            if (o)
-                v = o;
-        }
-
-        return;
-    }
-
-
-}
-
-// variant map Proxy getter, so we can convert access to string based
-// member lookup, to string hash on the fly
-
-static int variantmap_property_get(duk_context* ctx)
-{
-    // targ, key, recv
-
-    if (duk_is_string(ctx, 1))
-    {
-        StringHash key = duk_to_string(ctx, 1);
-        duk_get_prop_index(ctx, 0, (unsigned) key.Value());
-        return 1;
-    }
-
-    duk_push_undefined(ctx);
-    return 1;
-
-}
-
-// removes all keys from the variant map proxy target, REGARDLESS of key given for delete
-// see (lengthy) note in JSEventDispatcher::EndSendEvent
-static int variantmap_property_deleteproperty(duk_context* ctx)
-{
-    // deleteProperty: function (targ, key)
-
-    duk_enum(ctx, 0, DUK_ENUM_OWN_PROPERTIES_ONLY);
-
-    while (duk_next(ctx, -1, 0)) {
-        duk_del_prop(ctx, 0);
-    }
-
-    duk_push_boolean(ctx, 1);
-    return 1;
-
-}
-
-
-void js_push_variantmap(duk_context* ctx, const VariantMap &vmap)
-{
-
-    // setup proxy so we can map string
-    duk_get_global_string(ctx, "Proxy");
-
-    duk_push_object(ctx);
-
-    VariantMap::ConstIterator itr = vmap.Begin();
-
-    while (itr != vmap.End()) {
-
-        js_push_variant(ctx, itr->second_);
-
-
-        if (duk_is_undefined(ctx, -1)) {
-
-            duk_pop(ctx);
-        }
-        else
-        {
-            duk_put_prop_index(ctx, -2, (unsigned) itr->first_.Value());
-        }
-
-        itr++;
-
-    }
-
-    // setup property handler
-    duk_push_object(ctx);
-    duk_push_c_function(ctx, variantmap_property_get, 3);
-    duk_put_prop_string(ctx, -2, "get");
-    duk_push_c_function(ctx, variantmap_property_deleteproperty, 2);
-    duk_put_prop_string(ctx, -2, "deleteProperty");
-
-    duk_new(ctx, 2);
-
-
-}
-
-void js_push_variant(duk_context *ctx, const Variant& v)
-{
-    switch (v.GetType())
-    {
-    case VAR_NONE:
-        duk_push_undefined(ctx);
-        break;
-
-    case VAR_VOIDPTR:
-        duk_push_null(ctx);
-        break;
-
-    case VAR_PTR:
-    {
-        RefCounted* ref = v.GetPtr();
-
-        // if we're null or don't have any refs, return null
-        if (!ref || !ref->Refs())
-        {
-            duk_push_null(ctx);
+        default:
             break;
         }
 
-        // check that class is supported
-        duk_push_heap_stash(ctx);
-        duk_push_pointer(ctx, (void*)ref->GetClassID());
-        duk_get_prop(ctx, -2);
+        js_push_variant(ctx, value);
+    }
 
-        if (!duk_is_object(ctx, -1))
+    void js_to_variant(duk_context* ctx, int variantIdx, Variant &v, VariantType variantType)
+    {
+        v.Clear();
+
+        // convert to abs index
+        if (variantIdx < 0)
+            variantIdx = duk_get_top(ctx) + variantIdx;
+
+        if (duk_is_boolean(ctx, variantIdx))
         {
-            duk_pop_2(ctx);
-            duk_push_undefined(ctx);
+            v = duk_to_boolean(ctx, variantIdx) ? true : false;
+            return;
         }
-        else
+
+        if (duk_is_string(ctx, variantIdx))
         {
-            duk_pop_2(ctx);
-            js_push_class_object_instance(ctx, ref);
+            v = duk_to_string(ctx, variantIdx);
+            return;
         }
 
-    }   break;
-
-    case VAR_RESOURCEREF:
-    {
-        const ResourceRef& resourceRef(v.GetResourceRef());
-        ResourceCache* cache = JSVM::GetJSVM(ctx)->GetContext()->GetSubsystem<ResourceCache>();
-        Resource* resource = cache->GetResource(resourceRef.type_, resourceRef.name_);
-        js_push_class_object_instance(ctx, resource);
-    }   break;
-
-    case VAR_RESOURCEREFLIST:
-    {
-
-        const ResourceRefList& resourceRefList(v.GetResourceRefList());
-        const Context* context = JSVM::GetJSVM(ctx)->GetContext();
-
-        duk_push_object(ctx);
-        duk_push_string(ctx, context->GetTypeName(resourceRefList.type_).CString());
-        duk_put_prop_string(ctx, -2, "typeName");
-
-        duk_push_array(ctx);
-
-        ResourceCache* cache = context->GetSubsystem<ResourceCache>();
-
-        for (unsigned i = 0; i < resourceRefList.names_.Size(); i++) {
-
-            Resource* resource = cache->GetResource(resourceRefList.type_, resourceRefList.names_[i]);
-            js_push_class_object_instance(ctx, resource);
-            duk_put_prop_index(ctx, -2, i);
+        if (duk_is_number(ctx, variantIdx))
+        {
+            v = (float)duk_to_number(ctx, variantIdx);
+            return;
         }
 
-        duk_put_prop_string(ctx, -2, "resources");
+        if (duk_is_pointer(ctx, variantIdx))
+        {
+            v = (RefCounted*)duk_get_pointer(ctx, variantIdx);
+            return;
+        }
 
-    } break;
+        if (duk_is_array(ctx, variantIdx))
+        {
+            if (duk_get_length(ctx, variantIdx) == 2)
+            {
+                Vector2 v2;
+                duk_get_prop_index(ctx, variantIdx, 0);
+                v2.x_ = duk_to_number(ctx, -1);
+                duk_get_prop_index(ctx, variantIdx, 1);
+                v2.y_ = duk_to_number(ctx, -1);
+                duk_pop_n(ctx, 2);
+                v = v2;
+                return;
+            }
+            else if (duk_get_length(ctx, variantIdx) == 3)
+            {
+                Vector3 v3;
+                duk_get_prop_index(ctx, variantIdx, 0);
+                v3.x_ = duk_to_number(ctx, -1);
+                duk_get_prop_index(ctx, variantIdx, 1);
+                v3.y_ = duk_to_number(ctx, -1);
+                duk_get_prop_index(ctx, variantIdx, 2);
+                v3.z_ = duk_to_number(ctx, -1);
+                duk_pop_n(ctx, 3);
+                v = v3;
+                return;
+            }
+            else if (duk_get_length(ctx, variantIdx) == 4)
+            {
+                Vector4 v4;
+                duk_get_prop_index(ctx, variantIdx, 0);
+                v4.x_ = duk_to_number(ctx, -1);
+                duk_get_prop_index(ctx, variantIdx, 1);
+                v4.y_ = duk_to_number(ctx, -1);
+                duk_get_prop_index(ctx, variantIdx, 2);
+                v4.z_ = duk_to_number(ctx, -1);
+                duk_get_prop_index(ctx, variantIdx, 3);
+                v4.w_ = duk_to_number(ctx, -1);
+                duk_pop_n(ctx, 4);
+                v = v4;
+                return;
+            }
 
-    case VAR_BOOL:
-        duk_push_boolean(ctx, v.GetBool() ? 1 : 0);
-        break;
 
-    case VAR_INT:
-        duk_push_number(ctx, v.GetInt());
-        break;
+            return;
+        }
 
-    case VAR_FLOAT:
-        duk_push_number(ctx, v.GetFloat());
-        break;
+        {
+            void* bufferData;
+            duk_size_t bufferSize;
+            if (js_check_is_buffer_and_get_data(ctx, variantIdx, &bufferData, &bufferSize))
+            {
+                // copy the buffer into the variant
+                v.SetBuffer(bufferData, (unsigned)bufferSize);
+                return;
+            }
+        }
 
-    case VAR_STRING:
+        // object check after array and buffer object check
+        if (duk_is_object(ctx, variantIdx))
+        {
+            if (variantType == VAR_RESOURCEREFLIST)
+            {
+                ResourceRefList refList;
+
+                duk_get_prop_string(ctx, variantIdx, "typeName");
+                refList.type_ = duk_to_string(ctx, -1);
+
+                duk_get_prop_string(ctx, variantIdx, "resources");
+                int length = duk_get_length(ctx, -1);
+
+                for (int i = 0; i < length; i++) {
+
+                    duk_get_prop_index(ctx, -1, i);
+
+                    Resource* resource = NULL;
+
+                    if (duk_is_object(ctx, -1))
+                    {
+                        resource = js_to_class_instance<Resource>(ctx, -1, 0);
+
+                    }
+
+                    if (resource) {
+                        refList.names_.Push(resource->GetName());
+                    }
+                    else
+                        refList.names_.Push(String::EMPTY);
+
+                    duk_pop(ctx);
+                }
+
+                duk_pop_n(ctx, 2);
+
+                v = refList;
+            }
+            else
+            {
+                RefCounted* o = js_to_class_instance<RefCounted>(ctx, variantIdx, 0);
+                if (o)
+                    v = o;
+            }
+
+            return;
+        }
+
+
+    }
+
+    // variant map Proxy getter, so we can convert access to string based
+    // member lookup, to string hash on the fly
+
+    static int variantmap_property_get(duk_context* ctx)
     {
-        const String& string(v.GetString());
-        duk_push_lstring(ctx, string.CString(), string.Length());
-    }   break;
+        // targ, key, recv
 
-    case VAR_BUFFER:
-    {
-        const PODVector<unsigned char>& buffer(v.GetBuffer()); // The braces are to scope this reference.
-        duk_push_fixed_buffer(ctx, buffer.Size());
-        duk_push_buffer_object(ctx, -1, 0, buffer.Size(), DUK_BUFOBJ_UINT8ARRAY);
-        duk_replace(ctx, -2);
-        unsigned char* data = (unsigned char*)duk_require_buffer_data(ctx, -1, (duk_size_t*)nullptr);
-        memcpy(data, buffer.Buffer(), buffer.Size());
-    }   break;
+        if (duk_is_string(ctx, 1))
+        {
+            StringHash key = duk_to_string(ctx, 1);
+            duk_get_prop_index(ctx, 0, (unsigned)key.Value());
+            return 1;
+        }
 
-    case VAR_VECTOR2:
-    {
-        const Vector2& vector2(v.GetVector2());
-        duk_push_array(ctx);
-        duk_push_number(ctx, vector2.x_);
-        duk_put_prop_index(ctx, -2, 0);
-        duk_push_number(ctx, vector2.y_);
-        duk_put_prop_index(ctx, -2, 1);
-    }   break;
-
-    case VAR_INTVECTOR2:
-    {
-        const IntVector2& intVector2(v.GetIntVector2());
-        duk_push_array(ctx);
-        duk_push_number(ctx, intVector2.x_);
-        duk_put_prop_index(ctx, -2, 0);
-        duk_push_number(ctx, intVector2.y_);
-        duk_put_prop_index(ctx, -2, 1);
-    }   break;
-
-    case VAR_VECTOR3:
-    {
-        const Vector3& vector3(v.GetVector3());
-        duk_push_array(ctx);
-        duk_push_number(ctx, vector3.x_);
-        duk_put_prop_index(ctx, -2, 0);
-        duk_push_number(ctx, vector3.y_);
-        duk_put_prop_index(ctx, -2, 1);
-        duk_push_number(ctx, vector3.z_);
-        duk_put_prop_index(ctx, -2, 2);
-    }   break;
-
-    case VAR_QUATERNION:
-    {
-        const Vector3& vector3(v.GetQuaternion().EulerAngles());
-        duk_push_array(ctx);
-        duk_push_number(ctx, vector3.x_);
-        duk_put_prop_index(ctx, -2, 0);
-        duk_push_number(ctx, vector3.y_);
-        duk_put_prop_index(ctx, -2, 1);
-        duk_push_number(ctx, vector3.z_);
-        duk_put_prop_index(ctx, -2, 2);
-    }   break;
-
-    case VAR_COLOR:
-    {
-        const Color& color(v.GetColor());
-        duk_push_array(ctx);
-        duk_push_number(ctx, color.r_);
-        duk_put_prop_index(ctx, -2, 0);
-        duk_push_number(ctx, color.g_);
-        duk_put_prop_index(ctx, -2, 1);
-        duk_push_number(ctx, color.b_);
-        duk_put_prop_index(ctx, -2, 2);
-        duk_push_number(ctx, color.a_);
-        duk_put_prop_index(ctx, -2, 3);
-    }   break;
-
-    case VAR_VECTOR4:
-    {
-        const Vector4& vector4(v.GetVector4());
-        duk_push_array(ctx);
-        duk_push_number(ctx, vector4.x_);
-        duk_put_prop_index(ctx, -2, 0);
-        duk_push_number(ctx, vector4.y_);
-        duk_put_prop_index(ctx, -2, 1);
-        duk_push_number(ctx, vector4.z_);
-        duk_put_prop_index(ctx, -2, 2);
-        duk_push_number(ctx, vector4.w_);
-        duk_put_prop_index(ctx, -2, 3);
-    }   break;
-
-    default:
         duk_push_undefined(ctx);
-        break;
+        return 1;
+
+    }
+
+    // removes all keys from the variant map proxy target, REGARDLESS of key given for delete
+    // see (lengthy) note in JSEventDispatcher::EndSendEvent
+    static int variantmap_property_deleteproperty(duk_context* ctx)
+    {
+        // deleteProperty: function (targ, key)
+
+        duk_enum(ctx, 0, DUK_ENUM_OWN_PROPERTIES_ONLY);
+
+        while (duk_next(ctx, -1, 0)) {
+            duk_del_prop(ctx, 0);
+        }
+
+        duk_push_boolean(ctx, 1);
+        return 1;
+
     }
 
 
-}
+    void js_push_variantmap(duk_context* ctx, const VariantMap &vmap)
+    {
+
+        // setup proxy so we can map string
+        duk_get_global_string(ctx, "Proxy");
+
+        duk_push_object(ctx);
+
+        VariantMap::ConstIterator itr = vmap.Begin();
+
+        while (itr != vmap.End()) {
+
+            js_push_variant(ctx, itr->second_);
+
+
+            if (duk_is_undefined(ctx, -1)) {
+
+                duk_pop(ctx);
+            }
+            else
+            {
+                duk_put_prop_index(ctx, -2, (unsigned)itr->first_.Value());
+            }
+
+            itr++;
+
+        }
+
+        // setup property handler
+        duk_push_object(ctx);
+        duk_push_c_function(ctx, variantmap_property_get, 3);
+        duk_put_prop_string(ctx, -2, "get");
+        duk_push_c_function(ctx, variantmap_property_deleteproperty, 2);
+        duk_put_prop_string(ctx, -2, "deleteProperty");
+
+        duk_new(ctx, 2);
+
+
+    }
+
+    void js_push_variant(duk_context *ctx, const Variant& v, int arrayIndex)
+    {
+        switch (v.GetType())
+        {
+        case VAR_NONE:
+            duk_push_undefined(ctx);
+            break;
+
+        case VAR_VOIDPTR:
+            duk_push_null(ctx);
+            break;
+
+        case VAR_PTR:
+        {
+            RefCounted* ref = v.GetPtr();
+
+            // if we're null or don't have any refs, return null
+            if (!ref || !ref->Refs())
+            {
+                duk_push_null(ctx);
+                break;
+            }
+
+            // check that class is supported
+            duk_push_heap_stash(ctx);
+            duk_push_pointer(ctx, (void*)ref->GetClassID());
+            duk_get_prop(ctx, -2);
+
+            if (!duk_is_object(ctx, -1))
+            {
+                duk_pop_2(ctx);
+                duk_push_undefined(ctx);
+            }
+            else
+            {
+                duk_pop_2(ctx);
+                js_push_class_object_instance(ctx, ref);
+            }
+
+        }   break;
+
+        case VAR_RESOURCEREF:
+        {
+            const ResourceRef& resourceRef(v.GetResourceRef());
+            ResourceCache* cache = JSVM::GetJSVM(ctx)->GetContext()->GetSubsystem<ResourceCache>();
+            Resource* resource = cache->GetResource(resourceRef.type_, resourceRef.name_);
+            js_push_class_object_instance(ctx, resource);
+        }   break;
+
+        case VAR_RESOURCEREFLIST:
+        {
+
+            const ResourceRefList& resourceRefList(v.GetResourceRefList());
+            const Context* context = JSVM::GetJSVM(ctx)->GetContext();
+
+            duk_push_object(ctx);
+            duk_push_string(ctx, context->GetTypeName(resourceRefList.type_).CString());
+            duk_put_prop_string(ctx, -2, "typeName");
+
+            duk_push_array(ctx);
+
+            ResourceCache* cache = context->GetSubsystem<ResourceCache>();
+
+            for (unsigned i = 0; i < resourceRefList.names_.Size(); i++) {
+
+                Resource* resource = cache->GetResource(resourceRefList.type_, resourceRefList.names_[i]);
+                js_push_class_object_instance(ctx, resource);
+                duk_put_prop_index(ctx, -2, i);
+            }
+
+            duk_put_prop_string(ctx, -2, "resources");
+
+        } break;
+
+        case VAR_BOOL:
+            duk_push_boolean(ctx, v.GetBool() ? 1 : 0);
+            break;
+
+        case VAR_INT:
+            duk_push_number(ctx, v.GetInt());
+            break;
+
+        case VAR_FLOAT:
+            duk_push_number(ctx, v.GetFloat());
+            break;
+
+        case VAR_DOUBLE:
+            duk_push_number(ctx, v.GetFloat());
+            break;
+
+        case VAR_STRING:
+        {
+            const String& string(v.GetString());
+            duk_push_lstring(ctx, string.CString(), string.Length());
+        }   break;
+
+        case VAR_BUFFER:
+        {
+            const PODVector<unsigned char>& buffer(v.GetBuffer()); // The braces are to scope this reference.
+            duk_push_fixed_buffer(ctx, buffer.Size());
+            duk_push_buffer_object(ctx, -1, 0, buffer.Size(), DUK_BUFOBJ_UINT8ARRAY);
+            duk_replace(ctx, -2);
+            unsigned char* data = (unsigned char*)duk_require_buffer_data(ctx, -1, (duk_size_t*)nullptr);
+            memcpy(data, buffer.Buffer(), buffer.Size());
+        }   break;
+
+        case VAR_VECTOR2:
+        {
+            const Vector2& vector2(v.GetVector2());
+            duk_push_array(ctx);
+            duk_push_number(ctx, vector2.x_);
+            duk_put_prop_index(ctx, -2, 0);
+            duk_push_number(ctx, vector2.y_);
+            duk_put_prop_index(ctx, -2, 1);
+        }   break;
+
+        case VAR_INTVECTOR2:
+        {
+            const IntVector2& intVector2(v.GetIntVector2());
+            duk_push_array(ctx);
+            duk_push_number(ctx, intVector2.x_);
+            duk_put_prop_index(ctx, -2, 0);
+            duk_push_number(ctx, intVector2.y_);
+            duk_put_prop_index(ctx, -2, 1);
+        }   break;
+
+        case VAR_VECTOR3:
+        {
+            const Vector3& vector3(v.GetVector3());
+            duk_push_array(ctx);
+            duk_push_number(ctx, vector3.x_);
+            duk_put_prop_index(ctx, -2, 0);
+            duk_push_number(ctx, vector3.y_);
+            duk_put_prop_index(ctx, -2, 1);
+            duk_push_number(ctx, vector3.z_);
+            duk_put_prop_index(ctx, -2, 2);
+        }   break;
+
+        case VAR_QUATERNION:
+        {
+            const Vector3& vector3(v.GetQuaternion().EulerAngles());
+            duk_push_array(ctx);
+            duk_push_number(ctx, vector3.x_);
+            duk_put_prop_index(ctx, -2, 0);
+            duk_push_number(ctx, vector3.y_);
+            duk_put_prop_index(ctx, -2, 1);
+            duk_push_number(ctx, vector3.z_);
+            duk_put_prop_index(ctx, -2, 2);
+        }   break;
+
+        case VAR_COLOR:
+        {
+            const Color& color(v.GetColor());
+            duk_push_array(ctx);
+            duk_push_number(ctx, color.r_);
+            duk_put_prop_index(ctx, -2, 0);
+            duk_push_number(ctx, color.g_);
+            duk_put_prop_index(ctx, -2, 1);
+            duk_push_number(ctx, color.b_);
+            duk_put_prop_index(ctx, -2, 2);
+            duk_push_number(ctx, color.a_);
+            duk_put_prop_index(ctx, -2, 3);
+        }   break;
+
+        case VAR_VECTOR4:
+        {
+            const Vector4& vector4(v.GetVector4());
+            duk_push_array(ctx);
+            duk_push_number(ctx, vector4.x_);
+            duk_put_prop_index(ctx, -2, 0);
+            duk_push_number(ctx, vector4.y_);
+            duk_put_prop_index(ctx, -2, 1);
+            duk_push_number(ctx, vector4.z_);
+            duk_put_prop_index(ctx, -2, 2);
+            duk_push_number(ctx, vector4.w_);
+            duk_put_prop_index(ctx, -2, 3);
+        }   break;
+
+        case VAR_VARIANTVECTOR:
+        {
+            const VariantVector& vector(v.GetVariantVector());
+
+            // if we don't specify an array index, wrap and push the vector (EXPENSIVE!)
+            if (arrayIndex == -1)
+            {
+                SharedPtr<ScriptVector> scriptVector(new ScriptVector());
+                scriptVector->AdaptFromVector(vector);
+                js_push_class_object_instance(ctx, scriptVector);
+            }
+            else
+            {
+                if (arrayIndex < 0 || arrayIndex >= vector.Size())
+                {
+                    duk_push_undefined(ctx);
+                }
+                else
+                {
+                    // recursively push the variant
+                    js_push_variant(ctx, vector[arrayIndex]);
+                }
+            }
+
+        }   break;
+
+        default:
+            duk_push_undefined(ctx);
+            break;
+        }
+
+
+    }
 
 
 }

--- a/Source/AtomicJS/Javascript/JSAPI.h
+++ b/Source/AtomicJS/Javascript/JSAPI.h
@@ -58,9 +58,13 @@ void js_class_get_constructor(duk_context* ctx, const char* package, const char 
 void js_define_native_event(duk_context* ctx, const String& eventType, const String& eventName);
 
 /// Pushes variant value or undefined if can't be pushed
-void js_push_variant(duk_context* ctx, const Variant &v);
+void js_push_variant(duk_context* ctx, const Variant &v, int arrayIndex = -1);
 void js_push_variantmap(duk_context* ctx, const VariantMap &vmap);
 
+// Push a default value for the given variant type and set variantOut to the pushed value
+void js_push_default_variant(duk_context* ctx, VariantType variantType, Variant& variantOut);
+
+/// Sets a variant value from the duktape stack
 void js_to_variant(duk_context* ctx, int variantIdx, Variant &v, VariantType variantType = VAR_NONE);
 
 void js_object_to_variantmap(duk_context* ctx, int objIdx, VariantMap &v);

--- a/Source/AtomicJS/Javascript/JSComponent.cpp
+++ b/Source/AtomicJS/Javascript/JSComponent.cpp
@@ -190,7 +190,7 @@ void JSComponent::InitInstance(bool hasArgs, int argIdx)
             {
                 Variant& v = fieldValues_[itr->first_];
 
-                if (v.GetType() == itr->second_)
+                if (v.GetType() == itr->second_.variantType_)
                 {
                     js_push_variant(ctx, v);
                     duk_put_prop_string(ctx, -2, itr->first_.CString());

--- a/Source/AtomicJS/Javascript/JSComponentFile.cpp
+++ b/Source/AtomicJS/Javascript/JSComponentFile.cpp
@@ -415,7 +415,7 @@ bool JSComponentFile::BeginLoad(Deserializer& source)
 
                     if (variantType != VAR_NONE)
                     {
-                        AddField(name, variantType);
+                        AddField(name, variantType, false);
                     }
 
                     duk_pop_2(ctx);  // pop key value

--- a/Source/AtomicNET/NETScript/CSComponentAssembly.cpp
+++ b/Source/AtomicNET/NETScript/CSComponentAssembly.cpp
@@ -61,6 +61,7 @@ namespace Atomic
         typeMap_["Vector4"] = VAR_VECTOR4;
         typeMap_["Quaternion"] = VAR_QUATERNION;
         typeMap_["IntVector2"] = VAR_INTVECTOR2;
+        typeMap_["Color"] = VAR_COLOR;
 
     }
 
@@ -91,7 +92,8 @@ namespace Atomic
                 VariantType varType = VAR_NONE;
 
                 bool isEnum = jfield.Get("isEnum").GetBool();
-                String typeName = jfield.Get("typeName").GetString();
+                bool isArray = jfield.Get("isArray").GetBool();
+                String typeName = jfield.Get("typeName").GetString();               
                 String fieldName = jfield.Get("name").GetString();
                 String defaultValue = jfield.Get("defaultValue").GetString();
                 String tooltip;
@@ -156,30 +158,33 @@ namespace Atomic
 
                 }
 
-                if (!defaultValue.Length() && varType == VAR_RESOURCEREF)
+                if (!isArray)
                 {
-                    // We still need a default value for ResourceRef's so we know the classtype
-                    AddDefaultValue(fieldName, ResourceRef(typeName), className);
-                }
-                else
-                {
-                    Variant value;
-
-                    if (varType == VAR_RESOURCEREF)
+                    if (!defaultValue.Length() && varType == VAR_RESOURCEREF)
                     {
-                        ResourceRef rref(typeName);
-                        rref.name_ = defaultValue;
-                        value = rref;
+                        // We still need a default value for ResourceRef's so we know the classtype
+                        AddDefaultValue(fieldName, ResourceRef(typeName), className);
                     }
                     else
                     {
-                        value.FromString(varType, defaultValue);
-                    }
+                        Variant value;
 
-                    AddDefaultValue(fieldName, value, className);
+                        if (varType == VAR_RESOURCEREF)
+                        {
+                            ResourceRef rref(typeName);
+                            rref.name_ = defaultValue;
+                            value = rref;
+                        }
+                        else
+                        {
+                            value.FromString(varType, defaultValue);
+                        }
+
+                        AddDefaultValue(fieldName, value, className);
+                    }
                 }
 
-                AddField(fieldName, varType, className, tooltip);
+                AddField(fieldName, varType, isArray, className, tooltip);
 
             }
 

--- a/Source/ThirdParty/TurboBadger/tb_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.h
@@ -265,13 +265,6 @@ public:
     /** Set both min max and preferred height to the given height. */
     void SetHeight(int height) { min_h = max_h = pref_h = height; }
 
-    // ATOMIC BEGIN
-    bool operator == (const LayoutParams &lp) const { return min_w == lp.min_w &&
-                min_h == lp.min_h && max_w == lp.max_w && max_h == lp.max_h &&
-                pref_w == lp.pref_w && pref_h == lp.pref_h; }
-    // ATOMIC END
-
-
     int min_w, min_h;			///< The minimal preferred width and height.
     int max_w, max_h;			///< The maximum preferred width and height.
     int pref_w, pref_h;			///< The preferred width and height.

--- a/Source/ToolCore/JSBind/JSBFunction.h
+++ b/Source/ToolCore/JSBind/JSBFunction.h
@@ -155,6 +155,9 @@ public:
     bool IsStatic() const { return isStatic_; }
     bool IsInterface() const { return isInterface_; }
 
+    // true if return value has been mutated to be passed in at end of parameters (optimization)
+    bool HasMutatedReturn() const { return hasMutatedReturn_; }
+
     bool Skip(BindingLanguage language = BINDINGLANGUAGE_ANY) const
     {
         if (skip_ || language == BINDINGLANGUAGE_ANY)
@@ -301,7 +304,8 @@ private:
     bool isOverload_;
     bool isVirtual_;
     bool isStatic_;
-    bool skip_;
+    bool hasMutatedReturn_;
+    bool skip_;    
     PODVector<BindingLanguage> skipLanguages_;
 };
 

--- a/Source/ToolCore/JSBind/JSBHeaderVisitor.h
+++ b/Source/ToolCore/JSBind/JSBHeaderVisitor.h
@@ -92,7 +92,15 @@ public:
             if (classname.StartsWith("Atomic::"))
                 classname.Replace("Atomic::", "");
 
-            if (classname == "Vector" || classname == "PODVector")
+            if (classname == "VariantVector")
+            {
+                JSBClass* jclass = JSBPackage::GetClassAllPackages("ScriptVariant");
+                assert(jclass);
+
+                jtype = new JSBVectorType(new JSBClassType(jclass), false, true);
+
+            }
+            else if (classname == "Vector" || classname == "PODVector")
             {
                 PODVector<TemplateType> types;
                 unwrapTemplateType(fst, types);

--- a/Source/ToolCore/JSBind/JSBType.h
+++ b/Source/ToolCore/JSBind/JSBType.h
@@ -222,41 +222,6 @@ public:
 
 };
 
-class JSBVectorType : public JSBType
-{
-
-public:
-
-    JSBVectorType(JSBType* vtype, bool podVector = false) : vectorType_(vtype),
-        vectorTypeIsWeakPtr_(false),
-        vectorTypeIsSharedPtr_(false),
-        isPODVector_(podVector) {}
-
-    virtual JSBVectorType* asVectorType() { return this; }
-
-    String ToString();
-
-    virtual bool Match (JSBType* other)
-    {
-        if (!other)
-            return false;
-
-        JSBVectorType* pother = other->asVectorType();
-
-        if (!pother || !vectorType_->Match(pother->vectorType_))
-            return false;
-
-        return true;
-    }
-
-    JSBType* vectorType_;
-    bool vectorTypeIsWeakPtr_;
-    bool vectorTypeIsSharedPtr_;
-    bool isPODVector_;
-
-};
-
-
 
 class JSBClassType : public JSBType
 {
@@ -291,5 +256,42 @@ public:
 
 
 };
+
+class JSBVectorType : public JSBType
+{
+
+public:
+
+    JSBVectorType(JSBType* vtype, bool podVector = false, bool variantVector = false) : vectorType_(vtype),
+        vectorTypeIsWeakPtr_(false),
+        vectorTypeIsSharedPtr_(false),
+        isPODVector_(podVector),
+        isVariantVector_(variantVector) {}
+
+    virtual JSBVectorType* asVectorType() { return this; }
+
+    String ToString();
+
+    virtual bool Match (JSBType* other)
+    {
+        if (!other)
+            return false;
+
+        JSBVectorType* pother = other->asVectorType();
+
+        if (!pother || !vectorType_->Match(pother->vectorType_))
+            return false;
+
+        return true;
+    }
+
+    JSBType* vectorType_;
+    bool vectorTypeIsWeakPtr_;
+    bool vectorTypeIsSharedPtr_;
+    bool isPODVector_;
+    bool isVariantVector_;
+
+};
+
 
 }

--- a/Source/ToolCore/JSBind/JSBTypeScript.cpp
+++ b/Source/ToolCore/JSBind/JSBTypeScript.cpp
@@ -82,7 +82,10 @@ String JSBTypeScript::GetScriptType(JSBFunctionType* ftype)
 
     if (ftype->type_->asVectorType())
     {
-        scriptType = "string[]";
+        if (ftype->type_->asVectorType()->isVariantVector_)
+            scriptType = "ScriptVector";
+        else
+            scriptType = "string[]";
     }
 
     return scriptType;
@@ -147,6 +150,13 @@ void JSBTypeScript::ExportFunction(JSBFunction* function)
             continue;
 
         String name = ftype->name_;
+
+        if (function->HasMutatedReturn() && i == parameters.Size() - 1)
+        {
+            // TODO: would be great to type this as Vector<ScriptVariant> somehow
+            scriptType = "ScriptVector";
+            name = "outVector";
+        }
 
         // TS doesn't like arguments named arguments
         if (name == "arguments")

--- a/Source/ToolCore/JSBind/JavaScript/JSClassWriter.cpp
+++ b/Source/ToolCore/JSBind/JavaScript/JSClassWriter.cpp
@@ -179,7 +179,9 @@ bool JSClassWriter::OmitFunction(JSBFunction* function)
     {
         JSBFunctionType* ptype = parameters[i];
 
-        if (ptype->type_->asVectorType())
+        JSBVectorType* vtype = ptype->type_->asVectorType();
+
+        if (vtype && !vtype->isVariantVector_)
         {
             if (!ptype->isConst_ || ptype->type_->asVectorType()->isPODVector_)
             {

--- a/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
+++ b/Source/ToolCore/JSBind/JavaScript/JSModuleWriter.cpp
@@ -313,6 +313,7 @@ void JSModuleWriter::GenerateSource()
     }
 
     source += "#include <Duktape/duktape.h>\n";
+    source += "#include <Atomic/Script/ScriptVector.h>\n";
     source += "#include <AtomicJS/Javascript/JSVM.h>\n";
     source += "#include <AtomicJS/Javascript/JSAPI.h>\n";
 

--- a/Source/ToolCore/JSBind/JavaScript/JSPackageWriter.cpp
+++ b/Source/ToolCore/JSBind/JavaScript/JSPackageWriter.cpp
@@ -125,6 +125,7 @@ void JSPackageWriter::GenerateSource()
     }
 
     source += "#include <Duktape/duktape.h>\n";
+    source += "#include <Atomic/Script/ScriptVector.h>\n";
     source += "#include <AtomicJS/Javascript/JSVM.h>\n";
     source += "#include <AtomicJS/Javascript/JSAPI.h>\n";
 


### PR DESCRIPTION
This is hooked up for primitives and math types currently for C#, can be hooked up for JS/TS (most of the plumbing is now in place)

There are some improvements to make in the near future, filed as #1395 (support resource type and node arrays, ability to specify a fixed size array in Inspector attr which is auto allocated)

There is a C# Inspector Vector test in the AtomicTests repo to sanity check: https://github.com/AtomicGameEngine/AtomicTests/tree/master/CSharpTests/InspectorVector

Closes #606

```csharp
[Inspector]
bool[] MyBoolArray;

[Inspector]
int[] MyIntArray;

[Inspector]
float[] MyFloatArray;

[Inspector]
string[] MyStringArray;

[Inspector]
Color[] MyColorArray;

[Inspector]
Vector2[] MyVector2Array;

[Inspector]
Vector3[] MyVector3Array;
```

Yields:

![vectorinspector](https://cloud.githubusercontent.com/assets/376203/22131312/5a1f4c48-de67-11e6-80d8-dd8cf51c30e7.png)
