### PR TITLE
Add screenshot function

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -416,6 +416,8 @@ interface EditorFeatures {
     closePlayerLog: boolean;
     defaultPath: string;
     defaultLanguage: string;
+    screenshotPath: string;
+    screenshotFormat: string;
 }
 
 class PreferencesFormat {
@@ -478,7 +480,9 @@ class PreferencesFormat {
         this.editorFeatures = {
             closePlayerLog: true,
             defaultPath: userDocuments,
-            defaultLanguage: "JavaScript"
+            defaultLanguage: "JavaScript",
+            screenshotPath: userDocuments,
+            screenshotFormat: "png"
         };
 
     }
@@ -533,6 +537,16 @@ class PreferencesFormat {
 
         if (!prefs.editorFeatures.defaultPath) {
             prefs.editorFeatures.defaultPath = this.editorFeatures.defaultPath;
+            updatedMissingDefaults = true;
+        }
+
+        if (!prefs.editorFeatures.screenshotPath) {
+            prefs.editorFeatures.screenshotPath = this.editorFeatures.screenshotPath;
+            updatedMissingDefaults = true;
+        }
+
+        if (!prefs.editorFeatures.screenshotFormat) {
+            prefs.editorFeatures.screenshotFormat = this.editorFeatures.screenshotFormat;
             updatedMissingDefaults = true;
         }
 

--- a/Script/AtomicEditor/ui/EditorStrings.ts
+++ b/Script/AtomicEditor/ui/EditorStrings.ts
@@ -41,7 +41,8 @@ export enum StringID {
     ShortcutPlayDebug,
     ShortcutBuild,
     ShortcutBuildSettings,
-    ShortcutFrameSelected
+    ShortcutFrameSelected,
+    ShortcutScreenshot
 }
 
 export class EditorString {
@@ -96,6 +97,7 @@ export class EditorString {
         lookup[StringID.ShortcutPlayDebug] = "⇧" + shortcutKey + "P";
 
         lookup[StringID.ShortcutBuild] = shortcutKey + "B";
+        lookup[StringID.ShortcutScreenshot] = shortcutKey + "9";
 
     })();
 

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -174,6 +174,29 @@ class Shortcuts extends Atomic.ScriptObject {
         }
     }
 
+    invokeScreenshot() {
+        var features = Preferences.getInstance().editorFeatures; // get prefs
+        var pic_ext = features.screenshotFormat;
+        var pic_path = features.screenshotPath;
+        var dx = new Date();  // get the date NOW
+        var datestring = ("0" + dx.getDate()).slice( -2 ) + "_" + ("0" + (dx.getMonth() + 1 )).slice( -2 ) + "_" + dx.getFullYear()
+            + "_" + ("0" + dx.getHours()).slice(-2) + "_" + ("0" + dx.getMinutes()).slice(-2) + "_" + ("0" + dx.getSeconds()).slice(-2);
+        pic_path += "/Screenshot_" + datestring + "." + pic_ext;  // form filename
+        var myimage = new Atomic.Image; // make an image to save
+        if (Atomic.graphics.takeScreenShot(myimage)) { // take the screenshot
+            var saved_pic = false;
+            var jpgquality = 92; // very good quality jpeg 
+            if ( pic_ext == "png" ) saved_pic = myimage.savePNG(pic_path);
+            else if ( pic_ext == "jpg" ) saved_pic = myimage.saveJPG(pic_path, jpgquality);
+            else if ( pic_ext == "tga" ) saved_pic = myimage.saveTGA(pic_path);
+            else if ( pic_ext == "bmp" ) saved_pic = myimage.saveBMP(pic_path);
+            else if ( pic_ext == "dds" ) saved_pic = myimage.saveDDS(pic_path);
+            if (saved_pic)  EditorUI.showEditorStatus ( "Saved screenshot " + pic_path );
+            else EditorUI.showEditorStatus ( "Error - could not save screenshot " + pic_path );
+        }
+        else EditorUI.showEditorStatus ( "Error - could not take screenshot.");
+    }
+
     handleKeyDown(ev: Atomic.KeyDownEvent) {
 
         // if the right mouse buttons isn't down
@@ -249,6 +272,9 @@ class Shortcuts extends Atomic.ScriptObject {
                 } else {
                     this.invokePauseOrResumePlayer();
                 }
+            }
+            else if (ev.key == Atomic.KEY_9) {
+                this.invokeScreenshot();
             }
 
         }

--- a/Script/AtomicEditor/ui/Shortcuts.ts
+++ b/Script/AtomicEditor/ui/Shortcuts.ts
@@ -179,7 +179,7 @@ class Shortcuts extends Atomic.ScriptObject {
         var pic_ext = features.screenshotFormat;
         var pic_path = features.screenshotPath;
         var dx = new Date();  // get the date NOW
-        var datestring = ("0" + dx.getDate()).slice( -2 ) + "_" + ("0" + (dx.getMonth() + 1 )).slice( -2 ) + "_" + dx.getFullYear()
+        var datestring = dx.getFullYear() + "_" + ("0" + (dx.getMonth() + 1 )).slice(-2) + "_"  + ("0" + dx.getDate()).slice(-2)
             + "_" + ("0" + dx.getHours()).slice(-2) + "_" + ("0" + dx.getMinutes()).slice(-2) + "_" + ("0" + dx.getSeconds()).slice(-2);
         pic_path += "/Screenshot_" + datestring + "." + pic_ext;  // form filename
         var myimage = new Atomic.Image; // make an image to save

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -41,7 +41,6 @@ class MainFrameMenu extends Atomic.ScriptObject {
         MenuItemSources.createMenuItemSource("menu developer", developerItems);
         MenuItemSources.createMenuItemSource("menu help", helpItems);
         this.goScreenshot = 0;
-        this.subscribeToEvent(Atomic.UpdateEvent((ev) => this.handleScreenshot(ev)));
     }
 
     createPluginMenuItemSource(id: string, items: any): Atomic.UIMenuItemSource {
@@ -68,8 +67,10 @@ class MainFrameMenu extends Atomic.ScriptObject {
     handleScreenshot(ev) {
         if ( this.goScreenshot > 0 ) {
             this.goScreenshot--;
-            if ( this.goScreenshot == 0 )
+            if ( this.goScreenshot == 0 ) {
                 EditorUI.getShortcuts().invokeScreenshot();
+                this.unsubscribeFromEvent("Update");
+            }
         }
     }
 
@@ -244,6 +245,7 @@ class MainFrameMenu extends Atomic.ScriptObject {
             }
 
             if ( refid == "screenshot") {
+                this.subscribeToEvent(Atomic.UpdateEvent((ev) => this.handleScreenshot(ev)));
                 this.goScreenshot = 19;  // number of ticks to wait for the menu to close
                 return true;
             }

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -40,7 +40,8 @@ class MainFrameMenu extends Atomic.ScriptObject {
         MenuItemSources.createMenuItemSource("menu tools", toolsItems);
         MenuItemSources.createMenuItemSource("menu developer", developerItems);
         MenuItemSources.createMenuItemSource("menu help", helpItems);
-
+        this.goScreenshot = 0;
+        this.subscribeToEvent(Atomic.UpdateEvent((ev) => this.handleScreenshot(ev)));
     }
 
     createPluginMenuItemSource(id: string, items: any): Atomic.UIMenuItemSource {
@@ -61,6 +62,14 @@ class MainFrameMenu extends Atomic.ScriptObject {
                 developerMenuItemSource.removeItemWithStr("Plugins");
                 this.pluginMenuItemSource = null;
             }
+        }
+    }
+
+    handleScreenshot(ev) {
+        if ( this.goScreenshot > 0 ) {
+            this.goScreenshot--;
+            if ( this.goScreenshot == 0 )
+                EditorUI.getShortcuts().invokeScreenshot();
         }
     }
 
@@ -226,11 +235,16 @@ class MainFrameMenu extends Atomic.ScriptObject {
             }
 
             if (refid == "toggle codeeditor") {
-                var ctheme = EditorUI.getEditor().getApplicationPreference( "codeEditor","theme", "");
+                var ctheme = EditorUI.getEditor().getApplicationPreference( "codeEditor", "theme", "");
                 if ( ctheme == "vs-dark" )
-                    EditorUI.getEditor().setApplicationPreference( "codeEditor","theme","vs");
+                    EditorUI.getEditor().setApplicationPreference( "codeEditor", "theme", "vs");
                 else
-                    EditorUI.getEditor().setApplicationPreference( "codeEditor","theme","vs-dark");
+                    EditorUI.getEditor().setApplicationPreference( "codeEditor", "theme", "vs-dark");
+                return true;
+            }
+
+            if ( refid == "screenshot") {
+                this.goScreenshot = 19;  // number of ticks to wait for the menu to close
                 return true;
             }
 
@@ -350,6 +364,8 @@ class MainFrameMenu extends Atomic.ScriptObject {
 
     }
 
+    goScreenshot: number;
+
 }
 
 export = MainFrameMenu;
@@ -409,6 +425,7 @@ var developerItems = {
 
     "Toggle Theme": ["toggle theme"],
     "Toggle Code Editor Theme": ["toggle codeeditor"],
+    "ScreenShot": ["screenshot", StringID.ShortcutScreenshot],
     "Show Console": ["developer show console"],
     "Clear Preferences": ["developer clear preferences"], //Adds clear preference to developer menu items list
     "Debug": {


### PR DESCRIPTION
This PR add the function to save screenshots of the editor.
There is a preference for the screenshot path.
There is a preference for the save format : png, jpg, bmp, tga, dds
The image is saved with an autogenerated name : Screenshot_dd_mm_yyy_HH_MM_SS.ext
The screenshot is invoked with either the menu entry in Developer->Screenshot, or the key combo, Ctrl+9

Sorry, but this breaks the 35 additions chain... so talk to these ladies...
![screenshot_16_02_2017_19_10_19](https://cloud.githubusercontent.com/assets/19511757/23051980/23617452-f482-11e6-86e9-02321e1b22c1.png)