### PR TITLE
Do not build AtomicPlayer when javascript support is disabled.

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -4,9 +4,9 @@ option(ATOMIC_EDITOR "Build Editor" ON)
 
 add_subdirectory(ThirdParty)
 add_subdirectory(Atomic)
-add_subdirectory(AtomicPlayer)
 
 if (ATOMIC_JAVASCRIPT)
+    add_subdirectory(AtomicPlayer)
     add_subdirectory(AtomicJS)
     add_subdirectory(AtomicPlayerJS)
 endif ()


### PR DESCRIPTION
Overlooked this one somehow. Should be all of it now as my project happily builds with engine in a subdir.