### PR TITLE
Fix macOS detection (keep MacOSX string for compatibility)

### DIFF
--- a/Source/AtomicJS/Javascript/JSAtomic.cpp
+++ b/Source/AtomicJS/Javascript/JSAtomic.cpp
@@ -389,7 +389,7 @@ void jsapi_init_atomic(JSVM* vm)
     duk_put_prop_string(ctx, -2, "print");
 
     String platform = GetPlatform();
-    if (platform == "Mac OS X")
+    if (platform == "macOS")
         platform = "MacOSX";
 
     duk_push_string(ctx, platform.CString());


### PR DESCRIPTION

This PR fixes Mac platform detection in JS, which makes the editors shortcuts work again, etc