### PR TITLE
Modern and legacy Linux mono detection for #1544

### DIFF
--- a/Build/Scripts/BuildConfig.js
+++ b/Build/Scripts/BuildConfig.js
@@ -45,7 +45,10 @@ function processOptions(config) {
             if ( spawnSync)
                 config["with-atomicnet"] = spawnSync("which", ["xbuild"]).status == 1 ? false : true;
         } else if (os.platform() == "linux") {  // see if xbuild is available on linux
-            config["with-atomicnet"] = programFileExists('/usr/bin/xbuild') && programDirectoryExists('/usr/bin/mono/');
+            var hasXbuild = programFileExists('/usr/bin/xbuild');
+            var hasMonoFile = programFileExists('/usr/bin/mono');
+            var hasMonoDir = programDirectoryExists('/usr/bin/mono/');
+            config["with-atomicnet"] = hasXbuild && ( hasMonoFile || hasMonoDir );
         }
 	}
 


### PR DESCRIPTION
This should be sufficient rule to detect the existence of mono on (nearly) any type of linux system. 