### PR TITLE
Programmatically jump to line in editor

### DIFF
--- a/Data/AtomicEditor/CodeEditor/MonacoEditor.html
+++ b/Data/AtomicEditor/CodeEditor/MonacoEditor.html
@@ -118,6 +118,18 @@
                 interop.getInstance().formatCode();
             });
         }
+
+        function HOST_gotoLineNumber(lineNumber) {
+            setupEditor.then((interop) => {
+                interop.getInstance().gotoLineNumber(lineNumber);
+            });
+        }
+
+        function HOST_gotoTokenPos(tokenPosition) {
+            setupEditor.then((interop) => {
+                interop.getInstance().gotoPos(tokenPosition);
+            });
+        }
     </script>
 
 </body>

--- a/Resources/EditorData/AtomicEditor/editor/ui/typescriptresults.tb.txt
+++ b/Resources/EditorData/AtomicEditor/editor/ui/typescriptresults.tb.txt
@@ -1,0 +1,10 @@
+TBLayout: axis: y, distribution: available
+	lp: min-width: 640, min-height: 400;
+	TBLayout: distribution: available
+		TBLayout: distribution: available, size: available
+			TBEditField: multiline: 1, readonly: 1, id: msg, styling: 1
+	TBSeparator: gravity: left right, skin: AESeparator
+		lp: max-height: 5
+	TBLayout: axis: y, distribution: available
+		lp: max-height: 30
+		TBButton: text: Close, id: close, gravity: right

--- a/Script/AtomicEditor/editor/Editor.ts
+++ b/Script/AtomicEditor/editor/Editor.ts
@@ -191,12 +191,12 @@ class AtomicEditor extends Atomic.ScriptObject {
     setApplicationPreference(groupName: string, preferenceName: string, value: number | boolean | string) {
         Preferences.getInstance().setApplicationPreference(groupName, preferenceName, value);
         WebView.WebBrowserHost.setGlobalStringProperty("HOST_Preferences", "ApplicationPreferences", JSON.stringify(Preferences.getInstance().cachedApplicationPreferences, null, 2 ));
-        const eventData: EditorEvents.UserPreferencesChangedEvent = {
+        const eventData: Editor.UserPreferencesChangedNotificationEvent = {
             projectPreferences: JSON.stringify(Preferences.getInstance().cachedProjectPreferences),
             applicationPreferences: JSON.stringify(Preferences.getInstance().cachedApplicationPreferences)
         };
 
-        this.sendEvent(EditorEvents.UserPreferencesChangedNotification, eventData);
+        this.sendEvent(Editor.UserPreferencesChangedNotificationEventData(eventData));
     }
 
     /**

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -392,10 +392,12 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
 
     /**
      * Will load a resource editor or navigate to an already loaded resource editor by path
+     * @param resourcePath full path to resource to load 
+     * @param lineNumber optional line number to navigate to
      * @return {Editor.ResourceEditor}
      */
-    loadResourceEditor(resourcePath: string): Editor.ResourceEditor {
-        this.mainFrame.resourceframe.sendEvent(Editor.EditorEditResourceEventData({path: resourcePath}));
+    loadResourceEditor(resourcePath: string, lineNumber?: number): Editor.ResourceEditor {
+        this.mainFrame.resourceframe.sendEvent(Editor.EditorEditResourceEventData({path: resourcePath, lineNumber: lineNumber}));
         return this.mainFrame.resourceframe.currentResourceEditor;
     }
 

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -395,7 +395,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
      * @return {Editor.ResourceEditor}
      */
     loadResourceEditor(resourcePath: string): Editor.ResourceEditor {
-        this.mainFrame.resourceframe.sendEvent(EditorEvents.EditResource, {path: resourcePath} );
+        this.mainFrame.resourceframe.sendEvent(Editor.EditorEditResourceEventData({path: resourcePath}));
         return this.mainFrame.resourceframe.currentResourceEditor;
     }
 

--- a/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
+++ b/Script/AtomicEditor/hostExtensions/HostExtensionServices.ts
@@ -391,6 +391,15 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
     }
 
     /**
+     * Will load a resource editor or navigate to an already loaded resource editor by path
+     * @return {Editor.ResourceEditor}
+     */
+    loadResourceEditor(resourcePath: string): Editor.ResourceEditor {
+        this.mainFrame.resourceframe.sendEvent(EditorEvents.EditResource, {path: resourcePath} );
+        return this.mainFrame.resourceframe.currentResourceEditor;
+    }
+
+    /**
      * Adds a new menu to the hierarchy context menu
      * @param  {string} id
      * @param  {any} items
@@ -442,12 +451,21 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
             this.inspectorFrame.loadCustomInspectorWidget(customInspector);
         }
     }
+
     /**
      * Disaplays a modal window
      * @param  {Editor.Modal.ModalWindow} window
      */
     showModalWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow {
-        return this.modalOps.showExtensionWindow(windowText, uifilename, handleWidgetEventCB);
+        return this.modalOps.showExtensionWindow(windowText, uifilename, handleWidgetEventCB, true);
+    }
+
+    /**
+     * Disaplays a modal window
+     * @param  {Editor.Modal.ModalWindow} window
+     */
+    showNonModalWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow {
+        return this.modalOps.showExtensionWindow(windowText, uifilename, handleWidgetEventCB, false);
     }
 
     /**
@@ -455,7 +473,7 @@ export class UIServicesProvider extends ServicesProvider<Editor.HostExtensions.U
      * @param  {string} windowText
      * @param  {string} message
      */
-    showModalError(windowText: string, message: string) {
+    showModalError(windowText: string, message: string): Atomic.UIMessageWindow {
         return this.modalOps.showError(windowText, message);
     }
 

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
@@ -479,7 +479,6 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
             `Compilation Completed in ${results.duration}ms`
         ].join("\n");
 
-        //let window = this.serviceRegistry.uiServices.showModalError("TypeScript Compilation Results", message);
         let window = this.serviceRegistry.uiServices.showNonModalWindow("TypeScript Compilation Results", "AtomicEditor/editor/ui/typescriptresults.tb.txt", (ev:Atomic.UIWidgetEvent) => {
             if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
                 if (ev.target.id == "close") {
@@ -487,10 +486,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
                 } else {
                     let diag = links[ev.target.id];
                     if (diag) {
-                        const editor = this.serviceRegistry.uiServices.loadResourceEditor(diag.file) as Editor.JSResourceEditor;
-
-                        // TODO: need something here to wait for editor to fully load
-                        editor.gotoLineNumber(diag.row + 1);
+                        this.serviceRegistry.uiServices.loadResourceEditor(diag.file, diag.row + 1);
                     }
                 }
             }
@@ -499,20 +495,5 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
         let textField = window.getWidget<Atomic.UIEditField>("msg");
         textField.setText(message);
         textField.reformat(true);
-
-        /*
-        window.subscribeToEvent(Atomic.UIWidgetEvent(ev => {
-            if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
-                let diag = links[ev.target.id];
-                if (diag) {
-                    const editor = this.serviceRegistry.uiServices.loadResourceEditor(diag.file) as Editor.JSResourceEditor;
-
-                    // TODO: need something here to wait for editor to fully load
-                    editor.gotoLineNumber(diag.row + 1);
-                }
-            }
-        }));
-        */
-
     }
 }

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
@@ -441,6 +441,9 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
     }) {
         // get the name of the resources directory without preceding path
         let resourceDir = ToolCore.toolSystem.project.resourcePath.replace(Atomic.addTrailingSlash(ToolCore.toolSystem.project.projectPath), "");
+        let links = {};
+        let linkId = 0;
+
         let messageArray = results.annotations.filter(result => {
             // If we are compiling the lib.d.ts or some other built-in library and it was successful, then
             // we really don't need to display that result since it's just noise.  Only display it if it fails
@@ -456,7 +459,9 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
             if (result.type == "success") {
                 message += `<color #00ff00>${result.text}</color>`;
             } else {
-                message += `<color #e3e02b>${result.text} at line ${result.row} col ${result.column}</color>`;
+                message += `<color #e3e02b>${result.text} at line ${result.row + 1} col ${result.column}</color> <widget TBSkinImage: skin: MagnifierBitmap, text:"..." id: link${linkId}>`;
+                links["link" + linkId] = result;
+                linkId++;
             }
             return message;
         }).join("\n");
@@ -474,6 +479,40 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
             `Compilation Completed in ${results.duration}ms`
         ].join("\n");
 
-        this.serviceRegistry.uiServices.showModalError("TypeScript Compilation Results", message);
+        //let window = this.serviceRegistry.uiServices.showModalError("TypeScript Compilation Results", message);
+        let window = this.serviceRegistry.uiServices.showNonModalWindow("TypeScript Compilation Results", "AtomicEditor/editor/ui/typescriptresults.tb.txt", (ev:Atomic.UIWidgetEvent) => {
+            if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
+                if (ev.target.id == "close") {
+                  window.close();
+                } else {
+                    let diag = links[ev.target.id];
+                    if (diag) {
+                        const editor = this.serviceRegistry.uiServices.loadResourceEditor(diag.file) as Editor.JSResourceEditor;
+
+                        // TODO: need something here to wait for editor to fully load
+                        editor.gotoLineNumber(diag.row + 1);
+                    }
+                }
+            }
+        });
+
+        let textField = window.getWidget<Atomic.UIEditField>("msg");
+        textField.setText(message);
+        textField.reformat(true);
+
+        /*
+        window.subscribeToEvent(Atomic.UIWidgetEvent(ev => {
+            if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {
+                let diag = links[ev.target.id];
+                if (diag) {
+                    const editor = this.serviceRegistry.uiServices.loadResourceEditor(diag.file) as Editor.JSResourceEditor;
+
+                    // TODO: need something here to wait for editor to fully load
+                    editor.gotoLineNumber(diag.row + 1);
+                }
+            }
+        }));
+        */
+
     }
 }

--- a/Script/AtomicEditor/resources/ResourceOps.ts
+++ b/Script/AtomicEditor/resources/ResourceOps.ts
@@ -326,7 +326,7 @@ export function CreateNewAnimationPreviewScene(reportError: boolean = true): boo
     //Reset the animation viewer scene to a blank scene
     animFile = templateFile;
 
-    resourceOps.sendEvent(Editor.EditorEditResourceEventData({ path: animFilename }));
+    resourceOps.sendEvent(Editor.EditorEditResourceEventData({ path: animFilename, lineNumber: 0 }));
 
     return true;
 

--- a/Script/AtomicEditor/ui/ResourceEditorProvider.ts
+++ b/Script/AtomicEditor/ui/ResourceEditorProvider.ts
@@ -69,7 +69,7 @@ export default class ResourceEditorProvider {
     /**
      * Returns an editor for the provided resource type or null
      */
-    getEditor(resourcePath: string, tabContainer) {
+    getEditor(resourcePath: string, tabContainer, lineNumber: number) {
         let editorBuilder: Editor.Extensions.ResourceEditorBuilder;
         this.customEditorRegistry.forEach((builder) => {
             if (builder.canHandleResource(resourcePath)) {
@@ -88,7 +88,7 @@ export default class ResourceEditorProvider {
         }
 
         if (editorBuilder) {
-            return editorBuilder.getEditor(this.resourceFrame, resourcePath, tabContainer);
+            return editorBuilder.getEditor(this.resourceFrame, resourcePath, tabContainer, lineNumber);
         } else {
             return null;
         }

--- a/Script/AtomicEditor/ui/frames/ProjectFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ProjectFrame.ts
@@ -259,7 +259,7 @@ class ProjectFrame extends ScriptWidget {
 
                     } else {
 
-                        this.sendEvent(Editor.EditorEditResourceEventData({ "path": asset.path }));
+                        this.sendEvent(Editor.EditorEditResourceEventData({ "path": asset.path, lineNumber: 0 }));
                     }
 
                 }

--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -94,7 +94,7 @@ class ResourceFrame extends ScriptWidget {
 
         }
 
-        var editor = this.resourceEditorProvider.getEditor(ev.path, this.tabcontainer);
+        var editor = this.resourceEditorProvider.getEditor(ev.path, this.tabcontainer, ev.lineNumber);
         if (editor) {
 
             // cast and add editor lookup on widget itself

--- a/Script/AtomicEditor/ui/modal/ModalOps.ts
+++ b/Script/AtomicEditor/ui/modal/ModalOps.ts
@@ -257,23 +257,24 @@ class ModalOps extends Atomic.ScriptObject {
     }
 
     // TODO: standardize  to same pattern as other modal windows
-    showError(windowText: string, message: string) {
+    showError(windowText: string, message: string):Atomic.UIMessageWindow {
         var view = EditorUI.getView();
         var window = new Atomic.UIMessageWindow(view, "modal_error");
         window.show(windowText, message, Atomic.UI_MESSAGEWINDOW_SETTINGS.UI_MESSAGEWINDOW_SETTINGS_OK, true, 640, 360);
+        return window;
     }
 
-    showExtensionWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow {
-        if (this.show()) {
+    showExtensionWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void, modal: boolean = true): Editor.Modal.ExtensionWindow {
+        if (this.show(modal)) {
 
             this.opWindow = new ExtensionWindow(windowText, uifilename, handleWidgetEventCB);
             return this.opWindow;
         }
     }
 
-    private show(): boolean {
+    private show(modal:boolean = true): boolean {
 
-        if (this.dimmer.parent) {
+        if (modal && this.dimmer.parent) {
 
             console.log("WARNING: attempting to show modal while dimmer is active");
             return false;
@@ -288,7 +289,9 @@ class ModalOps extends Atomic.ScriptObject {
         }
 
         var view = EditorUI.getView();
-        view.addChild(this.dimmer);
+        if (modal) {
+            view.addChild(this.dimmer);
+        }
 
         return true;
 

--- a/Script/AtomicEditor/ui/modal/UIResourceOps.ts
+++ b/Script/AtomicEditor/ui/modal/UIResourceOps.ts
@@ -186,7 +186,7 @@ export class CreateComponent extends ModalWindow {
 
                         this.hide();
 
-                        this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile }));
+                        this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile, lineNumber: 0 }));
 
                     }
 
@@ -272,7 +272,7 @@ export class CreateScript extends ModalWindow {
 
                         this.hide();
 
-                        this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile }));
+                        this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile, lineNumber: 0 }));
 
                     }
 
@@ -330,7 +330,7 @@ export class CreateScene extends ModalWindow {
 
                     this.hide();
 
-                    this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile }));
+                    this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile, lineNumber: 0 }));
 
                 }
 
@@ -382,7 +382,7 @@ export class CreateMaterial extends ModalWindow {
 
                     this.hide();
 
-                    this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile }));
+                    this.sendEvent(Editor.EditorEditResourceEventData({ path: outputFile, lineNumber: 0 }));
 
                 }
 

--- a/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
+++ b/Script/AtomicEditor/ui/resourceEditors/AbstractTextResourceEditorBuilder.ts
@@ -42,7 +42,7 @@ export abstract class AbstractTextResourceEditorBuilder implements Editor.Extens
         return `atomic://${ToolCore.toolEnvironment.toolDataDir}CodeEditor/MonacoEditor.html`;
     }
 
-    getEditor(resourceFrame: Atomic.UIWidget, resourcePath: string, tabContainer: Atomic.UITabContainer): Editor.ResourceEditor {
+    getEditor(resourceFrame: Atomic.UIWidget, resourcePath: string, tabContainer: Atomic.UITabContainer, lineNumber: number): Editor.ResourceEditor {
         const editor = new Editor.JSResourceEditor(resourcePath, tabContainer, this.getEditorUrl());
 
         // one time subscriptions waiting for the web view to finish loading.  This event
@@ -51,6 +51,9 @@ export abstract class AbstractTextResourceEditorBuilder implements Editor.Extens
         editor.subscribeToEvent(WebView.WebViewLoadEndEvent((data) => {
             editor.unsubscribeFromEvent(WebView.WebViewLoadEndEventType);
             this.loadCode(<Editor.JSResourceEditor>editor, resourcePath);
+            if (lineNumber > 0) {
+                (<Editor.JSResourceEditor>editor).gotoLineNumber(lineNumber);
+            }
         }));
 
         // Cannot subscribe to WebMessage until the .ts side can return a Handler.Success() message

--- a/Script/AtomicWebViewEditor/editor/editorCommands.ts
+++ b/Script/AtomicWebViewEditor/editor/editorCommands.ts
@@ -200,3 +200,22 @@ export function invokeShortcut(shortcut: Editor.EditorShortcutType) {
             break;
     }
 }
+
+/**
+ * Selects the provided line number
+ */
+export function gotoLineNumber(lineNumber:number) {
+    const ed = internalEditor.getInternalEditor();
+    ed.revealLineInCenterIfOutsideViewport(lineNumber);
+    ed.setPosition(new monaco.Position(lineNumber, 0));
+}
+
+/**
+ * Selects the provided position
+ */
+export function gotoTokenPos(tokenPos:number) {
+    const ed = internalEditor.getInternalEditor();
+    const pos = ed.getModel().getPositionAt(tokenPos);
+    ed.revealPositionInCenterIfOutsideViewport(pos);
+    ed.setPosition(pos);
+}

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -251,7 +251,8 @@ declare module Editor.HostExtensions {
         refreshHierarchyFrame();
         loadCustomInspector(customInspector: Atomic.UIWidget);
         showModalWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow;
-        showModalError(windowText: string, message: string);
+        showNonModalWindow(windowText: string, uifilename: string, handleWidgetEventCB: (ev: Atomic.UIWidgetEvent) => void): Editor.Modal.ExtensionWindow;
+        showModalError(windowText: string, message: string):Atomic.UIMessageWindow;
         showResourceSelection(windowText: string, importerType: string, resourceType: string, callback: (retObject: any, args: any) => void, args?: any);
 
         /**
@@ -259,6 +260,13 @@ declare module Editor.HostExtensions {
          * @return {Editor.ResourceEditor}
          */
         getCurrentResourceEditor(): Editor.ResourceEditor;
+
+        
+        /**
+         * Will load a resource editor or navigate to an already loaded resource editor by path
+         * @return {Editor.ResourceEditor}
+         */
+        loadResourceEditor(path: string): Editor.ResourceEditor;
 
         /**
          * Register a custom editor.  These editors will override editors in the standard editor list if

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -119,10 +119,12 @@ declare module Editor.Extensions {
         canHandleResource(resourcePath: string) : boolean;
         /**
          * Generates a resource editor for the provided resource type
+         * @param  resourceFrame 
          * @param  resourcePath
          * @param  tabContainer
+         * @param  lineNumber
          */
-        getEditor(resourceFrame: Atomic.UIWidget, resourcePath: string, tabContainer: Atomic.UITabContainer) : Editor.ResourceEditor;
+        getEditor(resourceFrame: Atomic.UIWidget, resourcePath: string, tabContainer: Atomic.UITabContainer, lineNumber: number) : Editor.ResourceEditor;
     }
 }
 
@@ -264,9 +266,11 @@ declare module Editor.HostExtensions {
         
         /**
          * Will load a resource editor or navigate to an already loaded resource editor by path
+         * @param path The path to the resource to load
+         * @param lineNumber optional line number to navigate to
          * @return {Editor.ResourceEditor}
          */
-        loadResourceEditor(path: string): Editor.ResourceEditor;
+        loadResourceEditor(path: string, lineNumber?: number): Editor.ResourceEditor;
 
         /**
          * Register a custom editor.  These editors will override editors in the standard editor list if

--- a/Source/AtomicEditor/EditorMode/AEEditorEvents.h
+++ b/Source/AtomicEditor/EditorMode/AEEditorEvents.h
@@ -165,6 +165,7 @@ ATOMIC_EVENT(E_EDITORSAVERESOURCENOTIFICATION, EditorSaveResourceNotification)
 ATOMIC_EVENT(E_EDITOREDITRESOURCE, EditorEditResource)
 {
     ATOMIC_PARAM(P_PATH, Path);     // string
+    ATOMIC_PARAM(P_LINENUMBER, LineNumber); // int optional
 }
 
 // command to delete a resource

--- a/Source/AtomicEditor/Editors/JSResourceEditor.cpp
+++ b/Source/AtomicEditor/Editors/JSResourceEditor.cpp
@@ -235,12 +235,12 @@ void JSResourceEditor::SetFocus()
 
 void JSResourceEditor::GotoTokenPos(int tokenPos)
 {
-
+    webClient_->ExecuteJavaScript(ToString("HOST_gotoTokenPos(%d);", tokenPos));
 }
 
 void JSResourceEditor::GotoLineNumber(int lineNumber)
 {
-
+    webClient_->ExecuteJavaScript(ToString("HOST_gotoLineNumber(%d);", lineNumber));
 }
 
 bool JSResourceEditor::Save()


### PR DESCRIPTION
This PR wires up the JSResourceEditor::JumpToLineNumber and JumpToToken methods so that the editor can programmatically jump to a line number.  It additionally does the following:
- Can request to load an editor tab passing a file path and also a line number and it will either load up a new editor and jump to the line or switch to it if it was previously loaded and jump to the line
- work on the TypeScript compiler so that the compile results window that pops up is non-modal and magnifying glass icons appear next to each error.  Clicking the magnifying glass will load that file and jump to the line number

@JoshEngebretson At one point, wasn't there an "Errors" or "Issues" tab in the editor?  Do you think it would be a good idea to bring something like that back and then expose an API to be able to populate it with bookmarks to editor locations?  Bookmarks could be user set bookmarks, or a TODO parser that populates it, or the TS Compiler errors, or even a log scanner that scans the player log for errors?  If so, maybe that could be a followup issue?