### PR TITLE
Add the GetResourceDirs function into C# ResourceCache

### DIFF
--- a/Script/AtomicNET/AtomicNET/Resource/ResourceCache.cs
+++ b/Script/AtomicNET/AtomicNET/Resource/ResourceCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace AtomicEngine
@@ -27,6 +28,20 @@ namespace AtomicEngine
             }
 
             return null;
+        }
+
+        public List<string> GetResourceDirs()
+        {
+            List<string> resourceDirs = new List<string>();
+
+            ResourceCache cache = AtomicNET.GetSubsystem<ResourceCache>();
+
+            for (uint i = 0; i < cache.GetNumResourceDirs(); i++)
+            {
+                resourceDirs.Add(cache.GetResourceDir(i));
+            }
+
+            return resourceDirs;
         }
 
         /// <summary>

--- a/Script/AtomicNET/AtomicNET/Resource/ResourceCache.cs
+++ b/Script/AtomicNET/AtomicNET/Resource/ResourceCache.cs
@@ -30,15 +30,18 @@ namespace AtomicEngine
             return null;
         }
 
-        public List<string> GetResourceDirs()
+        /// <summary>
+        ///  Gets all resource directories and places it within an array.
+        /// </summary>
+        public string[] GetResourceDirs()
         {
-            List<string> resourceDirs = new List<string>();
+            ResourceCache cache = GetSubsystem<ResourceCache>();
 
-            ResourceCache cache = AtomicNET.GetSubsystem<ResourceCache>();
+             string[] resourceDirs = new string[cache.GetNumResourceDirs()];
 
             for (uint i = 0; i < cache.GetNumResourceDirs(); i++)
             {
-                resourceDirs.Add(cache.GetResourceDir(i));
+                resourceDirs[i] = cache.GetResourceDir(i);
             }
 
             return resourceDirs;


### PR DESCRIPTION
Added this function since Vector of Strings isn't implemented for general bindings and thus couldn't be exposed to C# from C++.