### PR TITLE
Move imgui ui assembly and rendering to END_RENDERING event. 

### DIFF
--- a/Source/Atomic/UI/SystemUI/SystemUI.h
+++ b/Source/Atomic/UI/SystemUI/SystemUI.h
@@ -82,7 +82,7 @@ protected:
 
     void ReallocateFontTexture();
     void UpdateProjectionMatrix();
-    void OnPostUpdate(Atomic::VariantMap& args);
+    void OnEndRendering(Atomic::VariantMap& args);
     void OnRenderDrawLists(ImDrawData* data);
     void OnRawEvent(VariantMap& args);
 };


### PR DESCRIPTION
Required for interoperability with Urho3D UI. It allows me to render Urho3D UI just before imgui in order to have imgui be rendered on top of everything. It does not affect anything related to TurboBadger, imgui still renders on top of it like before.