### PR TITLE
Expose the webView WebMessageHandler to script and fix an event signature

### DIFF
--- a/Script/Packages/WebView/WebView.json
+++ b/Script/Packages/WebView/WebView.json
@@ -2,5 +2,5 @@
 	"name" : "WebView",
 	"includes" : ["<Atomic/Graphics/DebugRenderer.h>"],
 	"sources" : ["Source/AtomicWebView"],
-	"classes" : ["WebBrowserHost", "WebClient", "WebRenderHandler", "WebTexture2D", "UIWebView"]
+	"classes" : ["WebBrowserHost", "WebClient", "WebRenderHandler", "WebTexture2D", "UIWebView", "WebMessageHandler"]
 }

--- a/Source/AtomicWebView/WebViewEvents.h
+++ b/Source/AtomicWebView/WebViewEvents.h
@@ -96,7 +96,7 @@ ATOMIC_EVENT(E_WEBMESSAGE, WebMessage)
     ATOMIC_PARAM(P_CEFBROWSER, Browser);       // CefBrowser*
     ATOMIC_PARAM(P_CEFFRAME, Frame);           // CefFrame*
 
-    ATOMIC_PARAM(P_DEFERRED, Deferred);        // Return Value: Bool
+    ATOMIC_PARAM(P_DEFERRED, Deferred);        // Bool Return Value
 }
 
 


### PR DESCRIPTION
Simple bindings update to expose the WebMessageHandler to script