### PR TITLE
Common subsystem pointers in Context

### DIFF
--- a/Script/Packages/Atomic/Core.json
+++ b/Script/Packages/Atomic/Core.json
@@ -1,6 +1,17 @@
 {
 	"name" : "Core",
 	"sources" : ["Source/Atomic/Core", "Source/Atomic/BuildInfo"],
+	"includes": [
+		"<Atomic/Engine/Engine.h>",
+		"<Atomic/Network/Network.h>",
+		"<Atomic/Web/Web.h>",
+		"<Atomic/Input/Input.h>",
+		"<Atomic/Audio/Audio.h>",
+		"<Atomic/UI/UI.h>",
+		"<Atomic/Graphics/Graphics.h>",
+		"<Atomic/Graphics/Renderer.h>",
+		"<Atomic/Metrics/Metrics.h>"
+	],
 	"classes" : ["Context", "Object", "AtomicBuildInfo", "Time"],
 	"classes_rename" : {
 		"Object" : "AObject"

--- a/Source/Atomic/Core/Context.h
+++ b/Source/Atomic/Core/Context.h
@@ -228,26 +228,26 @@ public:
     void AddGlobalEventListener(GlobalEventListener* listener) { globalEventListeners_.Push(listener); }
     void RemoveGlobalEventListener(GlobalEventListener* listener) { globalEventListeners_.Erase(globalEventListeners_.Find(listener)); }
 
-    WeakPtr<Engine> engine_;
-    WeakPtr<Time> time_;
-    WeakPtr<WorkQueue> workQueue_;
-    WeakPtr<Profiler> profiler_;
-    WeakPtr<FileSystem> fileSystem_;
-    WeakPtr<Log> log_;
-    WeakPtr<ResourceCache> cache_;
-    WeakPtr<Localization> l18n_;
-    WeakPtr<Network> network_;
-    WeakPtr<Web> web_;
-    WeakPtr<Database> db_;
-    WeakPtr<Input> input_;
-    WeakPtr<Audio> audio_;
-    WeakPtr<UI> ui_;
-    WeakPtr<SystemUI> systemUi_;
-    WeakPtr<Graphics> graphics_;
-    WeakPtr<Renderer> renderer_;
-    WeakPtr<Console> console_;
-    WeakPtr<DebugHud> debugHud_;
-    WeakPtr<Metrics> metrics_;
+    Engine* GetEngine() const { return engine_; }
+    Time* GetTime() const { return time_; }
+    WorkQueue* GetWorkQueue() const { return workQueue_; }
+    Profiler* GetProfiler() const { return profiler_; }
+    FileSystem* GetFileSystem() const { return fileSystem_; }
+    Log* GetLog() const { return log_; }
+    ResourceCache* GetResourceCache() const { return cache_; }
+    Localization* GetLocalization() const { return l18n_; }
+    Network* GetNetwork() const { return network_; }
+    Web* GetWeb() const { return web_; }
+    Database* GetDatabase() const { return db_; }
+    Input* GetInput() const { return input_; }
+    Audio* GetAudio() const { return audio_; }
+    UI* GetUI() const { return ui_; }
+    SystemUI* GetSystemUI() const { return systemUi_; }
+    Graphics* GetGraphics() const { return graphics_; }
+    Renderer* GetRenderer() const { return renderer_; }
+    Console* GetConsole() const { return console_; }
+    DebugHud* GetDebugHud() const { return debugHud_; }
+    Metrics* GetMetrics() const { return metrics_; }
 
     // ATOMIC END
 
@@ -311,6 +311,30 @@ private:
 
     PODVector<GlobalEventListener*> globalEventListeners_;
     bool editorContext_;
+
+    WeakPtr<Engine> engine_;
+    WeakPtr<Time> time_;
+    WeakPtr<WorkQueue> workQueue_;
+    WeakPtr<Profiler> profiler_;
+    WeakPtr<FileSystem> fileSystem_;
+    WeakPtr<Log> log_;
+    WeakPtr<ResourceCache> cache_;
+    WeakPtr<Localization> l18n_;
+    WeakPtr<Network> network_;
+    WeakPtr<Web> web_;
+    WeakPtr<Database> db_;
+    WeakPtr<Input> input_;
+    WeakPtr<Audio> audio_;
+    WeakPtr<UI> ui_;
+    WeakPtr<SystemUI> systemUi_;
+    WeakPtr<Graphics> graphics_;
+    WeakPtr<Renderer> renderer_;
+    WeakPtr<Console> console_;
+    WeakPtr<DebugHud> debugHud_;
+    WeakPtr<Metrics> metrics_;
+
+    friend class Engine;
+
     // ATOMIC END
 
 };

--- a/Source/Atomic/Core/Context.h
+++ b/Source/Atomic/Core/Context.h
@@ -38,6 +38,27 @@ public:
     virtual void EndSendEvent(Context* context, Object* sender, StringHash eventType, VariantMap& eventData) = 0;
 };
 
+class Metrics;
+class Engine;
+class Time;
+class WorkQueue;
+class Profiler;
+class FileSystem;
+class Log;
+class ResourceCache;
+class Localization;
+class Network;
+class Web;
+class Database;
+class Input;
+class Audio;
+class UI;
+class SystemUI;
+class Graphics;
+class Renderer;
+class Console;
+class DebugHud;
+
 // ATOMIC END
 
 /// Tracking structure for event receivers.
@@ -227,6 +248,27 @@ public:
     // hook for listening into events
     void AddGlobalEventListener(GlobalEventListener* listener) { globalEventListeners_.Push(listener); }
     void RemoveGlobalEventListener(GlobalEventListener* listener) { globalEventListeners_.Erase(globalEventListeners_.Find(listener)); }
+
+    WeakPtr<Engine> engine_;
+    WeakPtr<Time> time_;
+    WeakPtr<WorkQueue> workQueue_;
+    WeakPtr<Profiler> profiler_;
+    WeakPtr<FileSystem> fileSystem_;
+    WeakPtr<Log> log_;
+    WeakPtr<ResourceCache> cache_;
+    WeakPtr<Localization> l18n_;
+    WeakPtr<Network> network_;
+    WeakPtr<Web> web_;
+    WeakPtr<Database> db_;
+    WeakPtr<Input> input_;
+    WeakPtr<Audio> audio_;
+    WeakPtr<UI> ui_;
+    WeakPtr<SystemUI> systemUi_;
+    WeakPtr<Graphics> graphics_;
+    WeakPtr<Renderer> renderer_;
+    WeakPtr<Console> console_;
+    WeakPtr<DebugHud> debugHud_;
+    WeakPtr<Metrics> metrics_;
 
     // ATOMIC END
 

--- a/Source/Atomic/Core/Context.h
+++ b/Source/Atomic/Core/Context.h
@@ -38,27 +38,6 @@ public:
     virtual void EndSendEvent(Context* context, Object* sender, StringHash eventType, VariantMap& eventData) = 0;
 };
 
-class Metrics;
-class Engine;
-class Time;
-class WorkQueue;
-class Profiler;
-class FileSystem;
-class Log;
-class ResourceCache;
-class Localization;
-class Network;
-class Web;
-class Database;
-class Input;
-class Audio;
-class UI;
-class SystemUI;
-class Graphics;
-class Renderer;
-class Console;
-class DebugHud;
-
 // ATOMIC END
 
 /// Tracking structure for event receivers.

--- a/Source/Atomic/Core/Object.cpp
+++ b/Source/Atomic/Core/Object.cpp
@@ -592,6 +592,106 @@ void Object::UnsubscribeFromEventReceiver(Object* receiver)
 
 }
 
+template <> Engine* Object::GetSubsystem<Engine>() const
+{
+    return context_->engine_;
+}
+
+template <> Time* Object::GetSubsystem<Time>() const
+{
+    return context_->time_;
+}
+
+template <> WorkQueue* Object::GetSubsystem<WorkQueue>() const
+{
+    return context_->workQueue_;
+}
+
+template <> Profiler* Object::GetSubsystem<Profiler>() const
+{
+    return context_->profiler_;
+}
+
+template <> FileSystem* Object::GetSubsystem<FileSystem>() const
+{
+    return context_->fileSystem_;
+}
+
+template <> Log* Object::GetSubsystem<Log>() const
+{
+    return context_->log_;
+}
+
+template <> ResourceCache* Object::GetSubsystem<ResourceCache>() const
+{
+    return context_->cache_;
+}
+
+template <> Localization* Object::GetSubsystem<Localization>() const
+{
+    return context_->l18n_;
+}
+
+template <> Network* Object::GetSubsystem<Network>() const
+{
+    return context_->network_;
+}
+
+template <> Web* Object::GetSubsystem<Web>() const
+{
+    return context_->web_;
+}
+
+template <> Database* Object::GetSubsystem<Database>() const
+{
+    return context_->db_;
+}
+
+template <> Input* Object::GetSubsystem<Input>() const
+{
+    return context_->input_;
+}
+
+template <> Audio* Object::GetSubsystem<Audio>() const
+{
+    return context_->audio_;
+}
+
+template <> UI* Object::GetSubsystem<UI>() const
+{
+    return context_->ui_;
+}
+
+template <> SystemUI* Object::GetSubsystem<SystemUI>() const
+{
+    return context_->systemUi_;
+}
+
+template <> Graphics* Object::GetSubsystem<Graphics>() const
+{
+    return context_->graphics_;
+}
+
+template <> Renderer* Object::GetSubsystem<Renderer>() const
+{
+    return context_->renderer_;
+}
+
+template <> Console* Object::GetSubsystem<Console>() const
+{
+    return context_->console_;
+}
+
+template <> DebugHud* Object::GetSubsystem<DebugHud>() const
+{
+    return context_->debugHud_;
+}
+
+template <> Metrics* Object::GetSubsystem<Metrics>() const
+{
+    return context_->metrics_;
+}
+
 // ATOMIC END
 
 }

--- a/Source/Atomic/Core/Object.h
+++ b/Source/Atomic/Core/Object.h
@@ -39,6 +39,29 @@ namespace Atomic
 class Context;
 class EventHandler;
 
+// ATOMIC BEGIN
+class Engine;
+class Time;
+class WorkQueue;
+class Profiler;
+class FileSystem;
+class Log;
+class ResourceCache;
+class Localization;
+class Network;
+class Web;
+class Database;
+class Input;
+class Audio;
+class UI;
+class SystemUI;
+class Graphics;
+class Renderer;
+class Console;
+class DebugHud;
+class Metrics;
+// ATOMIC END
+
 /// Type info.
 class ATOMIC_API TypeInfo
 {
@@ -408,5 +431,31 @@ struct ATOMIC_API EventNameRegistrar
 #define ATOMIC_HANDLER(className, function) (new Atomic::EventHandlerImpl<className>(this, &className::function))
 /// Convenience macro to construct an EventHandler that points to a receiver object and its member function, and also defines a userdata pointer.
 #define ATOMIC_HANDLER_USERDATA(className, function, userData) (new Atomic::EventHandlerImpl<className>(this, &className::function, userData))
+
+
+// ATOMIC BEGIN
+// Explicit template specializations for most commonly used engine subsystems. They sidestep HashMap lookup and return
+// subsystem pointer cached in Context object.
+template <> Engine* Object::GetSubsystem<Engine>() const;
+template <> Time* Object::GetSubsystem<Time>() const;
+template <> WorkQueue* Object::GetSubsystem<WorkQueue>() const;
+template <> Profiler* Object::GetSubsystem<Profiler>() const;
+template <> FileSystem* Object::GetSubsystem<FileSystem>() const;
+template <> Log* Object::GetSubsystem<Log>() const;
+template <> ResourceCache* Object::GetSubsystem<ResourceCache>() const;
+template <> Localization* Object::GetSubsystem<Localization>() const;
+template <> Network* Object::GetSubsystem<Network>() const;
+template <> Web* Object::GetSubsystem<Web>() const;
+template <> Database* Object::GetSubsystem<Database>() const;
+template <> Input* Object::GetSubsystem<Input>() const;
+template <> Audio* Object::GetSubsystem<Audio>() const;
+template <> UI* Object::GetSubsystem<UI>() const;
+template <> SystemUI* Object::GetSubsystem<SystemUI>() const;
+template <> Graphics* Object::GetSubsystem<Graphics>() const;
+template <> Renderer* Object::GetSubsystem<Renderer>() const;
+template <> Console* Object::GetSubsystem<Console>() const;
+template <> DebugHud* Object::GetSubsystem<DebugHud>() const;
+template <> Metrics* Object::GetSubsystem<Metrics>() const;
+// ATOMIC END
 
 }

--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -184,6 +184,31 @@ Engine::Engine(Context* context) :
     // ATOMIC BEGIN        
     SubscribeToEvent(E_PAUSERESUMEREQUESTED, ATOMIC_HANDLER(Engine, HandlePauseResumeRequested));
     SubscribeToEvent(E_PAUSESTEPREQUESTED, ATOMIC_HANDLER(Engine, HandlePauseStepRequested));
+
+    context_->engine_ = context_->GetSubsystem<Engine>();
+    context_->time_ = context_->GetSubsystem<Time>();
+    context_->workQueue_ = context_->GetSubsystem<WorkQueue>();
+#ifdef ATOMIC_PROFILING
+    context_->profiler_ = context_->GetSubsystem<Profiler>();
+#endif
+    context_->fileSystem_ = context_->GetSubsystem<FileSystem>();
+#ifdef ATOMIC_LOGGING
+    context_->log_ = context_->GetSubsystem<Log>();
+#endif
+    context_->cache_ = context_->GetSubsystem<ResourceCache>();
+    context_->l18n_ = context_->GetSubsystem<Localization>();
+#ifdef ATOMIC_NETWORK
+    context_->network_ = context_->GetSubsystem<Network>();
+#endif
+#ifdef ATOMIC_WEB
+    context_->web_ = context_->GetSubsystem<Web>();
+#endif
+#ifdef ATOMIC_DATABASE
+    context_->db_ = context_->GetSubsystem<Database>();
+#endif
+    context_->input_ = context_->GetSubsystem<Input>();
+    context_->audio_ = context_->GetSubsystem<Audio>();
+    context_->ui_ = context_->GetSubsystem<UI>();
     // ATOMIC END
 }
 
@@ -206,6 +231,10 @@ bool Engine::Initialize(const VariantMap& parameters)
     {
         context_->RegisterSubsystem(new Graphics(context_));
         context_->RegisterSubsystem(new Renderer(context_));
+        // ATOMIC BEGIN
+        context_->graphics_ = context_->GetSubsystem<Graphics>();
+        context_->renderer_ = context_->GetSubsystem<Renderer>();
+        // ATOMIC END
     }
     else
     {
@@ -349,30 +378,14 @@ bool Engine::Initialize(const VariantMap& parameters)
 #endif
 
     // ATOMIC BEGIN
-    context_->RegisterSubsystem(new SystemUI(context_));
-
-    context_->engine_ = GetSubsystem<Engine>();
-    context_->time_ = GetSubsystem<Time>();
-    context_->workQueue_ = GetSubsystem<WorkQueue>();
-    context_->profiler_ = GetSubsystem<Profiler>();
-    context_->fileSystem_ = GetSubsystem<FileSystem>();
-    context_->log_ = GetSubsystem<Log>();
-    context_->cache_ = GetSubsystem<ResourceCache>();
-    context_->l18n_ = GetSubsystem<Localization>();
-    context_->network_ = GetSubsystem<Network>();
-    context_->web_ = GetSubsystem<Web>();
-#ifdef ATOMIC_DATABASE
-    context_->db_ = GetSubsystem<Database>();
-#endif
-    context_->input_ = GetSubsystem<Input>();
-    context_->audio_ = GetSubsystem<Audio>();
-    context_->ui_ = GetSubsystem<UI>();
-    context_->systemUi_ = GetSubsystem<SystemUI>();
-    context_->graphics_ = GetSubsystem<Graphics>();
-    context_->renderer_ = GetSubsystem<Renderer>();
-    context_->console_ = GetSubsystem<Console>();
-    context_->debugHud_ = GetSubsystem<DebugHud>();
-    context_->metrics_ = GetSubsystem<Metrics>();
+    if (!headless_)
+    {
+        context_->RegisterSubsystem(new SystemUI(context_));
+        context_->systemUi_ = context_->GetSubsystem<SystemUI>();
+        context_->console_ = context_->GetSubsystem<Console>();
+        context_->debugHud_ = context_->GetSubsystem<DebugHud>();
+    }
+    context_->metrics_ = context_->GetSubsystem<Metrics>();
     // ATOMIC END
 
     frameTimer_.Reset();

--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -43,6 +43,8 @@
 // ATOMIC BEGIN
 #include "../Resource/XMLFile.h"
 #include "../UI/SystemUI/SystemUI.h"
+#include "../UI/SystemUI/Console.h"
+#include "../UI/SystemUI/DebugHud.h"
 // ATOMIC END
 
 #ifdef ATOMIC_NAVIGATION
@@ -348,6 +350,29 @@ bool Engine::Initialize(const VariantMap& parameters)
 
     // ATOMIC BEGIN
     context_->RegisterSubsystem(new SystemUI(context_));
+
+    context_->engine_ = GetSubsystem<Engine>();
+    context_->time_ = GetSubsystem<Time>();
+    context_->workQueue_ = GetSubsystem<WorkQueue>();
+    context_->profiler_ = GetSubsystem<Profiler>();
+    context_->fileSystem_ = GetSubsystem<FileSystem>();
+    context_->log_ = GetSubsystem<Log>();
+    context_->cache_ = GetSubsystem<ResourceCache>();
+    context_->l18n_ = GetSubsystem<Localization>();
+    context_->network_ = GetSubsystem<Network>();
+    context_->web_ = GetSubsystem<Web>();
+#ifdef ATOMIC_DATABASE
+    context_->db_ = GetSubsystem<Database>();
+#endif
+    context_->input_ = GetSubsystem<Input>();
+    context_->audio_ = GetSubsystem<Audio>();
+    context_->ui_ = GetSubsystem<UI>();
+    context_->systemUi_ = GetSubsystem<SystemUI>();
+    context_->graphics_ = GetSubsystem<Graphics>();
+    context_->renderer_ = GetSubsystem<Renderer>();
+    context_->console_ = GetSubsystem<Console>();
+    context_->debugHud_ = GetSubsystem<DebugHud>();
+    context_->metrics_ = GetSubsystem<Metrics>();
     // ATOMIC END
 
     frameTimer_.Reset();

--- a/Source/Atomic/Engine/Engine.cpp
+++ b/Source/Atomic/Engine/Engine.cpp
@@ -42,6 +42,7 @@
 
 // ATOMIC BEGIN
 #include "../Resource/XMLFile.h"
+#include "../UI/SystemUI/SystemUI.h"
 // ATOMIC END
 
 #ifdef ATOMIC_NAVIGATION
@@ -344,6 +345,11 @@ bool Engine::Initialize(const VariantMap& parameters)
         EventProfiler::SetActive(true);
     }
 #endif
+
+    // ATOMIC BEGIN
+    context_->RegisterSubsystem(new SystemUI(context_));
+    // ATOMIC END
+
     frameTimer_.Reset();
 
     ATOMIC_LOGINFO("Initialized engine");

--- a/Source/Atomic/UI/SystemUI/SystemUI.cpp
+++ b/Source/Atomic/UI/SystemUI/SystemUI.cpp
@@ -87,6 +87,9 @@ SystemUI::SystemUI(Atomic::Context* context)
     });
     SubscribeToEvent(E_SDLRAWINPUT, std::bind(&SystemUI::OnRawEvent, this, _2));
     SubscribeToEvent(E_SCREENMODE, std::bind(&SystemUI::UpdateProjectionMatrix, this));
+
+    context_->RegisterSubsystem(new Console(context_));
+    context_->RegisterSubsystem(new DebugHud(context_));
 }
 
 SystemUI::~SystemUI()
@@ -366,17 +369,6 @@ void SystemUI::SetScale(float scale)
         return;
     uiScale_ = scale;
     UpdateProjectionMatrix();
-}
-
-void SystemUI::CreateConsoleAndDebugHud()
-{
-    Console* console = new Console(context_);
-    DebugHud* debugHud = new DebugHud(context_);
-
-    // Create console & debug hud
-    context_->RegisterSubsystem(console);
-    context_->RegisterSubsystem(debugHud);
-
 }
 
 }

--- a/Source/Atomic/UI/SystemUI/SystemUI.h
+++ b/Source/Atomic/UI/SystemUI/SystemUI.h
@@ -73,8 +73,6 @@ public:
             const Atomic::String& font_path, float size = 0,
             const std::initializer_list<unsigned short>& ranges = {}, bool merge = false);
 
-    void CreateConsoleAndDebugHud();
-
 protected:
     float uiScale_ = 1.f;
     Atomic::Matrix4 projection_;

--- a/Source/Atomic/UI/UI.cpp
+++ b/Source/Atomic/UI/UI.cpp
@@ -242,10 +242,6 @@ void UI::Initialize(const String& languageFile)
 
     initialized_ = true;
 
-    SystemUI* systemUI = new SystemUI(context_);
-    context_->RegisterSubsystem(systemUI);
-    systemUI->CreateConsoleAndDebugHud();
-
     //TB_DEBUG_SETTING(LAYOUT_BOUNDS) = 1;
 }
 


### PR DESCRIPTION
This PR adds most commonly used subsystem pointers to Context so we can avoid HashMap lookup when we need to get a subsystem. Lookup is cheap, but it all adds up.

In order to get hold of `SystemUI` pointer on engine initialization i had to clean up that part. Now `Engine::Initialize()` creates `SystemUI` subsystem and registers it. `SystemUI` constructor creates and registers `DebugHud` and `Console` subsystems.