### PR TITLE
Make string to floating-point conversion independent from locale.

### DIFF
--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -35,9 +35,10 @@
 // locale is set. The strtod_c_locale() is a workaround using the "C" locale explicitly,
 // which uses a dot as decimal separator.
 
+#include <locale.h>
+
 #ifdef _WIN32
 
-#include <locale.h>
 #include <stdlib.h>
 
 static
@@ -55,7 +56,9 @@ double strtod_c_locale(const char* nptr, char** endptr)
 
 #else
 
-#include <locale.h>
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
 
 static
 locale_t get_c_locale()

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -46,7 +46,11 @@ locale_t get_c_locale()
 static
 double strtod_c_locale(const char* nptr, char** endptr)
 {
-  return strtod_l(nptr, endptr, get_c_locale());
+#ifdef _WIN32
+    return _strtod_l(nptr, endptr, get_c_locale());
+#else
+    return strtod_l(nptr, endptr, get_c_locale());
+#endif
 }
 
 

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -36,6 +36,10 @@
 // which uses a dot as decimal separator.
 
 #include <locale.h>
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
+
 #include <stdlib.h>
 
 #ifdef _WIN32
@@ -54,10 +58,6 @@ double strtod_c_locale(const char* nptr, char** endptr)
 }
 
 #else
-
-#ifdef __APPLE__
-#include <xlocale.h>
-#endif
 
 static
 locale_t get_c_locale()

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -25,8 +25,30 @@
 #include "../Core/StringUtils.h"
 
 #include <cstdio>
+#include <locale.h>
 
 #include "../DebugNew.h"
+
+
+// The built-in strtod() function uses the current locale for parsing strings. On certain
+// locales (German, Swedish, ...) a comma is used as decimal separator. For portable XMLs,
+// we need to parse floating point values the same way on all platforms no matter what
+// locale is set. The strtod_c_locale() is a workaround using the "C" locale explicitly,
+// which uses a dot as decimal separator.
+
+static
+locale_t get_c_locale()
+{
+    static locale_t loc = newlocale(LC_ALL_MASK, "C", NULL);
+    return loc;
+}
+
+static
+double strtod_c_locale(const char* nptr, char** endptr)
+{
+  return strtod_l(nptr, endptr, get_c_locale());
+}
+
 
 namespace Atomic
 {
@@ -146,7 +168,7 @@ float ToFloat(const char* source)
     if (!source)
         return 0;
 
-    return (float)strtod(source, 0);
+    return (float)strtod_c_locale(source, 0);
 }
 
 double ToDouble(const String& source)
@@ -176,11 +198,11 @@ Color ToColor(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.r_ = (float)strtod(ptr, &ptr);
-    ret.g_ = (float)strtod(ptr, &ptr);
-    ret.b_ = (float)strtod(ptr, &ptr);
+    ret.r_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.g_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.b_ = (float)strtod_c_locale(ptr, &ptr);
     if (elements > 3)
-        ret.a_ = (float)strtod(ptr, &ptr);
+        ret.a_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }
@@ -241,10 +263,10 @@ Rect ToRect(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.min_.x_ = (float)strtod(ptr, &ptr);
-    ret.min_.y_ = (float)strtod(ptr, &ptr);
-    ret.max_.x_ = (float)strtod(ptr, &ptr);
-    ret.max_.y_ = (float)strtod(ptr, &ptr);
+    ret.min_.x_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.min_.y_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.max_.x_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.max_.y_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }
@@ -265,9 +287,9 @@ Quaternion ToQuaternion(const char* source)
     {
         // 3 coords specified: conversion from Euler angles
         float x, y, z;
-        x = (float)strtod(ptr, &ptr);
-        y = (float)strtod(ptr, &ptr);
-        z = (float)strtod(ptr, &ptr);
+        x = (float)strtod_c_locale(ptr, &ptr);
+        y = (float)strtod_c_locale(ptr, &ptr);
+        z = (float)strtod_c_locale(ptr, &ptr);
 
         return Quaternion(x, y, z);
     }
@@ -275,10 +297,10 @@ Quaternion ToQuaternion(const char* source)
     {
         // 4 coords specified: full quaternion
         Quaternion ret;
-        ret.w_ = (float)strtod(ptr, &ptr);
-        ret.x_ = (float)strtod(ptr, &ptr);
-        ret.y_ = (float)strtod(ptr, &ptr);
-        ret.z_ = (float)strtod(ptr, &ptr);
+        ret.w_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.x_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.y_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.z_ = (float)strtod_c_locale(ptr, &ptr);
 
         return ret;
     }
@@ -298,8 +320,8 @@ Vector2 ToVector2(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.x_ = (float)strtod(ptr, &ptr);
-    ret.y_ = (float)strtod(ptr, &ptr);
+    ret.x_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.y_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }
@@ -318,9 +340,9 @@ Vector3 ToVector3(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.x_ = (float)strtod(ptr, &ptr);
-    ret.y_ = (float)strtod(ptr, &ptr);
-    ret.z_ = (float)strtod(ptr, &ptr);
+    ret.x_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.y_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.z_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }
@@ -342,23 +364,23 @@ Vector4 ToVector4(const char* source, bool allowMissingCoords)
         if (elements < 4)
             return ret;
 
-        ret.x_ = (float)strtod(ptr, &ptr);
-        ret.y_ = (float)strtod(ptr, &ptr);
-        ret.z_ = (float)strtod(ptr, &ptr);
-        ret.w_ = (float)strtod(ptr, &ptr);
+        ret.x_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.y_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.z_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.w_ = (float)strtod_c_locale(ptr, &ptr);
 
         return ret;
     }
     else
     {
         if (elements > 0)
-            ret.x_ = (float)strtod(ptr, &ptr);
+            ret.x_ = (float)strtod_c_locale(ptr, &ptr);
         if (elements > 1)
-            ret.y_ = (float)strtod(ptr, &ptr);
+            ret.y_ = (float)strtod_c_locale(ptr, &ptr);
         if (elements > 2)
-            ret.z_ = (float)strtod(ptr, &ptr);
+            ret.z_ = (float)strtod_c_locale(ptr, &ptr);
         if (elements > 3)
-            ret.w_ = (float)strtod(ptr, &ptr);
+            ret.w_ = (float)strtod_c_locale(ptr, &ptr);
 
         return ret;
     }
@@ -426,15 +448,15 @@ Matrix3 ToMatrix3(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.m00_ = (float)strtod(ptr, &ptr);
-    ret.m01_ = (float)strtod(ptr, &ptr);
-    ret.m02_ = (float)strtod(ptr, &ptr);
-    ret.m10_ = (float)strtod(ptr, &ptr);
-    ret.m11_ = (float)strtod(ptr, &ptr);
-    ret.m12_ = (float)strtod(ptr, &ptr);
-    ret.m20_ = (float)strtod(ptr, &ptr);
-    ret.m21_ = (float)strtod(ptr, &ptr);
-    ret.m22_ = (float)strtod(ptr, &ptr);
+    ret.m00_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m01_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m02_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m10_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m11_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m12_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m20_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m21_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m22_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }
@@ -453,18 +475,18 @@ Matrix3x4 ToMatrix3x4(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.m00_ = (float)strtod(ptr, &ptr);
-    ret.m01_ = (float)strtod(ptr, &ptr);
-    ret.m02_ = (float)strtod(ptr, &ptr);
-    ret.m03_ = (float)strtod(ptr, &ptr);
-    ret.m10_ = (float)strtod(ptr, &ptr);
-    ret.m11_ = (float)strtod(ptr, &ptr);
-    ret.m12_ = (float)strtod(ptr, &ptr);
-    ret.m13_ = (float)strtod(ptr, &ptr);
-    ret.m20_ = (float)strtod(ptr, &ptr);
-    ret.m21_ = (float)strtod(ptr, &ptr);
-    ret.m22_ = (float)strtod(ptr, &ptr);
-    ret.m23_ = (float)strtod(ptr, &ptr);
+    ret.m00_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m01_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m02_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m03_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m10_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m11_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m12_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m13_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m20_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m21_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m22_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m23_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }
@@ -483,22 +505,22 @@ Matrix4 ToMatrix4(const char* source)
         return ret;
 
     char* ptr = (char*)source;
-    ret.m00_ = (float)strtod(ptr, &ptr);
-    ret.m01_ = (float)strtod(ptr, &ptr);
-    ret.m02_ = (float)strtod(ptr, &ptr);
-    ret.m03_ = (float)strtod(ptr, &ptr);
-    ret.m10_ = (float)strtod(ptr, &ptr);
-    ret.m11_ = (float)strtod(ptr, &ptr);
-    ret.m12_ = (float)strtod(ptr, &ptr);
-    ret.m13_ = (float)strtod(ptr, &ptr);
-    ret.m20_ = (float)strtod(ptr, &ptr);
-    ret.m21_ = (float)strtod(ptr, &ptr);
-    ret.m22_ = (float)strtod(ptr, &ptr);
-    ret.m23_ = (float)strtod(ptr, &ptr);
-    ret.m30_ = (float)strtod(ptr, &ptr);
-    ret.m31_ = (float)strtod(ptr, &ptr);
-    ret.m32_ = (float)strtod(ptr, &ptr);
-    ret.m33_ = (float)strtod(ptr, &ptr);
+    ret.m00_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m01_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m02_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m03_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m10_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m11_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m12_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m13_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m20_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m21_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m22_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m23_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m30_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m31_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m32_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m33_ = (float)strtod_c_locale(ptr, &ptr);
 
     return ret;
 }

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -37,6 +37,7 @@
 
 #ifdef _WIN32
 
+#include <locale.h>
 #include <stdlib.h>
 
 static

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -204,7 +204,7 @@ double ToDouble(const char* source)
     if (!source)
         return 0;
 
-    return strtod(source, 0);
+    return strtod_c_locale(source, 0);
 }
 
 Color ToColor(const String& source)

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -36,10 +36,9 @@
 // which uses a dot as decimal separator.
 
 #include <locale.h>
+#include <stdlib.h>
 
 #ifdef _WIN32
-
-#include <stdlib.h>
 
 static
 _locale_t get_c_locale()

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -25,7 +25,6 @@
 #include "../Core/StringUtils.h"
 
 #include <cstdio>
-#include <locale.h>
 
 #include "../DebugNew.h"
 
@@ -35,6 +34,27 @@
 // we need to parse floating point values the same way on all platforms no matter what
 // locale is set. The strtod_c_locale() is a workaround using the "C" locale explicitly,
 // which uses a dot as decimal separator.
+
+#ifdef _WIN32
+
+#include <stdlib.h>
+
+static
+_locale_t get_c_locale()
+{
+    static _locale_t loc = _create_locale(LC_ALL, "C");
+    return loc;
+}
+
+static
+double strtod_c_locale(const char* nptr, char** endptr)
+{
+    return _strtod_l(nptr, endptr, get_c_locale());
+}
+
+#else
+
+#include <locale.h>
 
 static
 locale_t get_c_locale()
@@ -46,12 +66,10 @@ locale_t get_c_locale()
 static
 double strtod_c_locale(const char* nptr, char** endptr)
 {
-#ifdef _WIN32
-    return _strtod_l(nptr, endptr, get_c_locale());
-#else
     return strtod_l(nptr, endptr, get_c_locale());
-#endif
 }
+
+#endif // _WIN32
 
 
 namespace Atomic


### PR DESCRIPTION
Instead of using strtod() for converting strings to doubles, use strtod_l()
with an explicit "C" locale. The problem of strtod() is that the decimal
separator changes with the locale. So an XML written on an English system
cannot be read on a German system, for example.

Using strtod_l() + "C" locale uses a dot as separator all the time (locale-independent).

This finally fixes #1465 and #1469 for me (linux + German locale).

Could somebody test this on other platforms (Win, MacOS, ...) please?