### PR TITLE
Atomic Updates

### DIFF
--- a/Data/AtomicEditor/ProjectTemplates/EmptyProject/JavaScript/Resources/Scripts/main.js
+++ b/Data/AtomicEditor/ProjectTemplates/EmptyProject/JavaScript/Resources/Scripts/main.js
@@ -1,9 +1,10 @@
 
 // This script is the main entry point of the game
 
-// called per frame, optional
-function update(timeStep) {
+exports.update = function() {
+
+    if (Atomic.input.getKeyDown(Atomic.KEY_ESCAPE)) {
+        Atomic.engine.exit();
+    }
 
 }
-
-exports.update = update;

--- a/Data/AtomicEditor/ProjectTemplates/Project2D/JavaScript/Resources/Scripts/main.js
+++ b/Data/AtomicEditor/ProjectTemplates/Project2D/JavaScript/Resources/Scripts/main.js
@@ -1,3 +1,11 @@
 // This script is the main entry point of the game
 
 Atomic.player.loadScene("Scenes/Scene.scene");
+
+exports.update = function() {
+
+    if (Atomic.input.getKeyDown(Atomic.KEY_ESCAPE)) {
+        Atomic.engine.exit();
+    }
+
+}

--- a/Data/AtomicEditor/ProjectTemplates/Project3D/JavaScript/Resources/Scripts/main.js
+++ b/Data/AtomicEditor/ProjectTemplates/Project3D/JavaScript/Resources/Scripts/main.js
@@ -2,9 +2,10 @@
 
 var scene = Atomic.player.loadScene("Scenes/Scene.scene");
 
-// called per frame, optional
-function update(timeStep) {
+exports.update = function() {
+
+    if (Atomic.input.getKeyDown(Atomic.KEY_ESCAPE)) {
+        Atomic.engine.exit();
+    }
 
 }
-
-exports.update = update;

--- a/Resources/CoreData/Shaders/HLSL/ProcSky.hlsl
+++ b/Resources/CoreData/Shaders/HLSL/ProcSky.hlsl
@@ -3,19 +3,23 @@
 #include "Transform.hlsl"
 
 void VS(float4 iPos : POSITION,
-		float3 iNormal : NORMAL, 
-		out float4 oPos : POSITION, 
+		float3 iNormal : NORMAL,
+		out float4 oPos : POSITION,
 		out float3 oTexCoord : TEXCOORD0)
 {
 	oPos = iPos;
 	oTexCoord = iNormal;
 }
 
-void PS(float3 oTexCoord: TEXCOORD0, out float4 oColor : COLOR0)
+void PS(float3 oTexCoord: TEXCOORD0, out float4 oColor : OUTCOLOR0)
 {
     float3 V = normalize( oTexCoord ) + float3(0, 0.2 ,0);
     float2 lt = float2( (1.0 + normalize( V.xz ).y) / 2.0, 1.0 - normalize( V ).y );
+
+    #ifndef D3D11
     oColor = float4(tex2D( sDiffMap, lt ).rgb, 1.0);
+    #else
+    oColor = float4(tDiffMap.Sample(sDiffMap, lt).rgb, 1.0);
+    #endif
+
 }
-
-

--- a/Source/Atomic/Environment/ProcSky.cpp
+++ b/Source/Atomic/Environment/ProcSky.cpp
@@ -182,10 +182,17 @@ float ProcSky::SetDayTime(float time)
         // fade out
         if (shadowFade_ < 0.0f || shadowFade_ != 1.0f)
         {
-            shadowFade_ += .05f;
+            if (autoUpdate_)
+            {
+                shadowFade_ += .05f;
 
-            if (shadowFade_ > 1.0f)
+                if (shadowFade_ > 1.0f)
+                    shadowFade_ = 1.0f;
+            }
+            else
+            {
                 shadowFade_ = 1.0f;
+            }
 
             sunlight_->SetShadowIntensity(shadowFade_);
 
@@ -205,10 +212,18 @@ float ProcSky::SetDayTime(float time)
         // fade in
         if (shadowFade_ < 0.0f || shadowFade_ != 0.0f)
         {
-            shadowFade_ -= .05f;
 
-            if (shadowFade_ < 0.0f)
+            if (autoUpdate_)
+            {
+                shadowFade_ -= .05f;
+
+                if (shadowFade_ < 0.0f)
+                    shadowFade_ = 0.0f;
+            }
+            else
+            {
                 shadowFade_ = 0.0f;
+            }
 
             sunlight_->SetShadowIntensity(shadowFade_);
 

--- a/Source/ToolCore/NETTools/NETProjectGen.cpp
+++ b/Source/ToolCore/NETTools/NETProjectGen.cpp
@@ -1220,13 +1220,9 @@ namespace ToolCore
 
                     propertyGroup.CreateChild("StartArguments").SetValue(startArguments);
 
-#ifdef ATOMIC_DEBUG
-                    // When building a debug build, default native code debugging to true
-                    if (cfg == "Debug")
-                    {
-                        propertyGroup.CreateChild("EnableUnmanagedDebugging").SetValue("true");
-                    }
-#endif                    
+                    // Always enabled unmanaged debugging, solve issues with release building hanging when run from IDE
+                    propertyGroup.CreateChild("EnableUnmanagedDebugging").SetValue("true");
+
                 }
 
 

--- a/Source/ToolCore/NETTools/NETProjectSystem.cpp
+++ b/Source/ToolCore/NETTools/NETProjectSystem.cpp
@@ -523,6 +523,12 @@ namespace ToolCore
 
         if (idePath_.Length())
         {
+            // Ensure the path ends with a slash
+            if (!idePath_.EndsWith("\\"))
+            {
+                idePath_ += "\\";
+            }
+
             idePath_.Replace("Tools\\", "IDE\\devenv.exe");
 
             if (!fileSystem->FileExists(idePath_))


### PR DESCRIPTION
+ C# fix for crashing when running from VS2015/VS2017 (odd issue with not using native debugger engine with managed code)
+ Fix for VS2015 detection when missing trailing slash
+ Quick esc exits for basic JS project templates
+ D3D11 proc sky shader fix
+ Fix for proc sky when autoupdate is not enabled
+ updating submodule commit
