### PR TITLE
Linux Control key detection wrong

### DIFF
--- a/Source/Atomic/UI/UIViewInput.cpp
+++ b/Source/Atomic/UI/UIViewInput.cpp
@@ -92,10 +92,10 @@ void UIView::HandleMouseButtonDown(StringHash eventType, VariantMap& eventData)
     Input* input = GetSubsystem<Input>();
     int qualifiers = input->GetQualifiers();
 
-#ifdef ATOMIC_PLATFORM_WINDOWS
-    bool superdown = input->GetKeyDown(KEY_LCTRL) || input->GetKeyDown(KEY_RCTRL);
-#else
+#ifdef ATOMIC_PLATFORM_OSX
     bool superdown = input->GetKeyDown(KEY_LGUI) || input->GetKeyDown(KEY_RGUI);
+#else
+    bool superdown = input->GetKeyDown(KEY_LCTRL) || input->GetKeyDown(KEY_RCTRL);
 #endif
 
     MODIFIER_KEYS mod = GetModifierKeys(qualifiers, superdown);
@@ -136,10 +136,10 @@ void UIView::HandleMouseButtonUp(StringHash eventType, VariantMap& eventData)
     pos = input->GetMousePosition();
     int qualifiers = input->GetQualifiers();
 
-#ifdef ATOMIC_PLATFORM_WINDOWS
-    bool superdown = input->GetKeyDown(KEY_LCTRL) || input->GetKeyDown(KEY_RCTRL);
-#else
+#ifdef ATOMIC_PLATFORM_OSX
     bool superdown = input->GetKeyDown(KEY_LGUI) || input->GetKeyDown(KEY_RGUI);
+#else
+    bool superdown = input->GetKeyDown(KEY_LCTRL) || input->GetKeyDown(KEY_RCTRL);
 #endif
 
     MODIFIER_KEYS mod = GetModifierKeys(qualifiers, superdown);

--- a/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
+++ b/Source/AtomicEditor/Editors/SceneEditor3D/SceneView3D.cpp
@@ -281,10 +281,10 @@ void SceneView3D::MoveCamera(float timeStep)
         CheckCameraSpeedBounds();
     }
 
-#ifdef ATOMIC_PLATFORM_WINDOWS
-    bool superdown = input->GetKeyDown(KEY_LCTRL) || input->GetKeyDown(KEY_RCTRL);
-#else
+#ifdef ATOMIC_PLATFORM_OSX
     bool superdown = input->GetKeyDown(KEY_LGUI) || input->GetKeyDown(KEY_RGUI);
+#else
+    bool superdown = input->GetKeyDown(KEY_LCTRL) || input->GetKeyDown(KEY_RCTRL);
 #endif
 
     if (!orbitting && mouseInView && !superdown && input->GetMouseButtonDown(MOUSEB_RIGHT)) {


### PR DESCRIPTION
This PR fixes a couple of instances of detecting when the Control vs Command button is pressed on linux. This resolves #1423