### PR TITLE
Allow Editor Plugins to define shortcuts and some linting

### DIFF
--- a/Script/AtomicEditor/editor/Preferences.ts
+++ b/Script/AtomicEditor/editor/Preferences.ts
@@ -491,7 +491,7 @@ class PreferencesFormat {
 
         this.developmentUI = {
             projectFrameWidthScalar: 1
-        }
+        };
 
     }
 
@@ -562,7 +562,7 @@ class PreferencesFormat {
             prefs.developmentUI = this.developmentUI;
             updatedMissingDefaults = true;
         }
-        
+
         return updatedMissingDefaults;
     }
 

--- a/Script/AtomicEditor/ui/AnimationToolbar.ts
+++ b/Script/AtomicEditor/ui/AnimationToolbar.ts
@@ -96,11 +96,11 @@ class AnimationToolbar extends Atomic.UIWidget {
     }
 
     handleUpdate(ev) {
-    
+
         var rotspeed = this.rotateModel.value;
         if (rotspeed > 0) {                  // only do work if the spinning is turned on
             this.updateDelta += ev.timeStep; // add some time to the clock
-            if (this.updateDelta > (0.134 * (10-rotspeed))) {  //see if we have reached our limit
+            if (this.updateDelta > (0.134 * (10 - rotspeed))) {  //see if we have reached our limit
                 this.updateDelta = 0.0;      // reset the limit
                 this.updateYaw += 2.1;       // increase the yaw
                 if (this.updateYaw > 26.3)   // clamp the yaw
@@ -110,7 +110,7 @@ class AnimationToolbar extends Atomic.UIWidget {
 
         }
     }
-    
+
     handleWidgetEvent(ev: Atomic.UIWidgetEvent): boolean {
 
         if (ev.type == Atomic.UI_EVENT_TYPE.UI_EVENT_TYPE_CLICK) {

--- a/Script/AtomicEditor/ui/frames/ProjectFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ProjectFrame.ts
@@ -95,7 +95,7 @@ class ProjectFrame extends ScriptWidget {
                 this.handleScaleWidth(data.arg1);
             }
         });
-                
+
     }
 
     handleAssetRenamed(ev: ToolCore.AssetRenamedEvent) {

--- a/Script/AtomicEditor/ui/frames/inspector/AttributeInfoEdit.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/AttributeInfoEdit.ts
@@ -351,7 +351,7 @@ class IntAttributeEdit extends AttributeInfoEdit {
                     } else {
                         widget.text = attrInfo.enumNames[value];
                     }
-                
+
                 }
                 else {
                     widget.text = value.toString();

--- a/Script/AtomicEditor/ui/frames/inspector/CreateComponentButton.ts
+++ b/Script/AtomicEditor/ui/frames/inspector/CreateComponentButton.ts
@@ -143,7 +143,7 @@ class CreateComponentButton extends Atomic.UIButton {
         var menu = new Atomic.UIMenuWindow(this, "create component popup");
         menu.fontDescription = this.fd;
         menu.show(componentCreateSource);
-    }
+    };
 
     handleWidgetEvent(ev: Atomic.UIWidgetEvent) {
 

--- a/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MainFrameMenu.ts
@@ -452,11 +452,11 @@ var developerItems = {
             "3x": ["developer ui width project 3x"],
             "4x": ["developer ui width project 4x"]
         }
-    },     
+    },
     "Theme": {
         "Toggle Theme": ["toggle theme"],
         "Toggle Code Editor Theme": ["toggle codeeditor"]
-    }, 
+    },
     "ScreenShot": ["screenshot", StringID.ShortcutScreenshot],
     "Show Console": ["developer show console"],
     "Clear Preferences": ["developer clear preferences"], //Adds clear preference to developer menu items list

--- a/Script/AtomicEditor/ui/frames/menus/MenuItemSources.ts
+++ b/Script/AtomicEditor/ui/frames/menus/MenuItemSources.ts
@@ -58,14 +58,20 @@ function createMenuItemSourceRecursive(items: any): Atomic.UIMenuItemSource {
 
                 if (value.length == 1)
                     src.addItem(new UIMenuItem(key, value[0]));
-                else if (value.length == 2)
-                    src.addItem(new UIMenuItem(key, value[0], strings.EditorString.GetString(value[1])));
+                else if (value.length == 2) {
+                    var prospectShortcut = value[1]; // raw shortcut or editor shortcut 
+                    if ( strings.EditorString.GetString(value[1]) != undefined )  // editor defined shortcut
+                        prospectShortcut = strings.EditorString.GetString(value[1]);
+                    src.addItem(new UIMenuItem(key, value[0], prospectShortcut));
+                }
                 else if (value.length == 3) {
 
                     var str = "";
-                    if (value[1])
-                        str = strings.EditorString.GetString(value[1]);
-
+                    if (value[1]) {
+                        str = value[1];
+                        if ( strings.EditorString.GetString(value[1]) != undefined )
+                            str = strings.EditorString.GetString(value[1]);
+                    }
                     var skinBg = "";
                     if (value[2])
                         skinBg = value[2];


### PR DESCRIPTION
This PR allows AtomicEditor Plugins to define Shortcut definitions and process the shortcut actions.  The Editor has an elaborate Shortcut system, but it doesn’t allow for shortcuts to be dynamically defined. There is also some mechanism that also defines unqualified F1-F12 as "special", which, sadly, won't allow these keys to be programmed from plugins, since they won't emit an event. Using qualified (shift, control, alt) emit events though. It will not check for duplicate shortcut definitions.

Using is page as an example https://github.com/AtomicGameEngine/AtomicGameEngine/wiki/Editor-Extensions

To define the shortcut : 

    this.serviceLocator.uiServices.createPluginMenuItemSource("My Menu", { "Open" : [`${this.name}.open.myaction`, "Ctrl+F5" ] });

To enable the shortcut action, add this code to the plugin projectLoaded() function :

```
        var myplug = this;
        this.subscribeToEvent( "UIShortcut", function (ev) {
            if ( ev.key == Atomic.KEY_F5  && ev.qualifiers == Atomic.QUAL_CTRL ) 
                myplug.menuItemClicked( "MyMenuPlugin.open.myaction" );
        });

```

There are also some misc TSLINT reject fixes that have crept in, while I was checking the file I changed. 
