### PR TITLE
Add access to Node vars from scripting languages

### DIFF
--- a/Source/Atomic/Scene/Node.h
+++ b/Source/Atomic/Scene/Node.h
@@ -602,6 +602,39 @@ public:
     /// Return child scene nodes by name hash, optionally recursive
     void GetChildrenWithName(PODVector<Node*>& dest, StringHash nameHash, bool recursive = false) const;
 
+    /// Scripting interface to set user data, the data type can be 
+    ///   Int, Bool, Float, Vector2, Vector3, Vector4, Quaternion
+    ///   String, Buffer, ResourceRef, ResourceRefList, IntRect,
+    ///   IntVector2, Matrix3,Matrix3x4, Matrix4, Double, Color
+    /// The data value must be programed in the appropriate string form
+    /// used by the Variant class.
+    void setUserData (const String& name, const String& vartype, const String& value) 
+    { 
+        vars_[name].FromString(vartype, value); 
+    }
+
+    /// Scripting interface to get user data as a string.
+    /// an empty string is returned if the entry name is not present.
+    String getUserData (const String& name) const {
+        if ( isUserData(name) )
+            return vars_[name]->ToString();
+        return String::EMPTY;
+    }
+
+    /// Scripting interface to check if the user data entry exists
+    /// returns true if present, returns false if it is not present.
+    bool isUserData (const String& name) const {
+        return vars_.Contains(name);
+    }
+
+    /// Scripting interface to get user data type as a string
+    /// an empty string is returned if the entry name is not present.
+    String getUserDataType (const String& name) const {
+         if ( isUserData(name) )
+            return vars_[name]->GetTypeName();
+         return String::EMPTY;
+   }
+
     // ATOMIC END
 
 protected:

--- a/Source/Atomic/Scene/Node.h
+++ b/Source/Atomic/Scene/Node.h
@@ -606,31 +606,30 @@ public:
     ///   Int, Bool, Float, Vector2, Vector3, Vector4, Quaternion
     ///   String, Buffer, ResourceRef, ResourceRefList, IntRect,
     ///   IntVector2, Matrix3,Matrix3x4, Matrix4, Double, Color
-    /// The data value must be programed in the appropriate string form
-    /// used by the Variant class.
-    void setUserData (const String& name, const String& vartype, const String& value) 
+    /// The data value must be formatted in the Variant type string format.
+    void SetVarFromString (const String& name, const String& vartype, const String& value) 
     { 
         vars_[name].FromString(vartype, value); 
     }
 
     /// Scripting interface to get user data as a string.
     /// an empty string is returned if the entry name is not present.
-    String getUserData (const String& name) const {
-        if ( isUserData(name) )
+    String GetVarAsString (const String& name) const {
+        if ( IsVar(name) )
             return vars_[name]->ToString();
         return String::EMPTY;
     }
 
     /// Scripting interface to check if the user data entry exists
     /// returns true if present, returns false if it is not present.
-    bool isUserData (const String& name) const {
+    bool IsVar (const String& name) const {
         return vars_.Contains(name);
     }
 
     /// Scripting interface to get user data type as a string
     /// an empty string is returned if the entry name is not present.
-    String getUserDataType (const String& name) const {
-         if ( isUserData(name) )
+    String GetVarType (const String& name) const {
+         if ( IsVar(name) )
             return vars_[name]->GetTypeName();
          return String::EMPTY;
    }


### PR DESCRIPTION
This PR adds access to the Node c++ class vars_ VariantMap from scripting languages.
The access is done completely by strings, but will handle a large subset of Variant types, those being  Int, Bool, Float, Vector2, Vector3, Vector4, Quaternion, String, Buffer, ResourceRef, ResourceRefList, IntRect, IntVector2, Matrix3,Matrix3x4, Matrix4, Double, Color. It is the users responsibility to convert to and from Variant type strings. The added methods are:
void setUserData (const String& name, const String& vartype, const String& value);  // set data
String getUserData (const String& name) const;  // get data
bool isUserData (const String& name) const;   // data exist?
String getUserDataType (const String& name) const;  //what kind of data is it