### PR TITLE
Changes conflicting enum names, and removes a badly thought out API call.

### DIFF
--- a/Source/Atomic/Web/WebRequest.h
+++ b/Source/Atomic/Web/WebRequest.h
@@ -26,6 +26,7 @@
 #include "../Core/Object.h"
 #include "../Container/Str.h"
 #include "../Container/ArrayPtr.h"
+#include "../IO/BufferQueue.h"
 
 namespace asio
 {
@@ -45,10 +46,10 @@ namespace Atomic
 /// HTTP connection state
 enum WebRequestState
 {
-    HTTP_INITIALIZING = 0,
-    HTTP_ERROR,
-    HTTP_OPEN,
-    HTTP_CLOSED
+    WR_INITIALIZING = 0,
+    WR_ERROR,
+    WR_OPEN,
+    WR_CLOSED
 };
 
 struct WebRequestInternalState;
@@ -80,7 +81,7 @@ public:
     void Abort();
 
     /// Return whether connection is in the open state.
-    bool IsOpen() const { return GetState() == HTTP_OPEN; }
+    bool IsOpen() const { return GetState() == WR_OPEN; }
 
     /// Return whether E_WEBREQUESTDOWNLOADCHUNK event will be fired or if only E_WEBREQUESTCOMPLETE will be.
     bool HasDownloadChunkEvent();
@@ -99,8 +100,8 @@ public:
     /// Set post data for request
     void SetPostData(const String& postData);
 
-    /// Get the request response as a string
-    const String& GetResponse();
+    /// Get the download buffer queue
+    SharedPtr<BufferQueue> GetDownloadBufferQueue();
 
 private:
 #ifndef EMSCRIPTEN


### PR DESCRIPTION
I've had this locally for a while. I'm trying to reconcile the upstream and my local version of Atomic. This fix may resolve some script naming conflicts, if anybody has them.