### PR TITLE
Fix ScriptEvent for 1302

### DIFF
--- a/Source/AtomicJS/Javascript/JSAtomic.cpp
+++ b/Source/AtomicJS/Javascript/JSAtomic.cpp
@@ -220,17 +220,19 @@ static int js_atomic_script(duk_context* ctx)
 
 static int js_atomic_ScriptEvent(duk_context* ctx)
 {
-    duk_push_current_function(ctx);
-    if (duk_get_top(ctx) == 2)
+    if (duk_get_top(ctx) != 2 || !duk_is_string(ctx, 0) || !duk_is_function(ctx, 1))
     {
-        String eventType = duk_get_string(ctx, 0);
-
-        duk_push_object(ctx);
-        duk_push_string(ctx, eventType.CString());
-        duk_put_prop_string(ctx, -2, "_eventType");
-        duk_dup(ctx, 1);
-        duk_put_prop_string(ctx, -2, "_callback");
+        duk_push_string(ctx, "Atomic.ScriptEvent(eventType:string, callback:function); - passed invalid parameters");
+        duk_throw(ctx);
+        return 0;
     }
+
+    String eventType = duk_get_string(ctx, 0);
+    duk_push_object(ctx);
+    duk_push_string(ctx, eventType.CString());
+    duk_put_prop_string(ctx, -2, "_eventType");
+    duk_dup(ctx, 1);
+    duk_put_prop_string(ctx, -2, "_callback");
 
     return 1;
 }
@@ -453,7 +455,7 @@ void jsapi_init_atomic(JSVM* vm)
     duk_push_c_function(ctx, js_atomic_destroy, 1);
     duk_put_prop_string(ctx, -2, "destroy");
 
-    duk_push_c_function(ctx, js_atomic_ScriptEvent, 1);
+    duk_push_c_function(ctx, js_atomic_ScriptEvent, 2);
     duk_put_prop_string(ctx, -2, "ScriptEvent");
 
 


### PR DESCRIPTION
This is a fix for the in progress #1302 branch

The parameter count for the native method was incorrect, so the method was never getting called.  

It is possible to debug this with the AtomicEditor by passing the --player option, specifying a project, and placing a break point in the method.  

AtomicEditor --player --project /Users/josh/Documents/AtomicProjects/MyProject

If you want variable arguments to a native function btw, specify DUK_VARARGS (then you need to check the stack top for how many args are passed in).  

I also removed the push of the current function at the top of the method.

The code paste now runs! 👍  😄 

