### PR TITLE
Update for GetParentRoot which gets the UIView root by default

### DIFF
--- a/Source/ThirdParty/TurboBadger/tb_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.cpp
@@ -814,11 +814,19 @@ bool TBWidget::IsEventDestinationFor(TBWidget *other_widget) const
     return false;
 }
 
-TBWidget *TBWidget::GetParentRoot()
+TBWidget *TBWidget::GetParentRoot(bool view_root)
 {
     TBWidget *tmp = this;
+
     while (tmp->m_parent)
+    {
+        if (view_root && !tmp->m_parent->m_parent)
+        {
+            return tmp;
+        }
+
         tmp = tmp->m_parent;
+    }
     return tmp;
 }
 

--- a/Source/ThirdParty/TurboBadger/tb_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_widgets.h
@@ -752,8 +752,9 @@ public:
         for widgets having multiple children by default, to specify which one that should get the children. */
     virtual TBWidget *GetContentRoot() { return this; }
 
-    /** Get this widget or a parent widget that is the absolute root parent. */
-    TBWidget *GetParentRoot();
+    /** Get this widget or a parent widget that is the absolute root parent
+        if view_root is true, will return the widget for the UIView attached to root widget */
+    TBWidget *GetParentRoot(bool view_root = true);
 
     /** Get the closest parent widget that is a TBWindow or nullptr if there is none.
         If this widget is a window itself, this will be returned. */


### PR DESCRIPTION
Fixes broken popups and other things that were incorrectly being parented to global root widget