### PR TITLE
Floating point values should be written with a dot as separator.

### DIFF
--- a/Source/Atomic/Container/Str.cpp
+++ b/Source/Atomic/Container/Str.cpp
@@ -32,6 +32,13 @@
 #pragma warning(disable:6293)
 #endif
 
+
+// ATOMIC BEGIN
+
+#include "../Core/Io.h"
+
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -133,7 +140,9 @@ String::String(float value) :
     buffer_(&endZero)
 {
     char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g", value);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g", value);
+    // ATOMIC END
     *this = tempBuffer;
 }
 
@@ -143,7 +152,9 @@ String::String(double value) :
     buffer_(&endZero)
 {
     char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%.15g", value);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%.15g", value);
+    // ATOMIC END
     *this = tempBuffer;
 }
 

--- a/Source/Atomic/Core/Io.cpp
+++ b/Source/Atomic/Core/Io.cpp
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2008-2016 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// ATOMIC BEGIN
+
+#include "../Precompiled.h"
+
+#include "../Core/Io.h"
+
+#ifdef ATOMIC_PLATFORM_WINDOWS
+
+namespace Atomic
+{
+
+_locale_t GetCLocale()
+{
+    static _locale_t loc = _create_locale(LC_ALL, "C");
+    return loc;
+}
+
+}
+
+double Atomic_strtod(const char* nptr, char** endptr)
+{
+    return _strtod_l(nptr, endptr, Atomic::GetCLocale());
+}
+
+#elif defined(ATOMIC_PLATFORM_ANDROID) || defined(ATOMIC_PLATFORM_IOS)
+
+// Android NDK/iOS don't do locale.
+
+#else
+
+// Linux and OSX share have the same implementation.
+
+namespace Atomic
+{
+
+locale_t GetCLocale()
+{
+    static locale_t loc = newlocale(LC_ALL_MASK, "C", NULL);
+    return loc;
+}
+
+}
+
+double Atomic_strtod(const char* nptr, char** endptr)
+{
+    return strtod_l(nptr, endptr, Atomic::GetCLocale());
+}
+
+#endif
+
+// ATOMIC END

--- a/Source/Atomic/Core/Io.h
+++ b/Source/Atomic/Core/Io.h
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2008-2016 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// ATOMIC BEGIN
+
+#pragma once
+
+// The built-in strtod() function uses the current locale for parsing strings. On certain
+// locales (German, Swedish, ...) a comma is used as decimal separator. For portable XML,
+// we need to parse floating point values the same way on all platforms no matter what
+// locale is set. The strtod_c_locale() is a workaround using the "C" locale explicitly,
+// which uses a dot as decimal separator. For the same reason, sprintf() cannot be used.
+// The function Atomic_strtod() and the macro Atomic_sprintf() should be used instead.
+
+#ifdef ATOMIC_PLATFORM_WINDOWS
+
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace Atomic
+{
+_locale_t GetCLocale();
+}
+
+double Atomic_strtod(const char* nptr, char** endptr);
+
+#define Atomic_sprintf(buffer, format, ...)   _sprintf_l(buffer, format, ::Atomic::GetCLocale(), __VA_ARGS__)
+
+#elif defined(ATOMIC_PLATFORM_ANDROID) || defined(ATOMIC_PLATFORM_IOS)
+
+// Android NDK/iOS don't do locale.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+inline
+double Atomic_strtod(const char* nptr, char** endptr)
+{
+    return strtod(nptr, endptr);
+}
+
+#define Atomic_sprintf(buffer, format, ...)   sprintf(buffer, format, __VA_ARGS__)
+
+#elif defined(ATOMIC_PLATFORM_OSX)
+
+#include <xlocale.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace Atomic
+{
+locale_t GetCLocale();
+}
+
+double Atomic_strtod(const char* nptr, char** endptr);
+
+#define Atomic_sprintf(buffer, format, ...)   sprintf_l(buffer, ::Atomic_GetCLocale(), format, __VA_ARGS__)
+
+#else
+
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace Atomic
+{
+locale_t GetCLocale();
+}
+
+double Atomic_strtod(const char* nptr, char** endptr);
+
+#define Atomic_sprintf(buffer, format, ...)                            \
+    do {                                                        \
+        locale_t oldLocale = uselocale(::Atomic::GetCLocale()); \
+        sprintf(buffer, format, __VA_ARGS__);                   \
+        uselocale(oldLocale);                                   \
+    } while (0)
+
+#endif
+
+// ATOMIC END

--- a/Source/Atomic/Core/Io.h
+++ b/Source/Atomic/Core/Io.h
@@ -63,6 +63,7 @@ double Atomic_strtod(const char* nptr, char** endptr)
 
 #elif defined(ATOMIC_PLATFORM_OSX)
 
+#include <locale.h>
 #include <xlocale.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -89,7 +90,7 @@ locale_t GetCLocale();
 
 double Atomic_strtod(const char* nptr, char** endptr);
 
-#define Atomic_sprintf(buffer, format, ...)                            \
+#define Atomic_sprintf(buffer, format, ...)                     \
     do {                                                        \
         locale_t oldLocale = uselocale(::Atomic::GetCLocale()); \
         sprintf(buffer, format, __VA_ARGS__);                   \

--- a/Source/Atomic/Core/StringUtils.cpp
+++ b/Source/Atomic/Core/StringUtils.cpp
@@ -29,57 +29,7 @@
 #include "../DebugNew.h"
 
 // ATOMIC BEGIN
-
-// The built-in strtod() function uses the current locale for parsing strings. On certain
-// locales (German, Swedish, ...) a comma is used as decimal separator. For portable XML,
-// we need to parse floating point values the same way on all platforms no matter what
-// locale is set. The strtod_c_locale() is a workaround using the "C" locale explicitly,
-// which uses a dot as decimal separator.
-
-#include <locale.h>
-#ifdef ATOMIC_PLATFORM_OSX
-#include <xlocale.h>
-#endif
-
-#include <stdlib.h>
-
-#ifdef ATOMIC_PLATFORM_WINDOWS
-
-static _locale_t get_c_locale()
-{
-    static _locale_t loc = _create_locale(LC_ALL, "C");
-    return loc;
-}
-
-static double strtod_c_locale(const char* nptr, char** endptr)
-{
-    return _strtod_l(nptr, endptr, get_c_locale());
-}
-
-#elif defined(ATOMIC_PLATFORM_ANDROID) || defined(ATOMIC_PLATFORM_IOS)
-
-// Android NDK/iOS don't do locale, so just revert to strtod
-
-static double strtod_c_locale(const char* nptr, char** endptr)
-{
-    return strtod(nptr, endptr);
-}
-
-#else
-
-static locale_t get_c_locale()
-{
-    static locale_t loc = newlocale(LC_ALL_MASK, "C", NULL);
-    return loc;
-}
-
-static double strtod_c_locale(const char* nptr, char** endptr)
-{
-    return strtod_l(nptr, endptr, get_c_locale());
-}
-
-#endif // ATOMIC_PLATFORM_WINDOWS
-
+#include "../Core/Io.h"
 // ATOMIC END
 
 namespace Atomic
@@ -201,7 +151,7 @@ float ToFloat(const char* source)
         return 0;
 
     // ATOMIC BEGIN
-    return (float)strtod_c_locale(source, 0);
+    return (float)Atomic_strtod(source, 0);
     // ATOMIC END
 }
 
@@ -216,7 +166,7 @@ double ToDouble(const char* source)
         return 0;
 
     // ATOMIC BEGIN
-    return strtod_c_locale(source, 0);
+    return Atomic_strtod(source, 0);
     // ATOMIC END
 }
 
@@ -236,11 +186,11 @@ Color ToColor(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.r_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.g_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.b_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.r_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.g_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.b_ = (float)Atomic_strtod(ptr, &ptr);
     if (elements > 3)
-        ret.a_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.a_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;
@@ -304,10 +254,10 @@ Rect ToRect(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.min_.x_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.min_.y_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.max_.x_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.max_.y_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.min_.x_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.min_.y_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.max_.x_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.max_.y_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;
@@ -331,9 +281,9 @@ Quaternion ToQuaternion(const char* source)
         float x, y, z;
 
         // ATOMIC BEGIN
-        x = (float)strtod_c_locale(ptr, &ptr);
-        y = (float)strtod_c_locale(ptr, &ptr);
-        z = (float)strtod_c_locale(ptr, &ptr);
+        x = (float)Atomic_strtod(ptr, &ptr);
+        y = (float)Atomic_strtod(ptr, &ptr);
+        z = (float)Atomic_strtod(ptr, &ptr);
         // ATOMIC END
 
         return Quaternion(x, y, z);
@@ -344,10 +294,10 @@ Quaternion ToQuaternion(const char* source)
         Quaternion ret;
 
         // ATOMIC BEGIN
-        ret.w_ = (float)strtod_c_locale(ptr, &ptr);
-        ret.x_ = (float)strtod_c_locale(ptr, &ptr);
-        ret.y_ = (float)strtod_c_locale(ptr, &ptr);
-        ret.z_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.w_ = (float)Atomic_strtod(ptr, &ptr);
+        ret.x_ = (float)Atomic_strtod(ptr, &ptr);
+        ret.y_ = (float)Atomic_strtod(ptr, &ptr);
+        ret.z_ = (float)Atomic_strtod(ptr, &ptr);
         // ATOMIC END
 
         return ret;
@@ -370,8 +320,8 @@ Vector2 ToVector2(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.x_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.y_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.x_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.y_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;
@@ -393,9 +343,9 @@ Vector3 ToVector3(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.x_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.y_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.z_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.x_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.y_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.z_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;
@@ -419,23 +369,23 @@ Vector4 ToVector4(const char* source, bool allowMissingCoords)
         if (elements < 4)
             return ret;
 
-        ret.x_ = (float)strtod_c_locale(ptr, &ptr);
-        ret.y_ = (float)strtod_c_locale(ptr, &ptr);
-        ret.z_ = (float)strtod_c_locale(ptr, &ptr);
-        ret.w_ = (float)strtod_c_locale(ptr, &ptr);
+        ret.x_ = (float)Atomic_strtod(ptr, &ptr);
+        ret.y_ = (float)Atomic_strtod(ptr, &ptr);
+        ret.z_ = (float)Atomic_strtod(ptr, &ptr);
+        ret.w_ = (float)Atomic_strtod(ptr, &ptr);
 
         return ret;
     }
     else
     {
         if (elements > 0)
-            ret.x_ = (float)strtod_c_locale(ptr, &ptr);
+            ret.x_ = (float)Atomic_strtod(ptr, &ptr);
         if (elements > 1)
-            ret.y_ = (float)strtod_c_locale(ptr, &ptr);
+            ret.y_ = (float)Atomic_strtod(ptr, &ptr);
         if (elements > 2)
-            ret.z_ = (float)strtod_c_locale(ptr, &ptr);
+            ret.z_ = (float)Atomic_strtod(ptr, &ptr);
         if (elements > 3)
-            ret.w_ = (float)strtod_c_locale(ptr, &ptr);
+            ret.w_ = (float)Atomic_strtod(ptr, &ptr);
 
         return ret;
     }
@@ -506,15 +456,15 @@ Matrix3 ToMatrix3(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.m00_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m01_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m02_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m10_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m11_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m12_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m20_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m21_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m22_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m00_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m01_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m02_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m10_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m11_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m12_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m20_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m21_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m22_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;
@@ -536,18 +486,18 @@ Matrix3x4 ToMatrix3x4(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.m00_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m01_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m02_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m03_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m10_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m11_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m12_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m13_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m20_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m21_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m22_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m23_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m00_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m01_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m02_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m03_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m10_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m11_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m12_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m13_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m20_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m21_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m22_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m23_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;
@@ -569,22 +519,22 @@ Matrix4 ToMatrix4(const char* source)
     char* ptr = (char*)source;
 
     // ATOMIC BEGIN
-    ret.m00_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m01_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m02_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m03_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m10_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m11_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m12_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m13_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m20_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m21_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m22_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m23_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m30_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m31_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m32_ = (float)strtod_c_locale(ptr, &ptr);
-    ret.m33_ = (float)strtod_c_locale(ptr, &ptr);
+    ret.m00_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m01_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m02_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m03_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m10_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m11_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m12_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m13_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m20_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m21_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m22_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m23_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m30_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m31_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m32_ = (float)Atomic_strtod(ptr, &ptr);
+    ret.m33_ = (float)Atomic_strtod(ptr, &ptr);
     // ATOMIC END
 
     return ret;

--- a/Source/Atomic/Math/Color.cpp
+++ b/Source/Atomic/Math/Color.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -224,7 +228,9 @@ Color Color::Lerp(const Color& rhs, float t) const
 String Color::ToString() const
 {
     char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g", r_, g_, b_, a_);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g", r_, g_, b_, a_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Matrix2.cpp
+++ b/Source/Atomic/Math/Matrix2.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -53,7 +57,9 @@ Matrix2 Matrix2::Inverse() const
 String Matrix2::ToString() const
 {
     char tempBuffer[MATRIX_CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g", m00_, m01_, m10_, m11_);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g", m00_, m01_, m10_, m11_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 }

--- a/Source/Atomic/Math/Matrix3.cpp
+++ b/Source/Atomic/Math/Matrix3.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -65,7 +69,9 @@ Matrix3 Matrix3::Inverse() const
 String Matrix3::ToString() const
 {
     char tempBuffer[MATRIX_CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g %g %g %g %g %g", m00_, m01_, m02_, m10_, m11_, m12_, m20_, m21_, m22_);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g %g %g %g %g %g", m00_, m01_, m02_, m10_, m11_, m12_, m20_, m21_, m22_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Matrix3x4.cpp
+++ b/Source/Atomic/Math/Matrix3x4.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -82,9 +86,11 @@ Matrix3x4 Matrix3x4::Inverse() const
 
 String Matrix3x4::ToString() const
 {
-    char tempBuffer[MATRIX_CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g %g %g %g %g %g %g %g %g", m00_, m01_, m02_, m03_, m10_, m11_, m12_, m13_, m20_, m21_, m22_,
+    char tempBuffer[MATRIX_CONVERSION_BUFFER_LENGTH];    
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g %g %g %g %g %g %g %g %g", m00_, m01_, m02_, m03_, m10_, m11_, m12_, m13_, m20_, m21_, m22_,
         m23_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Matrix4.cpp
+++ b/Source/Atomic/Math/Matrix4.cpp
@@ -29,6 +29,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -136,8 +140,10 @@ Matrix4 Matrix4::Inverse() const
 String Matrix4::ToString() const
 {
     char tempBuffer[MATRIX_CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g", m00_, m01_, m02_, m03_, m10_, m11_, m12_, m13_, m20_,
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g", m00_, m01_, m02_, m03_, m10_, m11_, m12_, m13_, m20_,
         m21_, m22_, m23_, m30_, m31_, m32_, m33_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Quaternion.cpp
+++ b/Source/Atomic/Math/Quaternion.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -313,8 +317,10 @@ Quaternion Quaternion::Nlerp(Quaternion rhs, float t, bool shortestPath) const
 
 String Quaternion::ToString() const
 {
-    char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g", w_, x_, y_, z_);
+    char tempBuffer[CONVERSION_BUFFER_LENGTH];    
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g", w_, x_, y_, z_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Rect.cpp
+++ b/Source/Atomic/Math/Rect.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -39,8 +43,10 @@ const IntRect IntRect::ZERO(0, 0, 0, 0);
 
 String Rect::ToString() const
 {
-    char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g", min_.x_, min_.y_, max_.x_, max_.y_);
+    char tempBuffer[CONVERSION_BUFFER_LENGTH];    
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g", min_.x_, min_.y_, max_.x_, max_.y_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Vector2.cpp
+++ b/Source/Atomic/Math/Vector2.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -43,7 +47,9 @@ const IntVector2 IntVector2::ZERO;
 String Vector2::ToString() const
 {
     char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g", x_, y_);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g", x_, y_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Vector3.cpp
+++ b/Source/Atomic/Math/Vector3.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -43,7 +47,9 @@ const Vector3 Vector3::ONE(1.0f, 1.0f, 1.0f);
 String Vector3::ToString() const
 {
     char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g", x_, y_, z_);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g", x_, y_, z_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 

--- a/Source/Atomic/Math/Vector4.cpp
+++ b/Source/Atomic/Math/Vector4.cpp
@@ -28,6 +28,10 @@
 
 #include "../DebugNew.h"
 
+// ATOMIC BEGIN
+#include "../Core/Io.h"
+// ATOMIC END
+
 namespace Atomic
 {
 
@@ -37,7 +41,9 @@ const Vector4 Vector4::ONE(1.0f, 1.0f, 1.0f, 1.0f);
 String Vector4::ToString() const
 {
     char tempBuffer[CONVERSION_BUFFER_LENGTH];
-    sprintf(tempBuffer, "%g %g %g %g", x_, y_, z_, w_);
+    // ATOMIC BEGIN
+    Atomic_sprintf(tempBuffer, "%g %g %g %g", x_, y_, z_, w_);
+    // ATOMIC END
     return String(tempBuffer);
 }
 


### PR DESCRIPTION
Floating point values should always use a '.' as decimal separator and not the separator
determined by the user's locale. Otherwise, XML files written on one system with an
English locale cannot be parsed back correctly on a system with e.g. a German locale.

Replacements for strtod() and sprintf() have been collected in Core/Io.{h,cpp}. Since
sprintf() has a variadic parameter list, the replacement Atomic_sprintf() is implemented
as a macro for simplicity.