### PR TITLE
Minor fixes for TMX files

### DIFF
--- a/Source/Atomic/Atomic2D/TmxFile2D.cpp
+++ b/Source/Atomic/Atomic2D/TmxFile2D.cpp
@@ -388,7 +388,10 @@ bool TmxFile2D::BeginLoad(Deserializer& source)
                     return false;
 
                 // ATOMIC BEGIN
-                if (tsxXMLFile->GetRoot("tileset").GetChild("tile"))
+
+                // Look for an image indicating that this is a spritesheet with multiple tiles instead
+                // of a series of individual images which are not supported
+                if (!tsxXMLFile->GetRoot("tileset").GetChild("image"))
                 {
                     ATOMIC_LOGERROR("Load TSX File failed: " + source + ". tsx files with individual images are not supported.");
                     return false;
@@ -586,7 +589,9 @@ bool TmxFile2D::LoadTileSet(const XMLElement& element)
                 return false;
 
             // ATOMIC BEGIN
-            if (tsxXMLFile->GetRoot("tileset").GetChild("tile"))
+            // Look for an image indicating that this is a spritesheet with multiple tiles instead
+            // of a series of individual images which are not supported
+            if (!tsxXMLFile->GetRoot("tileset").GetChild("image"))
             {
                 ATOMIC_LOGERROR("Load TSX File failed: " + source + ". tsx files with individual images are not supported.");
                 return false;

--- a/Source/Atomic/Atomic2D/TmxFile2D.cpp
+++ b/Source/Atomic/Atomic2D/TmxFile2D.cpp
@@ -387,8 +387,16 @@ bool TmxFile2D::BeginLoad(Deserializer& source)
                 if (!tsxXMLFile)
                     return false;
 
-                tsxXMLFiles_[source] = tsxXMLFile;
+                // ATOMIC BEGIN
+                if (tsxXMLFile->GetRoot("tileset").GetChild("tile"))
+                {
+                    ATOMIC_LOGERROR("Load TSX File failed: " + source + ". tsx files with individual images are not supported.");
+                    return false;
+                }
+                // ATOMIC END
 
+                tsxXMLFiles_[source] = tsxXMLFile;
+                
                 String textureFilePath =
                     GetParentPath(GetName()) + tsxXMLFile->GetRoot("tileset").GetChild("image").GetAttribute("source");
                 GetSubsystem<ResourceCache>()->BackgroundLoadResource<Texture2D>(textureFilePath, true, this);
@@ -418,7 +426,9 @@ bool TmxFile2D::EndLoad()
 
     XMLElement rootElem = loadXMLFile_->GetRoot("map");
     String version = rootElem.GetAttribute("version");
-    if (version != "1.0")
+    // ATOMIC BEGIN
+    if (version != "1.0" && version != "1.0.0")
+    // ATOMIC END
     {
         ATOMIC_LOGERROR("Invalid version");
         return false;
@@ -574,6 +584,14 @@ bool TmxFile2D::LoadTileSet(const XMLElement& element)
             SharedPtr<XMLFile> tsxXMLFile = LoadTSXFile(source);
             if (!tsxXMLFile)
                 return false;
+
+            // ATOMIC BEGIN
+            if (tsxXMLFile->GetRoot("tileset").GetChild("tile"))
+            {
+                ATOMIC_LOGERROR("Load TSX File failed: " + source + ". tsx files with individual images are not supported.");
+                return false;
+            }
+            // ATOMIC END
 
             // Add to napping to avoid release
             tsxXMLFiles_[source] = tsxXMLFile;

--- a/Source/Atomic/Atomic2D/TmxFile2D.h
+++ b/Source/Atomic/Atomic2D/TmxFile2D.h
@@ -171,7 +171,12 @@ class ATOMIC_API TmxFile2D : public Resource
     ATOMIC_OBJECT(TmxFile2D, Resource);
 
 public:
-    /// Construct.
+    /** Construct.
+      * This will load a Tiled .tmx file for use.  Not all
+      * Tile options are supported.  Some important limitions are:
+      * - The Tile Layer Format must be XML
+      * - The tilesets used in the map must be made from sprite sheets. Individual images are not supported
+     */
     TmxFile2D(Context* context);
     /// Destruct.
     virtual ~TmxFile2D();


### PR DESCRIPTION
This PR includes a couple quick fixes
- Latest version of Tiled has a version id of `1.0.0` instead of `1.0` so this recognizes both
- Tiled supports the ability to use individual images in a tileset instead of a spritesheet.  The version of the TMXFile in Urho and Atomic doesn't support this, but also doesn't indicate why loading a tmx with these fails.  This checks for that situation and writes out the appropriate error.

Note: I'll add a new issue to see if it will be possible for the TmxFile loader to support these types of tilesets in the future.