### PR TITLE
Add UIPeriodicTable example

### DIFF
--- a/Data/AtomicEditor/ExampleInfo/Examples.json
+++ b/Data/AtomicEditor/ExampleInfo/Examples.json
@@ -5,6 +5,7 @@
         "Basic3D",
         "PhysicsPlatformer",
         "Racer2D",
+        "UIPeriodicTable",
         "ToonTown",
         "AtomicBlaster",
         "RoboMan3D",


### PR DESCRIPTION
This adds the UIPeriodicTable example to the AtomicEditor example browser. 
My Examples submodule isn't updating for the new UIPeriodicTable directory, is there something else I need to do to make that happen?