### PR TITLE
Remove WeakPtr's from object metrics container

### DIFF
--- a/Source/Atomic/Metrics/Metrics.h
+++ b/Source/Atomic/Metrics/Metrics.h
@@ -120,8 +120,6 @@ private:
 
     void CaptureInstances(MetricsSnapshot* snapshot);
 
-    void PruneExpiredInstances();
-
     static void OnRefCountedCreated(RefCounted* refCounted);
     static void OnRefCountedDeleted(RefCounted* refCounted);
 
@@ -131,7 +129,7 @@ private:
 
     bool enabled_;
 
-    Vector<WeakPtr<RefCounted>> instances_;
+    Vector<RefCounted*> instances_;
 
 };
 


### PR DESCRIPTION
Use raw RefCounted pointers in metrics as WeakPtr can keep some instances "alive" for example in the ResourceCache

Closes #1471