### PR TITLE
User and Application settings improvements

### DIFF
--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -153,7 +153,7 @@ class Editor extends Atomic.ScriptObject {
 
 
     /**
-     * Sets a user preference value in the user settings file
+     * Sets a user preference value in the project user settings file
      * @param  {string} extensionName name of the extension the preference lives under
      * @param  {string} preferenceName name of the preference to set
      * @param  {number | boolean | string} value value to set
@@ -161,6 +161,37 @@ class Editor extends Atomic.ScriptObject {
     setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
         Preferences.getInstance().setUserPreference(extensionName, preferenceName, value);
         WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ProjectPreferences", JSON.stringify(Preferences.getInstance().cachedProjectPreferences, null, 2 ));
+        const eventData: EditorEvents.UserPreferencesChangedEvent = {
+            projectPreferences: JSON.stringify(Preferences.getInstance().cachedProjectPreferences),
+            applicationPreferences: JSON.stringify(Preferences.getInstance().cachedApplicationPreferences)
+        };
+
+        this.sendEvent(EditorEvents.UserPreferencesChangedNotification, eventData);
+    }
+
+    /**
+     * Return a preference value or the provided default from the global user settings file
+     * @param  {string} groupName name of the section the preference lives under
+     * @param  {string} preferenceName name of the preference to retrieve
+     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+     * @return {number|boolean|string}
+     */
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+    getApplicationPreference(groupName: string, preferenceName: string, defaultValue?: any): any {
+        return Preferences.getInstance().getApplicationPreference(groupName, preferenceName, defaultValue);
+    }
+
+    /**
+     * Sets a user preference value in the global application settings file
+     * @param  {string} groupName name of the section the preference lives under
+     * @param  {string} preferenceName name of the preference to set
+     * @param  {number | boolean | string} value value to set
+     */
+    setApplicationPreference(groupName: string, preferenceName: string, value: number | boolean | string) {
+        Preferences.getInstance().setApplicationPreference(groupName, preferenceName, value);
+        WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ApplicationPreferences", JSON.stringify(Preferences.getInstance().cachedApplicationPreferences, null, 2 ));
         const eventData: EditorEvents.UserPreferencesChangedEvent = {
             projectPreferences: JSON.stringify(Preferences.getInstance().cachedProjectPreferences),
             applicationPreferences: JSON.stringify(Preferences.getInstance().cachedApplicationPreferences)

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -141,15 +141,38 @@ export class ProjectServicesProvider extends ServicesProvider<Editor.HostExtensi
         return EditorUI.getEditor().getUserPreference(extensionName, preferenceName, defaultValue);
     }
 
+    /**
+     * Return a preference value or the provided default from the global user settings file
+     * @param  {string} groupName name of the section the preference lives under
+     * @param  {string} preferenceName name of the preference to retrieve
+     * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+     * @return {number|boolean|string}
+     */
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+    getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: any): any {
+        return EditorUI.getEditor().getApplicationPreference(settingsGroup, preferenceName, defaultValue);
+    }
 
     /**
-     * Sets a user preference value in the user settings file
+     * Sets a user preference value in the project user settings file
      * @param  {string} extensionName name of the extension the preference lives under
      * @param  {string} preferenceName name of the preference to set
      * @param  {number | boolean | string} value value to set
      */
     setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
         EditorUI.getEditor().setUserPreference(extensionName, preferenceName, value);
+    }
+
+    /**
+     * Sets an editor preference value in the global application settings file
+     * @param  {string} extensionName name of the extension the preference lives under
+     * @param  {string} preferenceName name of the preference to set
+     * @param  {number | boolean | string} value value to set
+     */
+    setApplicationPreference(extensionName: string, preferenceName: string, value: number | boolean | string) {
+        EditorUI.getEditor().setApplicationPreference(extensionName, preferenceName, value);
     }
 
     /**

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -326,12 +326,31 @@ declare module Editor.HostExtensions {
         getUserPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
 
         /**
-         * Sets a user preference value in the user settings file
+         * Return a preference value or the provided default from the global user settings file
+         * @param  {string} extensionName name of the section the preference lives under
+         * @param  {string} preferenceName name of the preference to retrieve
+         * @param  {number | boolean | string} defaultValue value to return if pref doesn't exist
+         * @return {number|boolean|string}
+         */
+        getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: number): number;
+        getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: string): string;
+        getApplicationPreference(settingsGroup: string, preferenceName: string, defaultValue?: boolean): boolean;
+
+        /**
+         * Sets a user preference value in the project settings file
          * @param  {string} extensionName name of the extension the preference lives under
          * @param  {string} preferenceName name of the preference to set
          * @param  {number | boolean | string} value value to set
          */
         setUserPreference(extensionName: string, preferenceName: string, value: number | boolean | string);
+
+        /**
+         * Sets an editor preference value in the global editor settings file
+         * @param  {string} groupName name of the section the preference lives under
+         * @param  {string} preferenceName name of the preference to set
+         * @param  {number | boolean | string} value value to set
+         */
+        setApplicationPreference(groupName: string, preferenceName: string, value: number | boolean | string);
     }
 
     export interface SceneServicesEventListener extends Editor.Extensions.ServiceEventListener {
@@ -412,8 +431,8 @@ declare module Editor.ClientExtensions {
     }
 
     export interface PreferencesChangedEventData {
-        applicationPreferences? : any,
-        projectPreferences? : any
+        applicationPreferences? : any;
+        projectPreferences? : any;
     }
 
     export interface WebViewServiceEventListener extends Editor.Extensions.EditorServiceExtension {


### PR DESCRIPTION
This PR enhances the way settings are handled
- Editor level settings can be retrieved and set from editor extensions
- When settings are updated, any open web views will auto-reconfigure the code editor window with any updates.  This allows for changing the code theme on the fly