### PR TITLE
Close wrapped file when disposing a File.Stream

### DIFF
--- a/Script/AtomicNET/AtomicNET/IO/File.cs
+++ b/Script/AtomicNET/AtomicNET/IO/File.cs
@@ -112,6 +112,17 @@ namespace AtomicEngine
 
                 file.Write(buffer, offset, count);
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (file != null)
+                {
+                    file.Close();
+                    file = null;
+                }
+
+                base.Dispose(disposing);
+            }
         }
 
         public System.IO.Stream ToStream()


### PR DESCRIPTION
Like it says on the label, fixes (my own damned) rookie mistake