### PR TITLE
Add UI Bargraph widget

### DIFF
--- a/Script/Packages/Atomic/UI.json
+++ b/Script/Packages/Atomic/UI.json
@@ -9,7 +9,7 @@
 								"UISelectList", "UIListView", "UIMessageWindow", "UILayoutParams", "UIFontDescription",
 								"UISkinImage", "UITabContainer", "UISceneView", "UIPreferredSize", "UIDragObject",
 								"UIContainer", "UISection", "UIInlineSelect", "UITextureWidget", "UIColorWidget", "UIColorWheel",
-								"UIScrollContainer", "UISeparator", "UIDimmer", "UISelectDropdown", "UISlider"],
+								"UIScrollContainer", "UISeparator", "UIDimmer", "UISelectDropdown", "UISlider", "UIBargraph"],
 	"overloads" : {
 	},
 	"typescript_decl" : {

--- a/Source/Atomic/UI/UI.cpp
+++ b/Source/Atomic/UI/UI.cpp
@@ -87,6 +87,7 @@ using namespace tb;
 #include "UISlider.h"
 #include "UIColorWidget.h"
 #include "UIColorWheel.h"
+#include "UIBargraph.h"
 
 #include "SystemUI/SystemUI.h"
 #include "SystemUI/SystemUIEvents.h"
@@ -792,6 +793,14 @@ UIWidget* UI::WrapWidget(tb::TBWidget* widget)
     if (widget->IsOfType<TBCheckBox>())
     {
         UICheckBox* nwidget = new UICheckBox(context_, false);
+        nwidget->SetWidget(widget);
+        WrapWidget(nwidget, widget);
+        return nwidget;
+    }
+
+    if (widget->IsOfType<TBBarGraph>())
+    {
+        UIBargraph* nwidget = new UIBargraph(context_, false);
         nwidget->SetWidget(widget);
         WrapWidget(nwidget, widget);
         return nwidget;

--- a/Source/Atomic/UI/UIBargraph.cpp
+++ b/Source/Atomic/UI/UIBargraph.cpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2014-2017, THUNDERBEAST GAMES LLC All rights reserved
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include <TurboBadger/tb_widgets.h>
+#include <TurboBadger/tb_widgets_common.h>
+#include <TurboBadger/tb_atomic_widgets.h>
+
+#include <Atomic/IO/Log.h>
+#include <Atomic/IO/FileSystem.h>
+
+#include "UIEvents.h"
+#include "UI.h"
+#include "UIBargraph.h"
+
+using namespace tb;
+
+namespace Atomic
+{
+
+UIBargraph::UIBargraph(Context* context, bool createWidget) : UIWidget(context, false)
+{
+    if (createWidget)
+    {
+        widget_ = new TBBarGraph();
+        widget_->SetDelegate(this);
+        GetSubsystem<UI>()->WrapWidget(this, widget_);
+    }
+}
+
+UIBargraph::~UIBargraph()
+{
+}
+
+bool UIBargraph::OnEvent(const tb::TBWidgetEvent &ev)
+{
+    return UIWidget::OnEvent(ev);
+}
+
+}

--- a/Source/Atomic/UI/UIBargraph.h
+++ b/Source/Atomic/UI/UIBargraph.h
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2014-2017, THUNDERBEAST GAMES LLC All rights reserved
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "UIWidget.h"
+
+#include "../Input/Input.h"
+
+namespace Atomic
+{
+
+class UIBargraph : public UIWidget
+{
+    ATOMIC_OBJECT(UIBargraph, UIWidget)
+
+public:
+
+    UIBargraph(Context* context, bool createWidget = true);
+    virtual ~UIBargraph();
+
+protected:
+
+    virtual bool OnEvent(const tb::TBWidgetEvent &ev);
+
+private:
+
+};
+
+}

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
@@ -197,4 +197,78 @@ void TBColorWheel::OnInflate(const INFLATE_INFO &info)
 TB_WIDGET_FACTORY(TBColorWheel, TBValue::TYPE_FLOAT, WIDGET_Z_TOP) {}
 
 
+// == TBBarGraph =======================================
+
+TBBarGraph::TBBarGraph() : color_(255,255,255,255), m_value (0.0), m_axis(AXIS_X)
+{
+}
+
+void TBBarGraph::SetColor ( const char *name )
+{
+	if ( name )
+  	 color_.SetFromString(name, strlen(name));
+     
+    InvalidateSkinStates();
+    Invalidate();
+}
+
+void TBBarGraph::SetColor(float r, float g, float b, float a)
+{
+    color_.Set(TBColor(r, g, b, a));
+
+    InvalidateSkinStates();
+    Invalidate();
+}
+
+void TBBarGraph::OnPaint(const PaintProps &paint_props)
+{
+    TBRect local_rect = GetRect();
+    local_rect.x = 0;
+    local_rect.y = 0;
+    
+    if ( m_axis == AXIS_X ) // horizontal bar
+    {
+        double w1 = (double)local_rect.w * ( m_value / 100.0 );
+        local_rect.w = (int)w1;
+    }
+    else if ( m_axis == AXIS_Y ) // vertical bar
+    {
+        double h1 = (double)local_rect.h * ( m_value / 100.0 );
+        local_rect.h = (int)h1;
+    }
+    g_renderer->DrawRectFill(local_rect, color_);
+}
+
+void TBBarGraph::OnInflate(const INFLATE_INFO &info)
+{
+    if (const char *colr = info.node->GetValueString("color", nullptr))
+        SetColor(colr);
+    if ( const char *axis = info.node->GetValueString("axis", "x") )
+        SetAxis(*axis == 'x' ? AXIS_X : AXIS_Y);
+    if (info.sync_type == TBValue::TYPE_FLOAT)
+        SetValueDouble(info.node->GetValueFloat("value", 0));
+    
+    TBWidget::OnInflate(info);
+}
+
+void TBBarGraph::SetValueDouble(double value)
+{
+    value = CLAMP(value, 0.0, 100.0);
+    if (value == m_value)
+        return;
+    m_value = value;
+
+    InvalidateSkinStates();
+    Invalidate();
+}
+
+void TBBarGraph::SetAxis(AXIS axis) 
+{ 
+    m_axis = axis; 
+    InvalidateSkinStates();
+    Invalidate();
+}
+
+TB_WIDGET_FACTORY(TBBarGraph, TBValue::TYPE_FLOAT, WIDGET_Z_TOP) {}
+
 }; // namespace tb

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
@@ -41,8 +41,8 @@ TBColorWidget::TBColorWidget() : color_(), alpha_ ( 1.0f)
 
 void TBColorWidget::SetColor ( const char *name )
 {
-	if ( name )
-  	 color_.SetFromString(name, strlen(name));
+    if ( name )
+        color_.SetFromString(name, strlen(name));
      
     InvalidateSkinStates();
     Invalidate();
@@ -181,8 +181,8 @@ void TBColorWheel::SetMarkerY ( int value )
 
 void TBColorWheel::SetMarkerColor ( const char *name )
 {
- 	if ( name )
-  	 markercolor_.SetFromString(name, strlen(name));
+    if ( name )
+        markercolor_.SetFromString(name, strlen(name));
      
     Invalidate();
 }
@@ -206,8 +206,8 @@ TBBarGraph::TBBarGraph() : color_(255,255,255,255), m_value (0.0), m_axis(AXIS_X
 
 void TBBarGraph::SetColor ( const char *name )
 {
-	if ( name )
-  	 color_.SetFromString(name, strlen(name));
+    if ( name )
+        color_.SetFromString(name, strlen(name));
      
     InvalidateSkinStates();
     Invalidate();
@@ -243,10 +243,10 @@ void TBBarGraph::OnPaint(const PaintProps &paint_props)
         local_rect.y = local_rect.h - (int)h1;
         local_rect.h = (int)h1;
         if ( m_margin > 0 && m_margin < (local_rect.w/2)-2 )
-		{
+        {
             local_rect.w -= (m_margin*2);
             local_rect.x += m_margin;
-		}
+        }
     }
     g_renderer->DrawRectFill(local_rect, color_);
 }

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
@@ -199,8 +199,9 @@ TB_WIDGET_FACTORY(TBColorWheel, TBValue::TYPE_FLOAT, WIDGET_Z_TOP) {}
 
 // == TBBarGraph =======================================
 
-TBBarGraph::TBBarGraph() : color_(255,255,255,255), m_value (0.0), m_axis(AXIS_X)
+TBBarGraph::TBBarGraph() : color_(255,255,255,255), m_value (0.0), m_axis(AXIS_X), m_margin(0)
 {
+    SetSkinBg(TBIDC("background_solid"), WIDGET_INVOKE_INFO_NO_CALLBACKS);
 }
 
 void TBBarGraph::SetColor ( const char *name )
@@ -230,11 +231,22 @@ void TBBarGraph::OnPaint(const PaintProps &paint_props)
     {
         double w1 = (double)local_rect.w * ( m_value / 100.0 );
         local_rect.w = (int)w1;
+        if ( m_margin > 0 && m_margin < (local_rect.h/2)-2)
+        {
+            local_rect.h -= (m_margin *2);
+            local_rect.y += m_margin;
+        }
     }
     else if ( m_axis == AXIS_Y ) // vertical bar
     {
         double h1 = (double)local_rect.h * ( m_value / 100.0 );
+        local_rect.y = local_rect.h - (int)h1;
         local_rect.h = (int)h1;
+        if ( m_margin > 0 && m_margin < (local_rect.w/2)-2 )
+		{
+            local_rect.w -= (m_margin*2);
+            local_rect.x += m_margin;
+		}
     }
     g_renderer->DrawRectFill(local_rect, color_);
 }
@@ -247,7 +259,7 @@ void TBBarGraph::OnInflate(const INFLATE_INFO &info)
         SetAxis(*axis == 'x' ? AXIS_X : AXIS_Y);
     if (info.sync_type == TBValue::TYPE_FLOAT)
         SetValueDouble(info.node->GetValueFloat("value", 0));
-    
+    SetMargin( (unsigned)info.node->GetValueInt("margin", 0 ) );
     TBWidget::OnInflate(info);
 }
 

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
@@ -56,7 +56,7 @@ public:
 
 private:
 
-	TBColor color_;
+    TBColor color_;
     float alpha_;
 };
 
@@ -85,7 +85,7 @@ private:
 
     int markerx_;
     int markery_; // where we clicked, put a box there
-	TBColor markercolor_; // what color box, default = black
+    TBColor markercolor_; // what color box, default = black
     float hue_;   // varies with the angle
     float saturation_; // varies with the radius.
 
@@ -106,7 +106,7 @@ public:
 };
 
 
-// simple bargraph, plots 0.0 to 100.0 in the selected color
+/// TBBarGraph a simple bargraph, plots 0.0 to 100.0 in the selected color
 class TBBarGraph : public TBWidget
 {
 public:
@@ -131,10 +131,10 @@ public:
     virtual unsigned GetMargin() const { return m_margin; }
 
 private:
-	TBColor color_;
+    TBColor color_;
     double m_value;
     AXIS m_axis;
-	unsigned m_margin;
+    unsigned m_margin;
 };
 
 

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
@@ -127,11 +127,14 @@ public:
     virtual int GetValue() { return (int) GetValueDouble(); }
     virtual void SetAxis(AXIS axis);
     virtual AXIS GetAxis() const { return m_axis; }
+    virtual void SetMargin(unsigned margin) { m_margin = margin; }
+    virtual unsigned GetMargin() const { return m_margin; }
 
 private:
 	TBColor color_;
     double m_value;
     AXIS m_axis;
+	unsigned m_margin;
 };
 
 

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
@@ -106,6 +106,35 @@ public:
 };
 
 
+// simple bargraph, plots 0.0 to 100.0 in the selected color
+class TBBarGraph : public TBWidget
+{
+public:
+    TBOBJECT_SUBCLASS(TBBarGraph, TBWidget); // For safe typecasting
+
+    TBBarGraph();
+
+    void SetColor ( const char * );
+    void SetColor (float r, float g, float b, float a);
+    const TBColor& GetColor() const { return color_; }
+
+    virtual void OnInflate(const INFLATE_INFO &info);
+    virtual void OnPaint(const PaintProps &paint_props);
+
+    virtual void SetValueDouble(double value);
+    virtual double GetValueDouble() { return m_value; }
+    virtual void SetValue(int value) { SetValueDouble(value); }
+    virtual int GetValue() { return (int) GetValueDouble(); }
+    virtual void SetAxis(AXIS axis);
+    virtual AXIS GetAxis() const { return m_axis; }
+
+private:
+	TBColor color_;
+    double m_value;
+    AXIS m_axis;
+};
+
+
 }; // namespace tb
 
 #endif // TB_ATOMIC_WIDGETS_H


### PR DESCRIPTION
This PR adds a Atomic UI Bargraph widget, it is also be used from script as a UIBargraph. 
It graphs values from 0.0-100.0, which can accessed with SetValueDouble(double), GetValueDouble(), SetValue(int), GetValue()
The axis command can change the drawing orientation to x, y
The bar color can be set with either hex or RGB values.
Setting a skin is needed, the default should be "background_solid"
A "live" demo of a slider changing the bargraph in a layout file is:  
  
             TBSlider: min: 0, max: 100, value: 0, connection: graphit
                   lp: width: 50, height: 16
             TBBarGraph: value: 0, skin: background_solid, color: #00AF34, axis: x, connection: graphit
                    lp: width: 50, height: 16