### PR TITLE
Check for `/usr/bin/mono/` directory 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -53,6 +53,8 @@
 
 - Manuel Freiberger (https://github.com/ombre5733)
 
+- John Shearer (https://github.com/shearer12345)
+
 ### Contribution Copyright and Licensing
 
 Atomic Game Engine contribution copyrights are held by their authors.  Each author retains the copyright to their contribution and agrees to irrevocably license the contribution under the Atomic Game Engine Contribution License `CONTRIBUTION_LICENSE.md`.  Please see `CONTRIBUTING.md` for more details.

--- a/Build/Scripts/BuildConfig.js
+++ b/Build/Scripts/BuildConfig.js
@@ -16,6 +16,18 @@ function programFileExists(filePath)
     }
 }
 
+// checks to see if a folder exists
+function programDirectoryExists(filePath)
+{
+    try
+    {
+        return fs.statSync(filePath).isDirectory();
+    }
+    catch (err)
+    {
+        return false;
+    }
+}
 
 function processOptions(config) {
 
@@ -33,7 +45,7 @@ function processOptions(config) {
             if ( spawnSync)
                 config["with-atomicnet"] = spawnSync("which", ["xbuild"]).status == 1 ? false : true;
         } else if (os.platform() == "linux") {  // see if xbuild is available on linux
-            config["with-atomicnet"] = programFileExists('/usr/bin/xbuild');
+            config["with-atomicnet"] = programFileExists('/usr/bin/xbuild') && programDirectoryExists('/usr/bin/mono/');
         }
 	}
 


### PR DESCRIPTION
Adds a check for the `/usr/bin/mono/` directory before automatically setting `with-atomicnet=true` - so doesn't build with C# when it shouldn't.

Added a `programDirectoryExists` function for the check

Closes #1544 

Tested on Ubuntu 17.04 - though should be consist on most distros. Mono seems pretty consistently installed to `/usr/bin/mono`