### PR TITLE
Add titlebar axis control for UIWindow

### DIFF
--- a/Source/Atomic/UI/UIDockWindow.cpp
+++ b/Source/Atomic/UI/UIDockWindow.cpp
@@ -117,6 +117,13 @@ bool UIDockWindow::OnEvent(const tb::TBWidgetEvent &ev)
     return UIWidget::OnEvent(ev);
 }
 
+void UIDockWindow::SetAxis(UI_AXIS axis)
+{
+    if (!widget_)
+        return;
+
+    widget_->SetAxis((AXIS) axis);
+}
 
 
 

--- a/Source/Atomic/UI/UIDockWindow.h
+++ b/Source/Atomic/UI/UIDockWindow.h
@@ -50,6 +50,7 @@ class ATOMIC_API UIDockWindow : public UIWindow
     bool HasDockContent();  /// Returns if the UIDockWindow contains docked content.
     void Dock( UIWidget *target );  /// Transfers the dock content to the target widget
     void Show( UIWidget *host, int xpos = 50, int ypos = 50 ); /// Show the UIDockWindow, and optional position
+    void SetAxis(UI_AXIS axis);   /// Axis orientation of titlebar, UI_AXIS_Y = top(default), UI_AXIS_X = left side
 
 protected:
 

--- a/Source/Atomic/UI/UIWindow.cpp
+++ b/Source/Atomic/UI/UIWindow.cpp
@@ -104,4 +104,12 @@ bool UIWindow::OnEvent(const tb::TBWidgetEvent &ev)
     return UIWidget::OnEvent(ev);
 }
 
+void UIWindow::SetAxis(UI_AXIS axis)
+{
+    if (!widget_)
+        return;
+
+    widget_->SetAxis((AXIS) axis);
+}
+
 }

--- a/Source/Atomic/UI/UIWindow.h
+++ b/Source/Atomic/UI/UIWindow.h
@@ -64,6 +64,8 @@ class ATOMIC_API UIWindow : public UIWidget
     void AddChild(UIWidget *child);
 
     void Close();
+    
+    void SetAxis(UI_AXIS axis);  /// Axis orientation of titlebar, UI_AXIS_Y = top(default), UI_AXIS_X = left side
 
 protected:
 

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.cpp
@@ -792,7 +792,7 @@ TBDockWindow::~TBDockWindow()
 
 void TBDockWindow::SetDockOrigin( TBID dockid )
 {
-     m_dockid = dockid;
+    m_dockid = dockid;
     if ( m_dockid > 0 ) //enable/show the (re)dock button is a return id is specified
     {
         m_redock_button.SetVisibilility(WIDGET_VISIBILITY_VISIBLE);
@@ -885,19 +885,37 @@ void TBDockWindow::OnResized(int old_w, int old_h)
     // Manually move our own decoration children
     // FIX: Put a layout in the TBMover so we can add things there nicely.
     int title_height = GetTitleHeight();
-    m_mover.SetRect(TBRect(0, 0, GetRect().w, title_height));
-    PreferredSize ps = m_resizer.GetPreferredSize();
-    m_resizer.SetRect(TBRect(GetRect().w - ps.pref_w, GetRect().h - ps.pref_h, ps.pref_w, ps.pref_h));
-    TBRect mover_rect = m_mover.GetPaddingRect();
-    int button_size = mover_rect.h;
-    m_close_button.SetRect(TBRect(mover_rect.x + mover_rect.w - button_size, mover_rect.y, button_size, button_size));
-    if (m_settings & WINDOW_SETTINGS_CLOSE_BUTTON)
-        mover_rect.w -= button_size;
-    // add redock button to header
-    m_redock_button.SetRect(TBRect(mover_rect.x + mover_rect.w - button_size, mover_rect.y, button_size, button_size));
-    if (m_settings & WINDOW_SETTINGS_CLOSE_BUTTON)
-        mover_rect.w -= button_size;
-    m_textfield.SetRect(mover_rect);
+    if ( m_axis == AXIS_Y )  // default 
+    {
+        m_mover.SetRect(TBRect(0, 0, GetRect().w, title_height));
+        PreferredSize ps = m_resizer.GetPreferredSize();
+        m_resizer.SetRect(TBRect(GetRect().w - ps.pref_w, GetRect().h - ps.pref_h, ps.pref_w, ps.pref_h));
+        TBRect mover_rect = m_mover.GetPaddingRect();
+        int button_size = mover_rect.h;
+        m_close_button.SetRect(TBRect(mover_rect.x + mover_rect.w - button_size, mover_rect.y, button_size, button_size));
+        if (m_settings & WINDOW_SETTINGS_CLOSE_BUTTON)
+            mover_rect.w -= button_size;
+        // add redock button to header
+        m_redock_button.SetRect(TBRect(mover_rect.x + mover_rect.w - button_size, mover_rect.y, button_size, button_size));
+        if (m_settings & WINDOW_SETTINGS_CLOSE_BUTTON)
+            mover_rect.w -= button_size;
+        m_textfield.SetRect(mover_rect);
+    }
+    else if ( m_axis == AXIS_X )  // rotated sideways
+    {
+        m_mover.SetRect(TBRect(0, 0, title_height, GetRect().h ));
+        PreferredSize ps = m_resizer.GetPreferredSize();
+        m_resizer.SetRect(TBRect(GetRect().w - ps.pref_w, GetRect().h - ps.pref_h, ps.pref_w, ps.pref_h));
+        TBRect mover_rect = m_mover.GetPaddingRect();
+        int button_size = mover_rect.w;
+        m_close_button.SetRect(TBRect(mover_rect.x + 1, mover_rect.y + 1, button_size, button_size));
+        if (m_settings & WINDOW_SETTINGS_CLOSE_BUTTON)
+            mover_rect.y += button_size;
+        m_redock_button.SetRect(TBRect(mover_rect.x + 1, mover_rect.y + 1, button_size, button_size));
+        if (m_settings & WINDOW_SETTINGS_CLOSE_BUTTON)
+            mover_rect.y -= button_size;
+        m_textfield.SetRect(TBRect(mover_rect.x + 5, mover_rect.y + mover_rect.h - button_size, button_size - 1, button_size));
+    }
 }
 
 

--- a/Source/ThirdParty/TurboBadger/tb_window.h
+++ b/Source/ThirdParty/TurboBadger/tb_window.h
@@ -99,6 +99,13 @@ public:
     virtual void OnRemove();
     virtual void OnChildAdded(TBWidget *child);
     virtual void OnResized(int old_w, int old_h);
+
+// ATOMIC BEGIN
+    /** Set along which axis the content should be layouted. */
+    virtual AXIS GetAxis() const { return m_axis; }
+    virtual void SetAxis(AXIS axis);
+// ATOMIC END
+
 protected:
     TBMover m_mover;
     TBResizer m_resizer;
@@ -106,6 +113,9 @@ protected:
     TBWidget m_close_button;
     WINDOW_SETTINGS m_settings;
     TBWidgetSafePointer m_last_focus;
+// ATOMIC BEGIN
+    AXIS m_axis;
+// ATOMIC END
     TBWindow *GetTopMostOtherWindow(bool only_activable_windows);
     void SetWindowActiveState(bool active);
     void DeActivate();


### PR DESCRIPTION
This Pr adds API control of the titlebar axis/location on the UIWindow. The default will be the AXIS_Y, which places the titlebar at the top of the window. The new option is AXIS_X, which moves the titlebar to the left side, the closer 'X' moves to the top of the titlebar, and what's left of the title string is at the bottom, though since Turbobadger can't display rotated text, it quickly clips the string. The resizer still occupies the lower right corner. The DockWindow was also updated with this capability.
This will satisfy a couple of items in #1620  [UI] Turbobadger wishlist (in no particular order)

![window_xy](https://user-images.githubusercontent.com/19511757/29289171-4b58d220-80f0-11e7-86f8-9dd35b63cd54.png)
