### PR TITLE
Automatically deploy Qt dlls to profiler executable directory.

### DIFF
--- a/Build/CMake/Modules/AtomicCommon.cmake
+++ b/Build/CMake/Modules/AtomicCommon.cmake
@@ -229,3 +229,28 @@ macro(msvc_set_runtime runtime_flag)
         set(${var} "${${var}} ${runtime_flag}d")
     endforeach()
 endmacro()
+
+# Macro deploys Qt dlls to folder where target executable is located.
+# Macro arguments:
+#  target - name of target which links to Qt.
+macro(deploy_qt_dlls target)
+    if (WIN32)
+        if (TARGET ${target})
+            # Find Qt dir
+            foreach (dir ${CMAKE_PREFIX_PATH})
+                if (EXISTS ${dir}/bin/windeployqt.exe)
+                    set(windeployqt "${dir}/bin/windeployqt.exe")
+                    break()
+                endif ()
+            endforeach ()
+            if (windeployqt)
+                add_custom_command(
+                    TARGET ${target}
+                    POST_BUILD
+                    COMMAND "${windeployqt}" --no-quick-import --no-translations --no-system-d3d-compiler --no-compiler-runtime --no-webkit2 --no-angle --no-opengl-sw $<TARGET_FILE_DIR:${target}>
+                    VERBATIM
+                )
+            endif ()
+        endif ()
+    endif ()
+endmacro()

--- a/Source/ThirdParty/easy_profiler/profiler_gui/CMakeLists.txt
+++ b/Source/ThirdParty/easy_profiler/profiler_gui/CMakeLists.txt
@@ -52,6 +52,7 @@ if (Qt5Widgets_FOUND)
     else ()
         target_link_libraries(profiler_gui easy_profiler)
     endif ()
+    deploy_qt_dlls (profiler_gui)
     # ATOMIC END
     if (WIN32)
         target_compile_definitions(profiler_gui PRIVATE -D_WIN32_WINNT=0x0600)


### PR DESCRIPTION
Change takes care of putting minimal required Qt dlls to the directory where `Profiler.exe` is built. This is only done for windows. Linux does not need this at all and i am not sure how it should work on MacOS so that one is left out. So as a result after building Atomic now you can go to `Artifacts/Build/Profiler/(Release|Debug)` and run `Profiler.exe`  without needing any extra steps.