### PR TITLE
Misc small improvements

### DIFF
--- a/Source/Atomic/CMakeLists.txt
+++ b/Source/Atomic/CMakeLists.txt
@@ -241,5 +241,5 @@ if (MSVC)
 endif ()
 
 if (UNIX OR MINGW)
-    target_compile_options(Atomic PUBLIC -std=gnu++11)
+    target_compile_options(Atomic PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>)
 endif ()

--- a/Source/Atomic/Core/Object.h
+++ b/Source/Atomic/Core/Object.h
@@ -215,7 +215,12 @@ public:
 
     static ClassID GetClassIDStatic() { static const int typeID = 0; return (ClassID) &typeID; }
     static const Atomic::String& GetTypeNameStatic() { static const Atomic::String typeNameStatic("Object"); return typeNameStatic; }
-
+    /// Send event with parameters to all subscribers.
+    void SendEvent(StringHash eventType, const VariantMap& eventData);
+    /// Block object from sending and receiving events.
+    void SetBlockEvents(bool block) { blockEvents_ = block; }
+    /// Return sending and receiving events blocking status.
+    bool GetBlockEvents() const { return blockEvents_; }
     // ATOMIC END
 
 protected:
@@ -237,6 +242,10 @@ private:
 
     /// Event handlers. Sender is null for non-specific handlers.
     LinkedList<EventHandler> eventHandlers_;
+
+    // ATOMIC BEGIN
+    bool blockEvents_;
+    // ATOMIC END
 };
 
 template <class T> T* Object::GetSubsystem() const { return static_cast<T*>(GetSubsystem(T::GetTypeStatic())); }

--- a/Source/Atomic/Math/Vector2.h
+++ b/Source/Atomic/Math/Vector2.h
@@ -52,7 +52,14 @@ public:
         y_(data[1])
     {
     }
-
+    // ATOMIC BEGIN
+    /// Construct from an int array.
+    IntVector2(const float* data) :
+        x_((int)data[0]),
+        y_((int)data[1])
+    {
+    }
+    // ATOMIC END
     /// Copy-construct from another vector.
     IntVector2(const IntVector2& rhs) :
         x_(rhs.x_),

--- a/Source/Atomic/UI/SystemUI/MessageBox.cpp
+++ b/Source/Atomic/UI/SystemUI/MessageBox.cpp
@@ -81,7 +81,7 @@ void MessageBox::RenderFrame(StringHash eventType, VariantMap& eventData)
     if (ImGui::Begin(titleText_.CString(), &isOpen_, windowSize_, -1, ImGuiWindowFlags_NoCollapse|
                      ImGuiWindowFlags_NoSavedSettings))
     {
-        ImGui::Text(messageText_.CString());
+        ImGui::TextUnformatted(messageText_.CString());
         auto region = ImGui::GetContentRegionAvail();
         ImGui::SetCursorPos(ImVec2(region.x - 100 + 20, region.y + 20));
 

--- a/Source/ThirdParty/SQLite/CMakeLists.txt
+++ b/Source/ThirdParty/SQLite/CMakeLists.txt
@@ -60,7 +60,12 @@ if (NOT IOS AND NOT TVOS AND NOT WEB)
 
     # Define dependency libs
     if (NOT WIN32)
-        set (LIBS dl pthread)    # ATOMIC FIX
+        # ATOMIC BEGIN
+        set (LIBS dl)
+        if (NOT ANDROID)
+            list (APPEND LIBS pthread)
+        endif ()
+        # ATOMIC END
         if (READLINE_FOUND)
             add_definitions (-DHAVE_READLINE)
             list (APPEND INCLUDE_DIRS ${READLINE_INCLUDE_DIRS})

--- a/Source/ThirdParty/easy_profiler/CMakeLists.txt
+++ b/Source/ThirdParty/easy_profiler/CMakeLists.txt
@@ -8,7 +8,9 @@ set(EASY_PRODUCT_VERSION_STRING "${EASY_PROGRAM_VERSION_MAJOR}.${EASY_PROGRAM_VE
 
 # ATOMIC BEGIN
 
-find_package(Qt5Widgets)
+if (ATOMIC_DESKTOP)
+    find_package(Qt5Widgets)
+endif ()
 
 set(EASY_OPTION_LIB_STATIC ON CACHE BOOL "" FORCE)
 set(EASY_OPTION_PREDEFINED_COLORS ON CACHE BOOL "" FORCE)
@@ -43,7 +45,7 @@ add_subdirectory(easy_profiler_core)
 
 # ATOMIC BEGIN
 # Only include the Qt client if on we're building desktop platform and Qt5 was found on system
-if (ATOMIC_DESKTOP AND Qt5Widgets_FOUND)
+if (Qt5Widgets_FOUND)
     add_subdirectory(profiler_gui)
 endif()
 #ATOMIC END

--- a/Source/ThirdParty/easy_profiler/easy_profiler_core/CMakeLists.txt
+++ b/Source/ThirdParty/easy_profiler/easy_profiler_core/CMakeLists.txt
@@ -121,7 +121,11 @@ easy_define_target_option(easy_profiler EASY_OPTION_PREDEFINED_COLORS EASY_OPTIO
 
 if (UNIX)
     target_compile_options(easy_profiler PRIVATE -Wall -Wno-long-long -Wno-reorder -Wno-braced-scalar-init -pedantic -O3)
-    target_link_libraries(easy_profiler pthread)
+    # ATOMIC BEGIN
+    if (NOT ANDROID)
+        target_link_libraries(easy_profiler pthread)
+    endif ()
+    # ATOMIC END
 elseif (WIN32)
     target_compile_definitions(easy_profiler PRIVATE -D_WIN32_WINNT=0x0600 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
     target_link_libraries(easy_profiler ws2_32 psapi)
@@ -132,7 +136,7 @@ if (MINGW)
 endif ()
 
 if (APPLE)
-    target_compile_options(easy_profiler PUBLIC -std=gnu++11)
+    target_compile_options(easy_profiler PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>)
 else ()
     
 
@@ -141,11 +145,9 @@ else ()
             target_compile_options(easy_profiler PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>)
         endif ()
     else()
-    
         if (NOT MSVC)
-            target_compile_options(easy_profiler PUBLIC -std=gnu++11)
+            target_compile_options(easy_profiler PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>)
         endif ()
-        
         set_target_properties(easy_profiler PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
     endif ()
 endif ()


### PR DESCRIPTION
This is a small collection of recent fixes and few additions. Lets go through them:

CMake version requirement bumped to 3.3. Why you ask? Because noone noticed, but we already depend on that version since we started using `$<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>`. `COMPILE_LANGUAGE:CXX` thingy was introduced in 3.3. Older distros may get recent prebuilt CMake binaries from CMake website and they run. Tested with CMake 3.9 on ubuntu 14.04 on travis.ci.

Several build fixes for android NDK 13b. Namely must not link to `pthread` because it does not/no longer exists on android. Also wrapped `-std=gnu++11` into generator expression because otherwise compiler fails building c files due to unknown flag. Also excluded profiler tool from build on android in a way that does not cause any warnings.

`ImGui::Text(messageText_.CString());` -> `ImGui::TextUnformatted(messageText_.CString());` because again on android it fails to build due to printing user-supplied text as format string being insecure. Clang is really nice, isnt it? ;)

Added `IntVector2` constructor taking in float array. No explanation needed here.

Added `SetBlockEvents(bool)` and `GetBlockEvents()` to `Object`. This allows us to block certain objects from sending and receiving events. I found it very convenient for implementing game states, but i am sure there are other useful applications. Blocking events is easier than unsubscribing and resubscribing after all.

Added `SendEvent(StringHash, const VariantMap&)` overload which allows us to use initializer lists for sending events. For example `SendEvent("foo", { {Foo::P_BAR, "bar"}, {Foo::P_FOO, 1} })`. While using this method variant causes extra copy i think there should be a convenience method for cases where speed does not matter.

This is a mix of various things, but i think they should be acceptable. If not, and if you think i should split PR up or get rid of some changes please let me know.