### PR TITLE
enable android source debug

### DIFF
--- a/Data/AtomicEditor/Deployment/Android/src/org/libsdl/app/SDLActivity.java
+++ b/Data/AtomicEditor/Deployment/Android/src/org/libsdl/app/SDLActivity.java
@@ -117,6 +117,12 @@ public class SDLActivity extends Activity {
                 @Override
                 public boolean accept(File dir, String filename) {
                     // Only list libraries, i.e. exclude gdbserver when it presents
+                    // ATOMIC BEGIN
+                    // Do not load any file as a library that contains the word gdbserver, ever!
+                    if ( filename.contains("gdbserver")) {
+                        return false;
+                    }
+                    // ATOMIC END
                     return filename.matches("^lib.*\\.so$");
                 }
             });

--- a/Resources/EditorData/AtomicEditor/editor/ui/buildsettings_android.tb.txt
+++ b/Resources/EditorData/AtomicEditor/editor/ui/buildsettings_android.tb.txt
@@ -57,11 +57,28 @@ TBLayout: axis: y, distribution: gravity, position: left
 				tooltip May be left blank if installed locally
 	TBLayout: axis: y, position: left, distribution: gravity
 		TBLayout: gravity: left, distribution-position: right bottom
-			TBClickLabel: text: "Release Path", skin: DarkGrayText
-				TBCheckBox: id: and_auth_check, lp: min-height: 20
-		TBLayout: gravity: left right, distribution-position: right bottom
-			TBEditField: id: auth_root, autofocus: 0
+			TBTextField: text: "APK:", skin: DarkGrayText
+			TBSelectDropdown: id: and_auth_check
+				tooltip Select type of APK to build
 				lp: min-width: 250
-				tooltip Select Release Path for a release version APK
+				items:
+					item: text: "Debug"
+					item: text: "Debug Source with gdbserver"
+					item: text: "Debug Source with libgdbserver.so"
+					item: text: "Release"
+		TBLayout: gravity: left right, distribution-position: right bottom
+			TBTextField: text: "REL:", skin: DarkGrayText
+				lp: min-width: 30
+			TBEditField: id: auth_root, autofocus: 0
+				lp: min-width: 220
+				tooltip Select path for release APK support files
 			TBButton: text: "Choose", id: choose_and_auth
-				tooltip Directory containing the ant.properties
+				tooltip Directory containing ant.properties
+		TBLayout: gravity: left right, distribution-position: right bottom
+			TBTextField: text: "NDK:", skin: DarkGrayText
+				lp: min-width: 30
+			TBEditField: id: ndk_root, autofocus: 0
+				lp: min-width: 220
+				tooltip Select NDK path, only needed for Source Debug
+			TBButton: text: "Choose", id: choose_ndk_auth
+				tooltip Directory containing Android NDK 

--- a/Script/AtomicEditor/ui/modal/build/platforms/AndroidSettingsWidget.ts
+++ b/Script/AtomicEditor/ui/modal/build/platforms/AndroidSettingsWidget.ts
@@ -47,10 +47,12 @@ class AndroidSettingsWidget extends Atomic.UIWidget implements BuildSettingsWind
 
         this.releaseChooseButton = <Atomic.UIButton>this.getWidget("choose_and_auth");
         this.releaseNameEdit = <Atomic.UIEditField>this.getWidget("auth_root");
-        this.releaseCheck = <Atomic.UICheckBox>this.getWidget("and_auth_check");
+        this.releaseCheck = <Atomic.UISelectDropdown>this.getWidget("and_auth_check");
         this.iconNameEdit = <Atomic.UIEditField>this.getWidget("icon_root");
         this.iconChooseButton = <Atomic.UIButton>this.getWidget("choose_icon");
         this.iconImage = <Atomic.UIImageWidget>this.getWidget("and_icon");
+        this.ndkChooseButton = <Atomic.UIButton>this.getWidget("choose_ndk_auth");
+        this.ndkPathEdit = <Atomic.UIEditField>this.getWidget("ndk_root");
 
         if (Atomic.platform == "Windows") {
 
@@ -123,7 +125,15 @@ class AndroidSettingsWidget extends Atomic.UIWidget implements BuildSettingsWind
                }
                 return true;
 
-           }
+            }  else if (ev.target.id == "choose_ndk_auth") {
+                var fileUtils = new Editor.FileUtils();
+                var currauth = this.ndkPathEdit.text;
+                var path = fileUtils.findPath( "Please choose the folder of your NDK", currauth );
+                if ( path.length > 0 )
+                    this.ndkPathEdit.text = path;
+                return true;
+
+            }
 
         }
 
@@ -186,6 +196,7 @@ class AndroidSettingsWidget extends Atomic.UIWidget implements BuildSettingsWind
         this.jdkRootEdit.text = toolPrefs.jDKRootPath;
         this.releaseNameEdit.text = toolPrefs.releasePath;
         this.releaseCheck.value = toolPrefs.releaseCheck;
+        this.ndkPathEdit.text = toolPrefs.ndkPath;
 
         this.appNameEdit.text = this.settings.appName;
         this.packageNameEdit.text = this.settings.packageName;
@@ -210,6 +221,7 @@ class AndroidSettingsWidget extends Atomic.UIWidget implements BuildSettingsWind
         ToolCore.toolEnvironment.toolPrefs.jDKRootPath = this.jdkRootEdit.text;
         ToolCore.toolEnvironment.toolPrefs.releasePath = this.releaseNameEdit.text;
         ToolCore.toolEnvironment.toolPrefs.releaseCheck = this.releaseCheck.value;
+        ToolCore.toolEnvironment.toolPrefs.ndkPath = this.ndkPathEdit.text;
 
         ToolCore.toolEnvironment.saveToolPrefs();
     }
@@ -230,10 +242,13 @@ class AndroidSettingsWidget extends Atomic.UIWidget implements BuildSettingsWind
 
     releaseNameEdit : Atomic.UIEditField;
     releaseChooseButton : Atomic.UIButton;
-    releaseCheck : Atomic.UICheckBox;
+    releaseCheck : Atomic.UISelectDropdown;
     iconNameEdit : Atomic.UIEditField;
     iconChooseButton : Atomic.UIButton;
     iconImage : Atomic.UIImageWidget;
+    ndkPathEdit : Atomic.UIEditField;
+    ndkChooseButton : Atomic.UIButton;
+
 }
 
 export = AndroidSettingsWidget;

--- a/Source/ToolCore/Build/AndroidProjectGenerator.h
+++ b/Source/ToolCore/Build/AndroidProjectGenerator.h
@@ -57,6 +57,7 @@ private:
     bool GenerateProjectProperties();
     bool GenerateActivitySource();
     bool CopyUserIcons( );
+    bool CopyDebugGdbserver();
 
     WeakPtr<BuildBase> buildBase_;
     String buildPath_;

--- a/Source/ToolCore/Build/BuildAndroid.cpp
+++ b/Source/ToolCore/Build/BuildAndroid.cpp
@@ -122,10 +122,10 @@ void BuildAndroid::RunADBInstall()
 
     Vector<String> args;
 
-    if ( prefs->GetReleaseCheck() > 0 ) // install release apk
+    if ( prefs->GetReleaseCheck() > 2 ) // install release apk
         args = String("install -r ./bin/Atomic-release.apk").Split(' ');
     else
-        args = String("install -r ./bin/Atomic-debug-unaligned.apk").Split(' ');
+        args = String("install -r ./bin/Atomic-debug.apk").Split(' ');
 
     currentBuildPhase_ = ADBInstall;
     Subprocess* subprocess = subs->Launch(adbCommand, args, buildPath_);
@@ -253,7 +253,7 @@ void BuildAndroid::RunAntDebug()
 
     String buildApk = "debug";  // the default
 
-    if ( tprefs->GetReleaseCheck() > 0 ) // create release apk
+    if ( tprefs->GetReleaseCheck() > 2 ) // create release apk
         buildApk = "release";
 
 

--- a/Source/ToolCore/ToolPrefs.cpp
+++ b/Source/ToolCore/ToolPrefs.cpp
@@ -36,7 +36,8 @@ ToolPrefs::ToolPrefs(Context* context) : Object(context),
     jdkRootPath_(),
     antPath_(),
     releasePath_(),
-    releaseCheck_(false)
+    releaseCheck_(0),
+    ndkPath_()
 {
 
 }
@@ -101,6 +102,7 @@ void ToolPrefs::Load()
         antPath_ = androidRoot.Get("antPath").GetString();
         releasePath_ = androidRoot.Get("releasePath").GetString();
         releaseCheck_ = androidRoot.Get("releaseCheck").GetInt();
+        ndkPath_ = androidRoot.Get("ndkPath").GetString();
     }
 
 }
@@ -119,7 +121,8 @@ void ToolPrefs::Save()
     androidRoot["antPath"] = antPath_;
     androidRoot["releasePath"] = releasePath_;
     androidRoot["releaseCheck"] = releaseCheck_;
-   root["android"] = androidRoot;
+    androidRoot["ndkPath"] = ndkPath_;
+    root["android"] = androidRoot;
 
     SharedPtr<File> file(new File(context_, path, FILE_WRITE));
     jsonFile->Save(*file, "   ");

--- a/Source/ToolCore/ToolPrefs.h
+++ b/Source/ToolCore/ToolPrefs.h
@@ -43,12 +43,14 @@ public:
     const String& GetAntPath();
     const String& GetReleasePath() { return releasePath_; }
     const int GetReleaseCheck() { return releaseCheck_; }
+    const String& GetNdkPath() { return ndkPath_; }
 
     void SetAndroidSDKPath(const String& path) { androidSDKPath_ = path; }
     void SetJDKRootPath(const String& path) { jdkRootPath_ = path; }
     void SetAntPath(const String& path) { antPath_ = path; }
     void SetReleasePath(const String& path) { releasePath_ = path; }
     void SetReleaseCheck(const int value) { releaseCheck_ = value; }
+    void SetNdkPath(const String& path) { ndkPath_ = path; }
 
     String GetPrefsPath();
     void Load();
@@ -61,6 +63,7 @@ private:
     String antPath_;
     String releasePath_;
     int releaseCheck_;
+    String ndkPath_;
 };
 
 }


### PR DESCRIPTION
This PR will allow users to insert gdbserver or libgdbserver.so into their APK so it may be debugged with GDB on an external host. Some versions of Android can not copy an executable into the lib directory of an APK, so the work around is to rename it lib*.so, and then execute it anyway, so both options are given.
I fixed the android player to not load anything that has the string "gdbserver" as a shared library, as this borks the resulting application.
And I fixed the push action to the android device to install Atomic-debug.apk instead of Atomic-debug-unaligned.apk, which is an intermediate file.
The Android wiki page needs to be updated to explain the new options.