### PR TITLE
Add Multicolumn List Widget

### DIFF
--- a/Script/Packages/Atomic/UI.json
+++ b/Script/Packages/Atomic/UI.json
@@ -11,7 +11,7 @@
 								"UIContainer", "UISection", "UIInlineSelect", "UITextureWidget", "UIColorWidget", "UIColorWheel",
 								"UIScrollContainer", "UISeparator", "UIDimmer", "UISelectDropdown", "UISlider", "UIBargraph",
 								"UIPromptWindow", "UIFinderWindow", "UIPulldownMenu", "UIRadioButton", "UIScrollBar", "UIDockWindow",
-								"UIButtonGrid"],
+								"UIButtonGrid", "UIMultiItem", "UIMultiItemSource" ],
 	"overloads" : {
 	},
 	"typescript_decl" : {

--- a/Source/Atomic/UI/UIMultiItem.cpp
+++ b/Source/Atomic/UI/UIMultiItem.cpp
@@ -1,0 +1,159 @@
+//
+// Copyright (c) 2014-2017, THUNDERBEAST GAMES LLC All rights reserved
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "UIMultiItem.h"
+
+using namespace tb;
+
+namespace Atomic
+{
+
+UIMultiItem::UIMultiItem(Context* context, const String &colid, const String &widgettype, const String &str, int colwidth, int colheight ) : Object(context)
+{
+    SetID(colid);
+    AddColumn ( widgettype, str, colwidth );
+    colHeight_ = colheight; 
+}
+
+UIMultiItem::~UIMultiItem()
+{
+}
+
+void UIMultiItem::SetID(const String& id)
+{
+    id_ = TBID(id.CString());
+}
+
+void UIMultiItem::AddColumn ( const String& widgettype, const String& str, int cwidth ) 
+{
+    colStr_.Push(str);
+    colWidget_.Push(widgettype);
+    colWidth_.Push(cwidth);
+}
+
+const String& UIMultiItem::GetColumnStr( int col )
+{
+    if ( col > -1 )
+        return colStr_[col];
+    return ( String::EMPTY );
+}
+
+const String& UIMultiItem::GetColumnWidget( int col ) 
+{
+    if ( col > -1 )
+    return colWidget_[col];
+    return ( String::EMPTY );
+}
+
+int UIMultiItem::GetColumnWidth( int col ) 
+{
+    if ( col > -1 )
+        return colWidth_[col];
+    return 0;
+}
+
+int UIMultiItem::GetNumColumns()
+{
+    return colStr_.Size();
+}
+
+tb::MultiItem* UIMultiItem::GetTBItem()
+{
+    tb::MultiItem* item = NULL;
+
+    int col = 0;
+    int numcols = GetNumColumns();
+    String strx = GetColumnStr(col);
+    String widx = GetColumnWidget(col);
+    int wix = GetColumnWidth(col);
+    item = new tb::MultiItem(id_, widx.CString(), strx.CString(), wix, colHeight_ );
+    for ( col = 1; col<numcols; col++)
+    {
+        strx = GetColumnStr(col);
+        widx = GetColumnWidget(col);
+        wix = GetColumnWidth(col);
+        item->AddColumn( widx.CString(), strx.CString(), wix );
+    }
+    return item;
+}
+
+// UIMultiItemSource 
+
+UIMultiItemSource::UIMultiItemSource(Context* context) : Object(context)
+{
+
+}
+
+UIMultiItemSource::~UIMultiItemSource()
+{
+
+}
+
+void UIMultiItemSource::RemoveItemWithId(const String& id)
+{
+    tb::TBID test = TBID(id.CString());
+    for (List<SharedPtr<UIMultiItem> >::Iterator itr = items_.Begin(); itr != items_.End(); itr++)
+    {
+        if ((*itr)->GetID() == test) {
+            items_.Erase(itr);
+            break;
+        }
+    }
+}
+
+void UIMultiItemSource::RemoveItemWithStr(const String& str)
+{
+    for (List<SharedPtr<UIMultiItem> >::Iterator itr = items_.Begin(); itr != items_.End(); itr++)
+    {
+        if ((*itr)->GetColumnStr(0) == str) {
+            items_.Erase(itr);
+            break;
+        }
+    }
+}
+
+const String& UIMultiItemSource::GetItemStr(int index)
+{
+    int nn = 0;
+    for (List<SharedPtr<UIMultiItem> >::Iterator itr = items_.Begin(); itr != items_.End(); itr++)
+    {
+        if ( nn == index) return (*itr)->GetColumnStr(0);
+        nn++;
+    }
+    return ( String::EMPTY );
+}
+
+MultiItemSource *UIMultiItemSource::GetTBItemSource()
+{
+    // caller's responsibility to clean up
+    MultiItemSource* src = new MultiItemSource();
+
+    for (List<SharedPtr<UIMultiItem> >::Iterator itr = items_.Begin(); itr != items_.End(); itr++)
+    {
+        tb::MultiItem* tbitem = (*itr)->GetTBItem();
+        src->AddItem(tbitem);
+    }
+
+    return src;
+}
+
+}

--- a/Source/Atomic/UI/UIMultiItem.cpp
+++ b/Source/Atomic/UI/UIMultiItem.cpp
@@ -27,7 +27,8 @@ using namespace tb;
 namespace Atomic
 {
 
-UIMultiItem::UIMultiItem(Context* context, const String &colid, const String &widgettype, const String &str, int colwidth, int colheight ) : Object(context)
+UIMultiItem::UIMultiItem(Context* context, const String &colid, const String &widgettype, const String &str, int colwidth, int colheight )
+ : UISelectItem(context, str, colid)
 {
     SetID(colid);
     AddColumn ( widgettype, str, colwidth );
@@ -98,7 +99,7 @@ tb::MultiItem* UIMultiItem::GetTBItem()
 
 // UIMultiItemSource 
 
-UIMultiItemSource::UIMultiItemSource(Context* context) : Object(context)
+UIMultiItemSource::UIMultiItemSource(Context* context) :  UISelectItemSource(context)
 {
 
 }

--- a/Source/Atomic/UI/UIMultiItem.h
+++ b/Source/Atomic/UI/UIMultiItem.h
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2014-2017, THUNDERBEAST GAMES LLC All rights reserved
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include <TurboBadger/tb_widgets.h>
+#include <TurboBadger/tb_select_item.h>
+#include <TurboBadger/tb_atomic_widgets.h>
+
+#include "../Core/Object.h"
+#include "../Container/List.h"
+#include "../IO/Log.h"
+
+namespace Atomic
+{
+
+class UIMultiItemSource;
+
+class ATOMIC_API UIMultiItem : public Object
+{
+    ATOMIC_OBJECT(UIMultiItem, Object)
+
+public:
+
+    UIMultiItem(Context* context, const String& colid,const String& widgettype, const String& str, int colwidth, int colheight );
+    virtual ~UIMultiItem();
+
+    void SetID(const String& id);
+    tb::TBID GetID() { return id_; }
+
+    void AddColumn ( const String& widgettype, const String& str, int colwidth );
+    const String& GetColumnStr( int col );
+    const String& GetColumnWidget( int col );
+    int GetColumnWidth( int col );
+    int GetNumColumns();
+
+    virtual tb::MultiItem * GetTBItem();
+
+protected:
+
+    tb::TBID id_;    // TBID
+    Vector <String> colStr_;
+    Vector <String> colWidget_; 
+    Vector <int>  colWidth_;
+    int colHeight_; 
+};
+
+class ATOMIC_API UIMultiItemSource : public Object
+{
+    ATOMIC_OBJECT(UIMultiItemSource, Object)
+
+public:
+
+    UIMultiItemSource(Context* context);
+    virtual ~UIMultiItemSource();
+
+    void AddItem(UIMultiItem* item) { items_.Push(SharedPtr<UIMultiItem>(item)); }
+    void RemoveItemWithId(const String& id);
+    void RemoveItemWithStr(const String& str);
+    int GetItemCount() { return items_.Size(); }
+
+    void Clear() { items_.Clear(); }
+
+    /// Returns item string for the index. Returns empty string for invalid indexes.
+    const String& GetItemStr(int index);
+
+    // caller's responsibility to clean up
+    virtual tb::MultiItemSource* GetTBItemSource();
+
+protected:
+
+    List<SharedPtr<UIMultiItem>> items_;
+
+};
+
+}

--- a/Source/Atomic/UI/UIMultiItem.h
+++ b/Source/Atomic/UI/UIMultiItem.h
@@ -30,14 +30,16 @@
 #include "../Container/List.h"
 #include "../IO/Log.h"
 
+#include "UISelectItem.h"
+
 namespace Atomic
 {
 
 class UIMultiItemSource;
 
-class ATOMIC_API UIMultiItem : public Object
+class ATOMIC_API UIMultiItem : public  UISelectItem
 {
-    ATOMIC_OBJECT(UIMultiItem, Object)
+    ATOMIC_OBJECT(UIMultiItem, UISelectItem )
 
 public:
 
@@ -64,9 +66,9 @@ protected:
     int colHeight_; 
 };
 
-class ATOMIC_API UIMultiItemSource : public Object
+class ATOMIC_API UIMultiItemSource : public UISelectItemSource
 {
-    ATOMIC_OBJECT(UIMultiItemSource, Object)
+    ATOMIC_OBJECT(UIMultiItemSource, UISelectItemSource )
 
 public:
 

--- a/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
+++ b/Source/ThirdParty/TurboBadger/tb_atomic_widgets.h
@@ -297,6 +297,63 @@ protected:
 
 };
 
+/// == MultiList Support  ==========================================
+
+/** MultiItem adds extra info to a string item. */
+class MultiItem : public TBGenericStringItem
+{
+public:
+    MultiItem(const TBID &colid, TBStr widgettype0, TBStr str0, int width0, int colheight=0 )
+        : TBGenericStringItem(str0, colid),
+        colStr_(TBValue::TYPE_ARRAY),
+        colWidget_(TBValue::TYPE_ARRAY),
+        colWidth_(TBValue::TYPE_ARRAY),
+        colHeight_(colheight)
+        {
+            colStr_.SetArray(new tb::TBValueArray(), TBValue::SET_AS_STATIC);
+            colWidget_.SetArray(new tb::TBValueArray(), TBValue::SET_AS_STATIC);
+            colWidth_.SetArray(new tb::TBValueArray(), TBValue::SET_AS_STATIC);
+            
+            AddColumn ( widgettype0, str0, width0);
+        }
+
+    void AddColumn ( TBStr string, TBStr widgettype, int width );
+    const char* GetColumnStr( int col );
+    const char* GetColumnWidget( int col );
+    int GetColumnWidth( int col );
+    int GetColumnHeight();
+    int GetNumColumns();
+
+private:
+    TBValue colStr_;
+    TBValue colWidget_; 
+    TBValue colWidth_;
+    int colHeight_; 
+};
+
+
+/** MultiItemSource provides items of type MultiItem and makes sure
+    the viewer is populated with the customized widget for each item. */
+class MultiItemSource : public TBSelectItemSourceList<MultiItem>
+{
+public:
+    virtual bool Filter(int index, const char *filter);
+    virtual TBWidget *CreateItemWidget(int index, TBSelectItemViewer *viewer);
+};
+
+/** MultiItemWidget is the widget representing a MultiItem.
+    On changes to the item, it calls InvokeItemChanged on the source, so that all
+    viewers of the source are updated to reflect the change. */
+class MultiItemWidget : public TBLayout
+{
+public:
+    MultiItemWidget(MultiItem *item, MultiItemSource *source, TBSelectItemViewer *source_viewer, int index);
+    virtual bool OnEvent(const TBWidgetEvent &ev);
+private:
+    MultiItemSource *m_source;
+    TBSelectItemViewer *m_source_viewer;
+    int m_index;
+};
 
 }; // namespace tb
 


### PR DESCRIPTION
UIMultiList
These are 2 classes that enable the UISelectList to have multiple columns.  There is API to set the column type, column width, data for the column and fixing the column height, if necessary. Once set into the UISelectList, it operates the same way, to get which row is selected.

There are a couple of column types that can be used
  TEXT = which is a TextField, with left justified text, the column data is the text that will be displayed.
  TEXTC = a TextField, with center justified text
  TEXTR = a TextField with right justified text
  IMAGE = an ImageWidget, the column data is the resource name (or pathname) to the file to display
  COLOR = a ColorWidget, the column data is the hex color string, like "#228800", to display.
  ICON = a SkinImage, the column data is the skin name for the icon to display.
  
If the column height is left as 0, the content will determine the height of the row. If you need it to be a fixed size, the column height field can be used.
The columm widths must be programmed, and are needed to keep alignment for the widget, the content will not exceed the programmed value.

Example Javascript code
```
    var mis = new Atomic.UIMultiItemSource();  // new itemsource

    var columnHeight = 0;   // 0 = let content determine column height
    var  = "item1";   // RefId string returned when list entry is selected
	var aumi1 = new Atomic.UIMultiItem( columnRefId, "ICON", "LogoAtomic", 32, columnHeight );
	aumi1.addColumn ( "TEXT", "a new kind of list...", 210 );
	aumi1.addColumn ( "TEXTC", "RW",  20 );
	aumi1.addColumn ( "COLOR", "#33FF33", 20 );
	aumi1.addColumn ( "TEXT", "moar", 66 );
	aumi1.addColumn ( "TEXT", "moar text is fine, in multiple columns.", 266 );
    mis.addItem( aumi1 );
    
    mylist.setSource(mis);

```
![multilist](https://user-images.githubusercontent.com/19511757/29592631-3054227a-875a-11e7-8ba7-c4fcd1ba309c.png)

