### PR TITLE
Real time theme switching in editor

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -149,6 +149,26 @@ class Preferences {
         this.write();
     }
 
+    saveEditorUiData(uiData: UserInterfaceData) {
+        this._prefs.uiData = uiData;
+        this.write();
+    }
+
+    toggleTheme() : void { // swap the themes
+        var uiData = this.uiData;
+        if ( this.uiData.defaultSkinPath == "AtomicEditor/resources/default_skin/" ) {
+            this.uiData.defaultSkinPath = "AtomicEditor/resources/default_skin_light/";
+            this.uiData.skinPath = "AtomicEditor/editor/skin_light/";
+        }
+        else {
+            this.uiData.defaultSkinPath = "AtomicEditor/resources/default_skin/";
+            this.uiData.skinPath = "AtomicEditor/editor/skin/";
+        }
+        var ui = Atomic.ui; // install the new skins, live action
+        ui.loadSkin(this.uiData.skinPath + "/skin.tb.txt", this.uiData.defaultSkinPath + "/skin.tb.txt");
+        this.saveEditorUiData(this.uiData); // save preferences
+    }
+
     useDefaultConfig(): void {
         this._prefs = new PreferencesFormat();
     }

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -220,6 +220,20 @@ class MainFrameMenu extends Atomic.ScriptObject {
 
         } else if (target.id == "menu developer popup") {
 
+            if (refid == "toggle theme") {
+                Preferences.getInstance().toggleTheme();
+                return true;
+            }
+
+            if (refid == "toggle codeeditor") {
+                var ctheme = EditorUI.getEditor().getApplicationPreference( "codeEditor","theme", "");
+                if ( ctheme == "vs-dark" )
+                    EditorUI.getEditor().setApplicationPreference( "codeEditor","theme","vs");
+                else
+                    EditorUI.getEditor().setApplicationPreference( "codeEditor","theme","vs-dark");
+                return true;
+            }
+
             if (refid == "developer show console") {
                 Atomic.ui.showConsole(true);
                 return true;
@@ -393,6 +407,8 @@ var buildItems = {
 
 var developerItems = {
 
+    "Toggle Theme": ["toggle theme"],
+    "Toggle Code Editor Theme": ["toggle codeeditor"],
     "Show Console": ["developer show console"],
     "Clear Preferences": ["developer clear preferences"], //Adds clear preference to developer menu items list
     "Debug": {


### PR DESCRIPTION
Allows switching of light and dark editor and code editor themes using an entries in the Developer menu, Toggle Theme and Toggle Code Editor Theme.
This changes happen in real time, and are saved in the preferences to the last setting you've selected, so it will come back in that theme.
  There are some minor artifacts when switching between the editor themes, a couple of borders and hilights are not changed for Turbobadger reasons and these return to normal on the next editor invocation. Since swapping themes is probably going to be a infrequent operation, it is tolerable.
