### PR TITLE
Add thumbnail tooltip

### DIFF
--- a/Script/AtomicEditor/ui/frames/ProjectFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ProjectFrame.ts
@@ -575,6 +575,21 @@ class ProjectFrame extends ScriptWidget {
         button.skinBg = "TBButton.flat";
         button["asset"] = asset;
         blayout["assetButton"] = button;
+
+        // support for image tooltips
+        var extx = asset.getExtension();
+        if ( extx == ".jpg" || extx == ".png" ) {
+            var tt = "#" + asset.path;
+            button.tooltip = tt;
+        }
+        if ( extx == ".prefab" || extx == ".mdl" || extx == ".fbx" ) {
+            var thumbfolder = ToolCore.toolSystem.project.projectPath + "Support/";
+            var tt = thumbfolder + asset.name + extx + ".png";  // only support png tooltips
+            if ( Atomic.getFileSystem().fileExists (tt) ) {     // if it exists, make the tooltip
+                button.tooltip = "#" + tt;
+            }
+        }
+
         blayout.addChild(button);
 
         return blayout;

--- a/Source/Atomic/UI/UI.cpp
+++ b/Source/Atomic/UI/UI.cpp
@@ -558,13 +558,31 @@ void UI::HandleUpdate(StringHash eventType, VariantMap& eventData)
         {
             tooltip_ = new UIPopupWindow(context_, true, hoveredWidget, "tooltip");
             UILayout* tooltipLayout = new UILayout(context_, UI_AXIS_Y, true);
-            if (hoveredWidget->GetShortened())
+            if (hoveredWidget->GetTooltip().Length() > 0 && hoveredWidget->GetTooltip().At(0) == '#' )
+            {
+                tooltipLayout->SetLayoutSize( UI_LAYOUT_SIZE_PREFERRED );
+                tooltipLayout->SetLayoutPosition(UI_LAYOUT_POSITION_CENTER); 
+                tooltipLayout->SetLayoutDistribution(UI_LAYOUT_DISTRIBUTION_PREFERRED ); 
+                tooltipLayout->SetLayoutDistributionPosition( UI_LAYOUT_DISTRIBUTION_POSITION_CENTER); 
+                UIImageWidget* img = new UIImageWidget(context_, true);
+                img->SetWidth(256);
+                img->SetHeight(256);
+                tooltipLayout->AddChild(img);
+                img->SetLayoutWidth(256);
+                img->SetLayoutHeight(256);
+                img->SetLayoutPrefWidth(256);
+                img->SetLayoutPrefHeight(256);
+                String myfile = hoveredWidget->GetTooltip();
+                myfile.Replace( "#", "" );
+                img->SetImage(myfile);
+            }
+            else if (hoveredWidget->GetShortened())
             {
                 UITextField* fullTextField = new UITextField(context_, true);
                 fullTextField->SetText(hoveredWidget->GetText());
                 tooltipLayout->AddChild(fullTextField);
             }
-            if (hoveredWidget->GetTooltip().Length() > 0)
+            else if (hoveredWidget->GetTooltip().Length() > 0)
             {
                 UITextField* tooltipTextField = new UITextField(context_, true);
                 tooltipTextField->SetText(hoveredWidget->GetTooltip());


### PR DESCRIPTION
This PR adds a thumbnail (image) tooltip. It will automagically provide the thumbnail tooltip for .png, .jpg assets in a project's Texture directory.  There is also support for using thumbnails for .prefab, .mdl and .fbx assets.   To add a thumbnail for an asset is "easy". The user can create a new directory in the project root directory (where Resources and Cache are) called Support.   A (png) thumbnail for an asset is named assetname.ext.png, where assetname.ext is what you would see in the Project browser. Then, when you hover over assetname.ext, the thumbnail tooltip will appear. If no thumbnail is created for the asset, then nothing will appear.
Normal text tooltips are unaffected, for a thumbail tooltip, the 1st character in the string is a  "#" character, followed by a pathname to the image to display. The Texture based images in the project will show the actual image files, as defined by the asset. The other type assets are redirected to the Support directory to look for custom thumbnail images.
The reason the Project/Support directory is selected to hold the thumbnails, is so they don’t effect the asset system, they are not needed for deploying the game, but they are relevant to the project.

OH NO 35 lines again!