### PR TITLE
TypeScript and Extension fixes

### DIFF
--- a/Script/AtomicEditor/hostExtensions/ServiceLocator.ts
+++ b/Script/AtomicEditor/hostExtensions/ServiceLocator.ts
@@ -71,9 +71,15 @@ export class ServiceLocatorType implements Editor.HostExtensions.HostServiceLoca
      * @param  {string} eventType
      * @param  {any} data
      */
-    sendEvent(eventType: string, data: any) {
+    sendEvent<T extends Atomic.EventCallbackMetaData>(eventCallbackMetaData:T)
+    sendEvent(eventType: string, data: any)
+    sendEvent(eventTypeOrMetaData: any, data?: any) {
         if (this.eventDispatcher) {
-            this.eventDispatcher.sendEvent(eventType, data);
+            if  (data) {
+                this.eventDispatcher.sendEvent(eventTypeOrMetaData, data);
+            } else {
+                this.eventDispatcher.sendEvent(eventTypeOrMetaData);
+            }
         }
     }
 

--- a/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
+++ b/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
@@ -25,7 +25,7 @@
 /**
  * Resource extension that supports the web view typescript extension
  */
-export default class ProjectBasedExtensionLoader implements Editor.HostExtensions.ProjectServicesEventListener {
+export default class ProjectBasedExtensionLoader extends Atomic.ScriptObject implements Editor.HostExtensions.ProjectServicesEventListener {
     name: string = "ProjectBasedExtensionLoader";
     description: string = "This service supports loading extensions that reside in the project under {ProjectRoot}/Editor and named '*.Service.js'.";
 

--- a/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
+++ b/Script/AtomicEditor/hostExtensions/coreExtensions/ProjectBasedExtensionLoader.ts
@@ -112,9 +112,12 @@ export default class ProjectBasedExtensionLoader implements Editor.HostExtension
                         extensionPath = extensionPath.substring(0, extensionPath.length - 3);
 
                         console.log(`Detected project extension at: ${extensionPath} `);
-                        // Note: duktape does not yet support unloading modules,
-                        // but will return the same object when passed a path the second time.
-                        let resourceServiceModule = require(ProjectBasedExtensionLoader.duktapeRequirePrefix + extensionPath);
+                        const moduleName = ProjectBasedExtensionLoader.duktapeRequirePrefix + extensionPath;
+
+                        // Make sure that we delete the module from the module cache first so if there are any
+                        // changes, they get reflected
+                        delete Duktape.modLoaded[moduleName];
+                        let resourceServiceModule = require(moduleName);
 
                         // Handle situation where the service is either exposed by a typescript default export
                         // or as the module.export (depends on if it is being written in typescript, javascript, es6, etc.)

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/CSharpLanguageExtension.ts
@@ -25,7 +25,7 @@ import EditorUI = require("ui/EditorUI");
 /**
 * Resource extension that supports the web view typescript extension
 */
-export default class CSharpLanguageExtension implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener {
+export default class CSharpLanguageExtension extends Atomic.ScriptObject implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener {
     name: string = "HostCSharpLanguageExtension";
     description: string = "This service supports the csharp language.";
 
@@ -39,9 +39,6 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
     private menuCreated = false;
     /** Reference to the compileOnSaveMenuItem */
     private compileOnSaveMenuItem: Atomic.UIMenuItem;
-
-    //** A script object so we can take part in event handling
-    private eventObject = new Atomic.ScriptObject();
 
     /**
     * Determines if the file name/path provided is something we care about
@@ -161,7 +158,7 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
             this.isNETProject = true;
             this.configureNETProjectMenu();
 
-            this.eventObject.subscribeToEvent(ToolCore.NETBuildResultEvent((eventData:ToolCore.NETBuildResultEvent) => {
+            this.subscribeToEvent(ToolCore.NETBuildResultEvent((eventData:ToolCore.NETBuildResultEvent) => {
 
                 if (!eventData.success) {
 
@@ -193,7 +190,7 @@ export default class CSharpLanguageExtension implements Editor.HostExtensions.Re
         this.serviceRegistry.uiServices.removePluginMenuItemSource("AtomicNET");
         this.menuCreated = false;
         this.isNETProject = false;
-        this.eventObject.unsubscribeFromAllEvents();
+        this.unsubscribeFromAllEvents();
     }
 
     /*** UIService implementation ***/

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
@@ -408,6 +408,12 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
     doFullCompile() {
         const editor = this.serviceRegistry.uiServices.getCurrentResourceEditor();
         if (editor && editor.typeName == "JSResourceEditor" && this.isValidFiletype(editor.fullPath)) {
+            this.serviceRegistry.sendEvent(Editor.EditorModalEventData({
+              type: Editor.EDITOR_MODALINFO,
+              title: "Compiling TypeScript",
+              message: "Compiling TypeScript..."
+            }));
+
             const jsEditor = <Editor.JSResourceEditor>editor;
             jsEditor.webView.webClient.executeJavaScript(`TypeScript_DoFullCompile('${JSON.stringify(this.buildTsConfig())}');`);
         } else {
@@ -464,6 +470,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
             infoColor = "#333333";
         }
 
+        let errors = false;
         let messageArray = results.annotations.filter(result => {
             // If we are compiling the lib.d.ts or some other built-in library and it was successful, then
             // we really don't need to display that result since it's just noise.  Only display it if it fails
@@ -482,12 +489,27 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
                 message += `<color ${errorColor}>${result.text} at line ${result.row + 1} col ${result.column}</color> <widget TBSkinImage: skin: MagnifierBitmap, text:"..." id: link${linkId}>`;
                 links["link" + linkId] = result;
                 linkId++;
+                errors = true;
             }
             return message;
         }).join("\n");
 
         if (messageArray.length == 0) {
             messageArray = "Success";
+        }
+
+        if (errors) {
+            this.serviceRegistry.sendEvent(Editor.EditorModalEventData({
+              type: Editor.EDITOR_MODALINFO,
+              title: "Compiling TypeScript",
+              message: "Errors detected while compiling TypeScript."
+            }));
+        } else {
+            this.serviceRegistry.sendEvent(Editor.EditorModalEventData({
+              type: Editor.EDITOR_MODALINFO,
+              title: "Compiling TypeScript",
+              message: "Successfully compiled TypeScript."
+            }));
         }
 
         let message = [

--- a/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
+++ b/Script/AtomicEditor/hostExtensions/languageExtensions/TypescriptLanguageExtension.ts
@@ -43,7 +43,7 @@ const defaultCompilerOptions = {
 /**
  * Resource extension that supports the web view typescript extension
  */
-export default class TypescriptLanguageExtension implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener {
+export default class TypescriptLanguageExtension extends Atomic.ScriptObject implements Editor.HostExtensions.ResourceServicesEventListener, Editor.HostExtensions.ProjectServicesEventListener {
     name: string = "HostTypeScriptLanguageExtension";
     description: string = "This service supports the typescript webview extension.";
 
@@ -240,7 +240,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
                 };
 
                 this.setTsConfigOnWebView(this.buildTsConfig());
-                this.serviceRegistry.sendEvent<Editor.EditorDeleteResourceNotificationEvent>(Editor.EditorDeleteResourceNotificationEventType, eventData);
+                this.sendEvent(Editor.EditorDeleteResourceNotificationEventData(eventData));
             }
         }
     }
@@ -269,7 +269,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
                 };
 
                 this.setTsConfigOnWebView(this.buildTsConfig());
-                this.serviceRegistry.sendEvent<Editor.EditorRenameResourceNotificationEvent>(Editor.EditorRenameResourceNotificationEventType, eventData);
+                this.sendEvent(Editor.EditorRenameResourceNotificationEventData(eventData));
             }
         }
     }
@@ -314,6 +314,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
         this.compileOnSaveMenuItem = null;
         this.menuCreated = false;
         this.isTypescriptProject = false;
+        this.unsubscribeFromAllEvents();
     }
 
     /*** UIService implementation ***/
@@ -408,7 +409,7 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
     doFullCompile() {
         const editor = this.serviceRegistry.uiServices.getCurrentResourceEditor();
         if (editor && editor.typeName == "JSResourceEditor" && this.isValidFiletype(editor.fullPath)) {
-            this.serviceRegistry.sendEvent(Editor.EditorModalEventData({
+            this.sendEvent(Editor.EditorModalEventData({
               type: Editor.EDITOR_MODALINFO,
               title: "Compiling TypeScript",
               message: "Compiling TypeScript..."
@@ -499,13 +500,13 @@ export default class TypescriptLanguageExtension implements Editor.HostExtension
         }
 
         if (errors) {
-            this.serviceRegistry.sendEvent(Editor.EditorModalEventData({
+            this.sendEvent(Editor.EditorModalEventData({
               type: Editor.EDITOR_MODALINFO,
               title: "Compiling TypeScript",
               message: "Errors detected while compiling TypeScript."
             }));
         } else {
-            this.serviceRegistry.sendEvent(Editor.EditorModalEventData({
+            this.sendEvent(Editor.EditorModalEventData({
               type: Editor.EDITOR_MODALINFO,
               title: "Compiling TypeScript",
               message: "Successfully compiled TypeScript."

--- a/Script/AtomicEditor/ui/frames/ResourceFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ResourceFrame.ts
@@ -88,7 +88,7 @@ class ResourceFrame extends ScriptWidget {
 
         if (this.editors[path]) {
 
-            this.navigateToResource(path);
+            this.navigateToResource(path, ev.lineNumber);
 
             return;
 
@@ -117,7 +117,10 @@ class ResourceFrame extends ScriptWidget {
 
         var editor = this.editors[fullpath];
 
-        if (this.currentResourceEditor == editor) return;
+        if (this.currentResourceEditor == editor) {
+            this.setCursorPositionInEditor(editor, lineNumber, tokenPos);
+            return;
+        }
 
         var root = this.tabcontainer.contentRoot;
 
@@ -135,18 +138,30 @@ class ResourceFrame extends ScriptWidget {
 
             editor.setFocus();
 
-            // this cast could be better
-            var ext = Atomic.getExtension(fullpath);
-
-            if (ext == ".js" && lineNumber != -1) {
-                (<Editor.JSResourceEditor>editor).gotoLineNumber(lineNumber);
-            }
-            else if (ext == ".js" && tokenPos != -1) {
-                (<Editor.JSResourceEditor>editor).gotoTokenPos(tokenPos);
-            }
-
+            this.setCursorPositionInEditor(editor, lineNumber, tokenPos);
         }
 
+    }
+
+    /**
+     * 
+     * Set the cursor to the correct line number in the editor
+     * @param {Editor.ResourceEditor} editor
+     * @param {any} [lineNumber=-1]
+     * @param {any} [tokenPos=-1]
+     * 
+     * @memberOf ResourceFrame
+     */
+    setCursorPositionInEditor(editor: Editor.ResourceEditor, lineNumber = -1, tokenPos = -1) {
+        if (editor instanceof Editor.JSResourceEditor) {
+            if (lineNumber != -1) {
+                (<Editor.JSResourceEditor>editor).gotoLineNumber(lineNumber);
+            }
+
+            if (tokenPos != -1) {
+                (<Editor.JSResourceEditor>editor).gotoTokenPos(tokenPos);
+            }
+        }
     }
 
     handleCloseResource(ev: Editor.EditorResourceCloseEvent) {

--- a/Script/AtomicEditor/ui/modal/UIResourceOps.ts
+++ b/Script/AtomicEditor/ui/modal/UIResourceOps.ts
@@ -264,7 +264,7 @@ export class CreateScript extends ModalWindow {
 
                 if (selectedTemplate) {
                     // Check to see if we have a file extension.  If we don't then use the one defined in the template
-                    if (outputFile.indexOf(".") == -1) {
+                    if (outputFile.lastIndexOf(`.${selectedTemplate.ext}`) != outputFile.length - selectedTemplate.ext.length) {
                         outputFile += selectedTemplate.ext;
                     }
 

--- a/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ClientExtensionServices.ts
@@ -35,10 +35,23 @@ interface EventSubscription {
 export class EventDispatcher implements Editor.Extensions.EventDispatcher {
     private subscriptions: EventSubscription[] = [];
 
-    sendEvent(eventType: string, data: any) {
+    sendEvent<T extends Atomic.EventCallbackMetaData>(eventCallbackMetaData:T)
+    sendEvent(eventType: string, data: any)
+    sendEvent(eventTypeOrWrapped: any, data?: any) {
+        let eventType: string;
+        let eventData: any;
+        if (typeof(eventTypeOrWrapped) == "string") {
+            eventType = eventTypeOrWrapped;
+            eventData = data;
+        } else {
+            const metaData = eventTypeOrWrapped as Atomic.EventCallbackMetaData;
+            eventType = metaData._eventType;
+            eventData = metaData._callbackData;
+        }
+
         this.subscriptions.forEach(sub => {
             if (sub.eventName == eventType) {
-                sub.callback(data);
+                sub.callback(eventData);
             }
         });
     }

--- a/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
+++ b/Script/AtomicWebViewEditor/clientExtensions/ServiceLocator.ts
@@ -53,9 +53,15 @@ export class ClientServiceLocatorType implements Editor.ClientExtensions.ClientS
      * @param  {string} eventType
      * @param  {any} data
      */
-    sendEvent(eventType: string, data: any) {
+    sendEvent<T extends Atomic.EventCallbackMetaData>(eventCallbackMetaData:T)
+    sendEvent(eventType: string, data: any)
+    sendEvent(eventTypeOrWrapped: any, data?: any) {
         if (this.eventDispatcher) {
-            this.eventDispatcher.sendEvent(eventType, data);
+            if (data) {
+                this.eventDispatcher.sendEvent(eventTypeOrWrapped, data);
+            } else {
+                this.eventDispatcher.sendEvent(eventTypeOrWrapped);
+            }
         }
     }
 

--- a/Script/TypeScript/EditorWork.d.ts
+++ b/Script/TypeScript/EditorWork.d.ts
@@ -64,6 +64,7 @@ declare module Editor.Extensions {
          */
         sendEvent(eventType: string, data: any);
         sendEvent<T extends Atomic.EventMetaData>(eventType:string, data?:T);
+        sendEvent<T extends Atomic.EventCallbackMetaData>(eventCallbackMetaData:T);
 
         /**
          * Subscribe to an event and provide a callback.  This can be used by services to subscribe to custom events

--- a/Script/TypeScript/duktape.d.ts
+++ b/Script/TypeScript/duktape.d.ts
@@ -11,6 +11,13 @@ declare var console: Console;
 declare function require(filename: string): any;
 
 declare interface DuktapeModule {
+    /**
+     * List of modules that have been loaded via the "require" statement
+     * 
+     * @type {string[]}
+     * @memberOf DuktapeModule
+     */
+    modLoaded: string[];
     modSearch(id: string, require, exports, module);
 }
 


### PR DESCRIPTION
This is just a combination of small changes that I discovered while trying to put together a tutorial for creating a menu extension.
- Updated the service locator sendEvent method signature to use the new event system
- Changed the extensions to all descend from Atomic.ScriptObject so that they can be event listeners/senders (which effectively deprecates the sendEvent method in the service locator)
- Modified the extension loader to clear any previously loaded extensions from the ```require``` cache when closing and re-opening a project.  Otherwise it was not loading the changes and required you to exit the editor entirely.
- fix for not trying to compile previously transpiled js files.  JS files will only be put into the TS transpiler if they are true js files and not transpiled from ts.
- Send notifications to the status bar when transpiling typescript. Thanks @JimMarlowe! 👍 
- modified the output of the TS transpiler so that it looks good in both dark theme and light theme.
- fixed an issue where clicking an error in the transpiled output wouldn't always navigate to the line in the editor
- fixed an issue where the file extension was not automatically being appended to a new file if the filename had dots in it.