### PR TITLE
Fix preview animations crash #1402

### DIFF
--- a/Resources/EditorData/AtomicEditor/editor/ui/animationtoolbar.tb.txt
+++ b/Resources/EditorData/AtomicEditor/editor/ui/animationtoolbar.tb.txt
@@ -1,3 +1,7 @@
+definitions
+	menubutton
+		lp: height: 28, width: 28
+		skin TBButton.uniformflat
 TBLayout: axis: y, distribution: gravity, spacing: 10
 	lb: min_width: 750
 	TBLayout:
@@ -35,4 +39,4 @@ TBLayout: axis: y, distribution: gravity, spacing: 10
 				tooltip Play Animation
 				lp: width: 30, height: 30
 	TBLayout: distribution: gravity, axis: x, spacing: 4
-			TBContainer: skin: AEContainer, gravity: all, id: blendcontainer
+#	TBContainer: skin: AEContainer, gravity: all, id: blendcontainer

--- a/Script/AtomicEditor/ui/AnimationToolbar.ts
+++ b/Script/AtomicEditor/ui/AnimationToolbar.ts
@@ -170,12 +170,14 @@ class AnimationToolbar extends Atomic.UIWidget {
 
         this.animatedModel = <Atomic.AnimatedModel>modelNode.getComponent("AnimatedModel");
         this.animationController = <Atomic.AnimationController>modelNode.getComponent("AnimationController");
-        var model = this.animatedModel.model;
-        this.animatedModel.setBoneCreationOverride(true);
-        this.animatedModel.setModel(model, true);
+        if ( this.animatedModel != null && this.animationController != null ) {
+            var model = this.animatedModel.model;
+            this.animatedModel.setBoneCreationOverride(true);
+            this.animatedModel.setModel(model, true);
 
-        var animComp = new Atomic.AnimatedModel();
-        var animContComp = new Atomic.AnimationController();
+            var animComp = new Atomic.AnimatedModel();
+            var animContComp = new Atomic.AnimationController();
+        }
     }
 
     openAnimationSelectionBox(animationWidget: Atomic.UIEditField, animationSlot: Atomic.Animation) {


### PR DESCRIPTION
This was caused by an assumption that you would only press the Preview Animation button on an animated model, and was blindly using objects to that effect. You can press the button any time you are looking at at model, and it becomes a fair model browser (some models don’t get textures applied). And now you can press any of the animation settings on a static model and it wont crash.
There were some Turbobadger errors coming out, only when I compiled with debug, so I fixed those too.  I left the last line in, but commented out, the token blendcontainer is not used anywhere, maybe for future use?
 AtomicEditor/editor/ui/animationtoolbar.tb.txt(6):Parse error: Include "definitions>menubutton" was not found!
AtomicEditor/editor/ui/animationtoolbar.tb.txt(13):Parse error: Include "definitions>menubutton" was not found!
AtomicEditor/editor/ui/animationtoolbar.tb.txt(19):Parse error: Include "definitions>menubutton" was not found!
AtomicEditor/editor/ui/animationtoolbar.tb.txt(25):Parse error: Include "definitions>menubutton" was not found!
AtomicEditor/editor/ui/animationtoolbar.tb.txt(32):Parse error: Include "definitions>menubutton" was not found!
