### PR TITLE
Add statusbar to AtomicEditor

### DIFF
--- a/Resources/EditorData/AtomicEditor/editor/ui/mainframe.tb.txt
+++ b/Resources/EditorData/AtomicEditor/editor/ui/mainframe.tb.txt
@@ -66,5 +66,5 @@ TBLayout: distribution: gravity, axis: y
                             TBLayout: axis: y, position: left, gravity: top left
                                 TBSkinImage: skin: LogoAtomic64, id: current_platform_indicator
                                     lp: height: 28, width:28
-                        TBLayout: gravity: left right
-                            TBWidget
+                        TBLayout: gravity: left right, distribution: available, size: available
+                            TBEditField: id: editorStatusText, text: "", is-focusable: 0, skin: 0, readonly: 1, adapt-to-content: 0

--- a/Script/AtomicEditor/ui/EditorUI.ts
+++ b/Script/AtomicEditor/ui/EditorUI.ts
@@ -68,6 +68,10 @@ export function showModalError(windowText:string, message:string) {
   editorUI.showModalError(windowText, message);
 }
 
+export function showEditorStatus(message:string) {
+    editorUI.showEditorStatus(message);
+}
+
 export function getCurrentResourceEditor():Editor.ResourceEditor {
     return getMainFrame().resourceframe.currentResourceEditor;
 }
@@ -107,13 +111,22 @@ class EditorUI extends Atomic.ScriptObject {
     ServiceLocator.subscribeToEvents(this.mainframe);
 
     this.subscribeToEvent(Editor.EditorModalEvent((event:Editor.EditorModalEvent) => {
-      this.showModalError(event.title, event.message);
+        if (event.type == Editor.EDITOR_MODALERROR)
+            this.showModalError(event.title, event.message);
+        else if ( event.type == Editor.EDITOR_MODALINFO)
+            this.showEditorStatus(event.message);
     }));
+
+    this.showEditorStatus("Ready.");
 
   }
 
   showModalError(windowText: string, message: string) {
       this.modalOps.showError(windowText, message);
+  }
+
+  showEditorStatus(message: string) {
+      this.mainframe.showStatusText(message);
   }
 
   view: Atomic.UIView;

--- a/Script/AtomicEditor/ui/frames/MainFrame.ts
+++ b/Script/AtomicEditor/ui/frames/MainFrame.ts
@@ -45,6 +45,9 @@ class MainFrame extends ScriptWidget {
 
         this.getWidget("consolecontainer").visibility = Atomic.UI_WIDGET_VISIBILITY.UI_WIDGET_VISIBILITY_GONE;
 
+        this.statusText = <Atomic.UIEditField>this.getWidget("editorStatusText");
+        this.statusText.subscribeToEvent(Atomic.UpdateEvent((ev) => this.handleStatusAging(ev)));
+
         this.inspectorframe = new InspectorFrame();
         this.inspectorlayout.addChild(this.inspectorframe);
 
@@ -182,6 +185,20 @@ class MainFrame extends ScriptWidget {
         }
     }
 
+    showStatusText(message: string) {
+        this.statusText.text = message;  // display the status message
+        this.updateDelta = 10.0;         // start the clock for removing the text
+    }
+
+    handleStatusAging(ev) {    // to avoid showing stale status text
+        if ( this.updateDelta > 0 ) {
+           this.updateDelta -= ev.timeStep;
+           if ( this.updateDelta < 0 )
+                this.statusText.text = "";  // remove it after 10 seconds.
+        }
+    }
+
+
     projectframe: ProjectFrame;
     resourceframe: ResourceFrame;
     inspectorframe: InspectorFrame;
@@ -191,7 +208,8 @@ class MainFrame extends ScriptWidget {
     mainToolbar: MainToolbar;
     animationToolbar: AnimationToolbar;
     menu: MainFrameMenu;
-
+    statusText: Atomic.UIEditField;
+    updateDelta: number;
 }
 
 export = MainFrame;


### PR DESCRIPTION
This PR adds a status bar to the AtomicEditor. It displays text at the bottom of the tool, and uses a timer to remove the text after 10 seconds to avoid having stale text being displayed. The feature can be accessed from inside the editor code with the API  EditorUI.showEditorStatus( "I am a status message" );
or by using an event like : this.sendEvent(Editor.EditorModalEventData({ type: Editor.EDITOR_MODALINFO, title: "", message: "I am a status message" }));
