### PR TITLE
Add UISelectList accessors to get list strings

### DIFF
--- a/Source/Atomic/UI/UISelectList.cpp
+++ b/Source/Atomic/UI/UISelectList.cpp
@@ -123,6 +123,23 @@ String UISelectList::GetSelectedItemID()
     return id_;
 }
 
+/// Returns the string of the selected item from the list widget
+const String& UISelectList::GetSelectedItemString()
+{
+    int selected = ((TBSelectList*)widget_)->GetValue();
+    TBSelectItemSource *tbsource = (TBSelectItemSource*)((TBSelectList*)widget_)->GetSource();
+    if ( tbsource && selected >= 0 && selected < tbsource->GetNumItems() )
+    {
+        const char *strx = tbsource->GetItemString(selected);
+        if (strx )
+        {
+            static String uiSelectListItemStr = strx;
+            return (uiSelectListItemStr);
+        }
+    }
+    return String::EMPTY;
+}
+
 bool UISelectList::GetItemSelected(int index)
 {
     if (!widget_)
@@ -144,6 +161,22 @@ String UISelectList::GetItemID(int index)
 
     return _id;
 
+}
+
+/// Returns the string of item at the requested index from the list widget
+const String& UISelectList::GetItemString(int index)
+{
+    TBSelectItemSource *tbsource = (TBSelectItemSource*)((TBSelectList*)widget_)->GetSource();
+    if ( tbsource && index >= 0 && index < tbsource->GetNumItems() )
+    {
+        const char *strx = tbsource->GetItemString(index);
+        if (strx != NULL)
+        {
+            static String uiSelectListItemStr = strx;
+            return (uiSelectListItemStr);
+        }
+    }
+    return String::EMPTY;
 }
 
 String UISelectList::GetHoverItemID()

--- a/Source/Atomic/UI/UISelectList.cpp
+++ b/Source/Atomic/UI/UISelectList.cpp
@@ -35,7 +35,7 @@ using namespace tb;
 namespace Atomic
 {
 
-UISelectList::UISelectList(Context* context, bool createWidget) : UIWidget(context, false), transferStr()
+UISelectList::UISelectList(Context* context, bool createWidget) : UIWidget(context, false)
 {
     if (createWidget)
     {
@@ -124,7 +124,7 @@ String UISelectList::GetSelectedItemID()
 }
 
 /// Returns the string of the selected item from the list widget
-const String& UISelectList::GetSelectedItemString()
+String UISelectList::GetSelectedItemString()
 {
     int selected = ((TBSelectList*)widget_)->GetValue();
     TBSelectItemSource *tbsource = (TBSelectItemSource*)((TBSelectList*)widget_)->GetSource();
@@ -132,10 +132,7 @@ const String& UISelectList::GetSelectedItemString()
     {
         const char *strx = tbsource->GetItemString(selected);
         if (strx )
-        {
-            transferStr = (String)strx;
-            return (transferStr);
-        }
+            return ( tbsource->GetItemString(selected) );
     }
     return String::EMPTY;
 }
@@ -164,17 +161,14 @@ String UISelectList::GetItemID(int index)
 }
 
 /// Returns the string of item at the requested index from the list widget
-const String& UISelectList::GetItemString(int index)
+String UISelectList::GetItemString(int index)
 {
     TBSelectItemSource *tbsource = (TBSelectItemSource*)((TBSelectList*)widget_)->GetSource();
     if ( tbsource && index >= 0 && index < tbsource->GetNumItems() )
     {
         const char *strx = tbsource->GetItemString(index);
         if (strx != NULL)
-        {
-            transferStr = (String)strx;
-            return (transferStr);
-        }
+            return ( tbsource->GetItemString(index) );
     }
     return String::EMPTY;
 }

--- a/Source/Atomic/UI/UISelectList.cpp
+++ b/Source/Atomic/UI/UISelectList.cpp
@@ -35,7 +35,7 @@ using namespace tb;
 namespace Atomic
 {
 
-UISelectList::UISelectList(Context* context, bool createWidget) : UIWidget(context, false)
+UISelectList::UISelectList(Context* context, bool createWidget) : UIWidget(context, false), transferStr()
 {
     if (createWidget)
     {
@@ -133,8 +133,8 @@ const String& UISelectList::GetSelectedItemString()
         const char *strx = tbsource->GetItemString(selected);
         if (strx )
         {
-            static String uiSelectListItemStr = strx;
-            return (uiSelectListItemStr);
+            transferStr = (String)strx;
+            return (transferStr);
         }
     }
     return String::EMPTY;
@@ -172,8 +172,8 @@ const String& UISelectList::GetItemString(int index)
         const char *strx = tbsource->GetItemString(index);
         if (strx != NULL)
         {
-            static String uiSelectListItemStr = strx;
-            return (uiSelectListItemStr);
+            transferStr = (String)strx;
+            return (transferStr);
         }
     }
     return String::EMPTY;

--- a/Source/Atomic/UI/UISelectList.h
+++ b/Source/Atomic/UI/UISelectList.h
@@ -83,6 +83,8 @@ protected:
 
 private:
 
+    String transferStr;
+
 };
 
 

--- a/Source/Atomic/UI/UISelectList.h
+++ b/Source/Atomic/UI/UISelectList.h
@@ -71,9 +71,9 @@ public:
     void SetUIListView(bool value);
 
     /// Returns the string of item at the requested index
-    const String& GetItemString(int index);
+    String GetItemString(int index);
     /// Returns the string of the selected item
-    const String& GetSelectedItemString();
+    String GetSelectedItemString();
 
 protected:
 
@@ -82,8 +82,6 @@ protected:
     virtual bool OnEvent(const tb::TBWidgetEvent &ev);
 
 private:
-
-    String transferStr;
 
 };
 

--- a/Source/Atomic/UI/UISelectList.h
+++ b/Source/Atomic/UI/UISelectList.h
@@ -70,6 +70,11 @@ public:
 
     void SetUIListView(bool value);
 
+    /// Returns the string of item at the requested index
+    const String& GetItemString(int index);
+    /// Returns the string of the selected item
+    const String& GetSelectedItemString();
+
 protected:
 
     void HandleUIUpdate(StringHash eventType, VariantMap& eventData);


### PR DESCRIPTION
This PR makes the UISelectList a little more useful. There is a lot of data hiding going on between the UISelectList and the UISelectItemSource, as far as I can tell you can only program a UISelectList with a UISelectItemSource. Once the UISelectItemSource is created and then leave the scope, you cant get the UISelectItemSource back out of the UISelectList. But, there is an internal TBSelectItemSource that the UISelectList uses to do the drawing and stuff, and I can find that, and return the strings that you can _clearly_ see... 
The added methods are :
``const String& UISelectList::GetItemString(int index);``
and
``const String& UISelectList::GetSelectedItemString();``
and they pass thru the script bindings without issue. Example code snippet :
```
if ( ev.target.id == "myselectlist") {
   var selectlist = <Atomic.UISelectList>this.mahWindow.getWidget(ev.target.id);
   var selected = selectlist.getValue();
   Atomic.print ( "Atomic.UISelectList selected item = " + selected );
   Atomic.print ( "Atomic.UISelectList selected string = " + selectlist.getSelectedItemString());
   Atomic.print ( "or Atomic.UISelectList selected string = " + selectlist.getItemString(selected));
   }
```