### PR TITLE
MingW-w64 support

### DIFF
--- a/Build/CMake/Modules/AtomicDesktop.cmake
+++ b/Build/CMake/Modules/AtomicDesktop.cmake
@@ -1,7 +1,7 @@
 set(ATOMIC_DESKTOP TRUE)
 
 # Check whether the CEF submodule is available
-if (NOT DEFINED ATOMIC_WEBVIEW AND EXISTS ${ATOMIC_SOURCE_DIR}/Submodules/CEF)
+if (NOT MINGW AND NOT DEFINED ATOMIC_WEBVIEW AND EXISTS ${ATOMIC_SOURCE_DIR}/Submodules/CEF)
     #Check if CEF got pulled by looking if the foldes is empty
     file(GLOB CEF_FILES ${ATOMIC_SOURCE_DIR}/Submodules/CEF/*)
 

--- a/Source/Atomic/Environment/ProcSky.h
+++ b/Source/Atomic/Environment/ProcSky.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
+#if _MSC_VER
 #define fmax max
 #define fmin min
 #endif

--- a/Source/AtomicEditor/Utils/FileUtils.cpp
+++ b/Source/AtomicEditor/Utils/FileUtils.cpp
@@ -96,10 +96,7 @@ String FileUtils::NewProjectFileDialog()
     upath = GetSubsystem<FileSystem>()->GetUserDocumentsDir();
 #endif
 
-    nfdresult_t result = NFD_ChooseDirectory( "Please choose the root folder for your project",
-                                upath.Length() ? GetNativePath(upath).CString() : "",
-                                &outPath);
-
+    nfdresult_t result = NFD_PickFolder(upath.Length() ? GetNativePath(upath).CString() : "", &outPath);
 
     if (outPath && result == NFD_OKAY)
     {
@@ -121,9 +118,7 @@ String FileUtils::GetBuildPath(const String& defaultPath)
 
     nfdchar_t *outPath = NULL;
     
-    nfdresult_t result = NFD_ChooseDirectory( "Please choose the build folder",
-                                defaultPath.Length() ? GetNativePath(defaultPath).CString() : "",
-                                &outPath);
+    nfdresult_t result = NFD_PickFolder(defaultPath.Length() ? GetNativePath(defaultPath).CString() : "", &outPath);
 
     if (outPath && result == NFD_OKAY)
     {
@@ -145,15 +140,7 @@ String FileUtils::GetAntPath(const String& defaultPath)
 
     nfdchar_t *outPath = NULL;
 
-#ifdef ATOMIC_PLATFORM_WINDOWS
-    String msg = "Please select the folder which contains ant.bat";
-#else
-    String msg = "Please select the folder which contains the ant executable";
-#endif
-
-    nfdresult_t result = NFD_ChooseDirectory(msg.CString(),
-                        defaultPath.Length() ? GetNativePath(defaultPath).CString() : "",
-                        &outPath);
+    nfdresult_t result = NFD_PickFolder(defaultPath.Length() ? GetNativePath(defaultPath).CString() : "", &outPath);
 
     if (outPath && result == NFD_OKAY)
     {
@@ -208,9 +195,7 @@ String FileUtils::FindPath(const String& title, const String& defaultPath)
     String resultPath;
     nfdchar_t *outPath = NULL;
 
-    nfdresult_t result = NFD_ChooseDirectory(title.CString(),
-                       defaultPath.Length() ? GetNativePath(defaultPath).CString() : "",
-                       &outPath);
+    nfdresult_t result = NFD_PickFolder(defaultPath.Length() ? GetNativePath(defaultPath).CString() : "", &outPath);
 
     if (outPath && result == NFD_OKAY)
     {

--- a/Source/ThirdParty/Civetweb/CMakeLists.txt
+++ b/Source/ThirdParty/Civetweb/CMakeLists.txt
@@ -36,6 +36,9 @@ if (WIN32)
             add_definitions (-D_TIMESPEC_DEFINED)
         endif ()
     endif ()
+    # ATOMIC BEGIN
+    set(LIBS ws2_32.lib)
+    # ATOMIC END
 elseif (APPLE AND (NOT IOS OR IPHONEOS_DEPLOYMENT_TARGET STREQUAL "" OR NOT IPHONEOS_DEPLOYMENT_TARGET VERSION_LESS 10.0))    # We cheat a little bit here with a hard-coded check because iOS 10.3 SDK when targeting 9.3 has strong symbol for iPhoneOS archs but weak symbol for iPhoneSimulator archs
     include (CheckLibraryExists)
     check_library_exists (c clock_gettime "" FOUND_CLOCK_GETTIME_IN_C)

--- a/Source/ThirdParty/Poco/Foundation/include/Poco/FPEnvironment_WIN32.h
+++ b/Source/ThirdParty/Poco/Foundation/include/Poco/FPEnvironment_WIN32.h
@@ -27,6 +27,26 @@
 
 namespace Poco {
 
+// ATOMIC BEGIN
+#if __MINGW32__ || __MINW64__
+#	define RC_DOWN _RC_DOWN
+#	define RC_UP _RC_UP
+#	define RC_NEAR _RC_NEAR
+#	define RC_CHOP _RC_CHOP
+
+#	define SW_ZERODIVIDE _EM_ZERODIVIDE
+#	define SW_INEXACT _EM_INEXACT
+#	define SW_OVERFLOW _EM_OVERFLOW
+#	define SW_UNDERFLOW _EM_UNDERFLOW
+#	define SW_INVALID _EM_INVALID
+
+#	define MCW_DN _MCW_DN
+#	define MCW_EM _MCW_EM
+#	define MCW_IC _MCW_IC
+#	define MCW_RC _MCW_RC
+#	define MCW_PC _MCW_PC
+#endif
+// ATOMIC END
 
 class Foundation_API FPEnvironmentImpl
 {

--- a/Source/ThirdParty/WebSocketPP/include/websocketpp/common/thread.hpp
+++ b/Source/ThirdParty/WebSocketPP/include/websocketpp/common/thread.hpp
@@ -36,11 +36,14 @@
 #if defined _WEBSOCKETPP_CPP11_INTERNAL_ && !defined _WEBSOCKETPP_NO_CPP11_THREAD_
     // MinGW by default does not support C++11 thread/mutex so even if the
     // internal check for C++11 passes, ignore it if we are on MinGW
-    #if (!defined(__MINGW32__) && !defined(__MINGW64__))
+// ATOMIC BEGIN
+// Reasonably new MingW supports these features.
+//    #if (!defined(__MINGW32__) && !defined(__MINGW64__))
         #ifndef _WEBSOCKETPP_CPP11_THREAD_
             #define _WEBSOCKETPP_CPP11_THREAD_
         #endif
-    #endif
+//    #endif
+// ATOMIC END
 #endif
 
 #ifdef _WEBSOCKETPP_CPP11_THREAD_

--- a/Source/ThirdParty/kNet/CMakeLists.txt
+++ b/Source/ThirdParty/kNet/CMakeLists.txt
@@ -53,6 +53,9 @@ if (WIN32)
         get_filename_component (baseName ${srcFile} NAME)
         set_source_files_properties (${srcFile} PROPERTIES COMPILE_FLAGS "-DDEBUG_CPP_NAME=\"\\\"${baseName}\"\\\"")
     endforeach ()
+   # ATOMIC BEGIN
+   set(LIBS ws2_32.lib)
+   # ATOMIC END
 endif ()
 
 # Define source files

--- a/Source/ThirdParty/libcurl/CMakeLists.txt
+++ b/Source/ThirdParty/libcurl/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if (WIN32)
+if (MSVC)
     include(LibCurlWindows.cmake)
 else()
     include(LibCurl.cmake)

--- a/Source/ThirdParty/libcurl/lib/CMakeLists.txt
+++ b/Source/ThirdParty/libcurl/lib/CMakeLists.txt
@@ -76,7 +76,7 @@ add_library(
   )
 
 if(WIN32 AND CURL_STATICLIB)
-  set_target_properties(${LIB_NAME} PROPERTIES STATIC_LIBRARY_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+  set_target_properties(${LIB_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
 target_link_libraries(${LIB_NAME} ${CURL_LIBS})

--- a/Source/ThirdParty/nativefiledialog/CMakeLists.txt
+++ b/Source/ThirdParty/nativefiledialog/CMakeLists.txt
@@ -2,7 +2,7 @@
 set (SOURCE_FILES nfd_common.c nfd.h)
 
 if (APPLE)
-    set (SOURCE_FILES ${SOURCE_FILES} nfd_cocoa.mm )
+    set (SOURCE_FILES ${SOURCE_FILES} nfd_cocoa.m )
 endif( APPLE)
 
 if (WIN32)

--- a/Source/ThirdParty/nativefiledialog/nfd.h
+++ b/Source/ThirdParty/nativefiledialog/nfd.h
@@ -48,12 +48,12 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
 /* save dialog */
 nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
-                            const nfdchar_t *defaultFilename,
                             nfdchar_t **outPath );
 
-nfdresult_t NFD_ChooseDirectory( const nfdchar_t *prompt,
-                                 const nfdchar_t *defaultPath,
-                                 nfdchar_t **outPath );
+
+/* select folder dialog */
+nfdresult_t NFD_PickFolder( const nfdchar_t *defaultPath,
+                            nfdchar_t **outPath);
 
 /* nfd_common.c */
 

--- a/Source/ThirdParty/nativefiledialog/nfd_gtk.c
+++ b/Source/ThirdParty/nativefiledialog/nfd_gtk.c
@@ -13,8 +13,7 @@
 
 
 const char INIT_FAIL_MSG[] = "gtk_init_check failed to initilaize GTK+";
-const char NOPATH_MSG[] = "The selected path is out of memory.";
-const char NOMEM_MSG[] = "Out of memory.";
+
 
 static void AddTypeToFilterName( const char *typebuf, char *filterName, size_t bufsize )
 {
@@ -26,7 +25,7 @@ static void AddTypeToFilterName( const char *typebuf, char *filterName, size_t b
         strncat( filterName, SEP, bufsize - len - 1 );
         len += strlen(SEP);
     }
-
+    
     strncat( filterName, typebuf, bufsize - len - 1 );
 }
 
@@ -37,34 +36,34 @@ static void AddFiltersToDialog( GtkWidget *dialog, const char *filterList )
     const char *p_filterList = filterList;
     char *p_typebuf = typebuf;
     char filterName[NFD_MAX_STRLEN] = {0};
-
+    
     if ( !filterList || strlen(filterList) == 0 )
         return;
 
     filter = gtk_file_filter_new();
     while ( 1 )
     {
-
+        
         if ( NFDi_IsFilterSegmentChar(*p_filterList) )
         {
             char typebufWildcard[NFD_MAX_STRLEN];
             /* add another type to the filter */
             assert( strlen(typebuf) > 0 );
             assert( strlen(typebuf) < NFD_MAX_STRLEN-1 );
-
+            
             snprintf( typebufWildcard, NFD_MAX_STRLEN, "*.%s", typebuf );
             AddTypeToFilterName( typebuf, filterName, NFD_MAX_STRLEN );
-
+            
             gtk_file_filter_add_pattern( filter, typebufWildcard );
-
+            
             p_typebuf = typebuf;
             memset( typebuf, 0, sizeof(char) * NFD_MAX_STRLEN );
         }
-
+        
         if ( *p_filterList == ';' || *p_filterList == '\0' )
         {
             /* end of filter -- add it to the dialog */
-
+            
             gtk_file_filter_set_name( filter, filterName );
             gtk_file_chooser_add_filter( GTK_FILE_CHOOSER(dialog), filter );
 
@@ -73,7 +72,7 @@ static void AddFiltersToDialog( GtkWidget *dialog, const char *filterList )
             if ( *p_filterList == '\0' )
                 break;
 
-            filter = gtk_file_filter_new();
+            filter = gtk_file_filter_new();            
         }
 
         if ( !NFDi_IsFilterSegmentChar( *p_filterList ) )
@@ -84,7 +83,7 @@ static void AddFiltersToDialog( GtkWidget *dialog, const char *filterList )
 
         p_filterList++;
     }
-
+    
     /* always append a wildcard option to the end*/
 
     filter = gtk_file_filter_new();
@@ -112,7 +111,7 @@ static nfdresult_t AllocPathSet( GSList *fileList, nfdpathset_t *pathSet )
     GSList *node;
     nfdchar_t *p_buf;
     size_t count = 0;
-
+    
     assert(fileList);
     assert(pathSet);
 
@@ -122,7 +121,6 @@ static nfdresult_t AllocPathSet( GSList *fileList, nfdpathset_t *pathSet )
     pathSet->indices = NFDi_Malloc( sizeof(size_t)*pathSet->count );
     if ( !pathSet->indices )
     {
-        NFDi_SetError(NOMEM_MSG);
         return NFD_ERROR;
     }
 
@@ -142,7 +140,7 @@ static nfdresult_t AllocPathSet( GSList *fileList, nfdpathset_t *pathSet )
         nfdchar_t *path = (nfdchar_t*)(node->data);
         size_t byteLen = strlen(path)+1;
         ptrdiff_t index;
-
+        
         memcpy( p_buf, path, byteLen );
         g_free(node->data);
 
@@ -155,7 +153,7 @@ static nfdresult_t AllocPathSet( GSList *fileList, nfdpathset_t *pathSet )
     }
 
     g_slist_free( fileList );
-
+    
     return NFD_OKAY;
 }
 
@@ -164,13 +162,13 @@ static void WaitForCleanup(void)
     while (gtk_events_pending())
         gtk_main_iteration();
 }
-
+                                 
 /* public */
 
 nfdresult_t NFD_OpenDialog( const char *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath )
-{
+{    
     GtkWidget *dialog;
     nfdresult_t result;
 
@@ -208,7 +206,6 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
             {
                 g_free( filename );
                 gtk_widget_destroy(dialog);
-                NFDi_SetError(NOPATH_MSG);
                 return NFD_ERROR;
             }
         }
@@ -216,8 +213,8 @@ nfdresult_t NFD_OpenDialog( const char *filterList,
 
         result = NFD_OKAY;
     }
- 
-   
+
+    WaitForCleanup();
     gtk_widget_destroy(dialog);
     WaitForCleanup();
 
@@ -259,13 +256,13 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
         if ( AllocPathSet( fileList, outPaths ) == NFD_ERROR )
         {
             gtk_widget_destroy(dialog);
-            NFDi_SetError(NOPATH_MSG);
             return NFD_ERROR;
         }
-
+        
         result = NFD_OKAY;
     }
 
+    WaitForCleanup();
     gtk_widget_destroy(dialog);
     WaitForCleanup();
 
@@ -274,7 +271,6 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
 
 nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
-                            const nfdchar_t *defaultFilename,
                             nfdchar_t **outPath )
 {
     GtkWidget *dialog;
@@ -291,19 +287,21 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
                                           GTK_FILE_CHOOSER_ACTION_SAVE,
                                           "_Cancel", GTK_RESPONSE_CANCEL,
                                           "_Save", GTK_RESPONSE_ACCEPT,
-                                          NULL );
+                                          NULL ); 
     gtk_file_chooser_set_do_overwrite_confirmation( GTK_FILE_CHOOSER(dialog), TRUE );
 
-    /* Build the filter list */
+    /* Build the filter list */    
     AddFiltersToDialog(dialog, filterList);
-    SetDefaultPath(dialog, defaultPath);
 
-    result = NFD_CANCEL;
+    /* Set the default path */
+    SetDefaultPath(dialog, defaultPath);
+    
+    result = NFD_CANCEL;    
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )
     {
         char *filename;
         filename = gtk_file_chooser_get_filename( GTK_FILE_CHOOSER(dialog) );
-
+        
         {
             size_t len = strlen(filename);
             *outPath = NFDi_Malloc( len + 1 );
@@ -312,7 +310,6 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
             {
                 g_free( filename );
                 gtk_widget_destroy(dialog);
-                NFDi_SetError(NOPATH_MSG);
                 return NFD_ERROR;
             }
         }
@@ -321,39 +318,43 @@ nfdresult_t NFD_SaveDialog( const nfdchar_t *filterList,
         result = NFD_OKAY;
     }
 
-    gtk_widget_destroy(dialog);
-
     WaitForCleanup();
-
+    gtk_widget_destroy(dialog);
+    WaitForCleanup();
+    
     return result;
 }
 
-nfdresult_t NFD_ChooseDirectory( const nfdchar_t *prompt,
-                                 const nfdchar_t *defaultPath,
-                                 nfdchar_t **outPath )
+nfdresult_t NFD_PickFolder(const nfdchar_t *defaultPath,
+    nfdchar_t **outPath)
 {
-    GtkWidget *dialog = NULL;
-    nfdresult_t result = NFD_ERROR;
+    GtkWidget *dialog;
+    nfdresult_t result;
 
-    if ( !gtk_init_check( NULL, NULL ) )
+    if (!gtk_init_check(NULL, NULL))
     {
         NFDi_SetError(INIT_FAIL_MSG);
         return NFD_ERROR;
     }
-    dialog = gtk_file_chooser_dialog_new( prompt,
+
+    dialog = gtk_file_chooser_dialog_new( "Select folder",
                                           NULL,
                                           GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
                                           "_Cancel", GTK_RESPONSE_CANCEL,
-                                          "_Open", GTK_RESPONSE_ACCEPT,
-                                          NULL );
+                                          "_Select", GTK_RESPONSE_ACCEPT,
+                                          NULL ); 
+    gtk_file_chooser_set_do_overwrite_confirmation( GTK_FILE_CHOOSER(dialog), TRUE );
 
+
+    /* Set the default path */
     SetDefaultPath(dialog, defaultPath);
-
-    result = NFD_CANCEL;
+    
+    result = NFD_CANCEL;    
     if ( gtk_dialog_run( GTK_DIALOG(dialog) ) == GTK_RESPONSE_ACCEPT )
     {
-        char *filename = NULL;
+        char *filename;
         filename = gtk_file_chooser_get_filename( GTK_FILE_CHOOSER(dialog) );
+        
         {
             size_t len = strlen(filename);
             *outPath = NFDi_Malloc( len + 1 );
@@ -362,17 +363,17 @@ nfdresult_t NFD_ChooseDirectory( const nfdchar_t *prompt,
             {
                 g_free( filename );
                 gtk_widget_destroy(dialog);
-                NFDi_SetError(NOPATH_MSG);
                 return NFD_ERROR;
             }
         }
         g_free(filename);
+
         result = NFD_OKAY;
     }
 
-    gtk_widget_destroy(dialog);
-
     WaitForCleanup();
-
-    return result;        
+    gtk_widget_destroy(dialog);
+    WaitForCleanup();
+    
+    return result;
 }


### PR DESCRIPTION
Engine can now build with MingW-w64. What is still missing is webview and as direct consequence of that - editor. Webview is disabled if mingw is detected. Bindings build though. I also updated nativefiledialog to latest version which already is pretty old. That was required in order to get mingw building. As a consequence of update it is no longer possible to set title of dialog for choosing a directory. I hope it is acceptable.