### PR TITLE
[C#] Better scene resource management

### DIFF
--- a/Script/AtomicNET/AtomicNET/Core/NativeCore.cs
+++ b/Script/AtomicNET/AtomicNET/Core/NativeCore.cs
@@ -226,7 +226,7 @@ namespace AtomicEngine
 
         }
 
-        static void ExpireNatives()
+        internal static void ExpireNatives()
         {
             var watch = new Stopwatch();
             watch.Start();

--- a/Script/AtomicNET/AtomicNET/Player/Player.cs
+++ b/Script/AtomicNET/AtomicNET/Player/Player.cs
@@ -28,6 +28,11 @@ namespace AtomicPlayer
             {
                 if (loadedScenes.Contains(e.Scene))
                     loadedScenes.Remove(e.Scene);
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                NativeCore.ExpireNatives();                
+
             });
 
         }

--- a/Source/Atomic/UI/SystemUI/DebugHud.cpp
+++ b/Source/Atomic/UI/SystemUI/DebugHud.cpp
@@ -277,6 +277,12 @@ void DebugHud::SetProfilerMode(DebugHudProfileMode mode)
 
         if (!metrics)
             size = 32;
+        else
+        {
+            // Enable metrics immediately
+            if (!metrics->GetEnabled())
+                metrics->Enable();
+        }
 
         if (profilerText_.NotNull())
         {

--- a/Source/Atomic/UI/UI.cpp
+++ b/Source/Atomic/UI/UI.cpp
@@ -946,6 +946,16 @@ void UI::SetDebugHudProfileMode(DebugHudProfileMode mode)
     hud->SetProfilerMode(mode);
 }
 
+void UI::SetDebugHudRefreshInterval(float seconds)
+{
+    SystemUI::DebugHud* hud = GetSubsystem<SystemUI::DebugHud>();
+
+    if (!hud)
+        return;
+
+    hud->SetProfilerInterval(seconds);
+}
+
 void UI::ShowConsole(bool value)
 {
     SystemUI::Console* console = GetSubsystem<SystemUI::Console>();

--- a/Source/Atomic/UI/UI.h
+++ b/Source/Atomic/UI/UI.h
@@ -107,6 +107,9 @@ public:
 
     void SetDebugHudExtents(bool useRootExtents = true, const IntVector2& position = IntVector2::ZERO, const IntVector2& size = IntVector2::ZERO);
 
+    /// Set the DebugHud refresh interval for performance and metrics in seconds
+    void SetDebugHudRefreshInterval(float seconds);
+
     void ShowConsole(bool value);
     void ToggleConsole();
 


### PR DESCRIPTION
When unloading a scene in C#, run GC and ExpireNatives, exposing DebugHud update interval through UI subsystem, enable metrics immediately when mode set so doesn't miss instances created before next Update

See https://github.com/AtomicGameEngine/AtomicTests/tree/master/CSharpTests/SceneResourcesTest for test case