### PR TITLE
Add right-click import on resources folders #357

### DIFF
--- a/Script/AtomicEditor/ui/frames/ProjectFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ProjectFrame.ts
@@ -104,8 +104,11 @@ class ProjectFrame extends ScriptWidget {
                 var pathInfo = Atomic.splitPath(srcFilename);
                 var destFilename = Atomic.addTrailingSlash(data.destination);
                 destFilename += pathInfo.fileName + pathInfo.ext;
-                if ( fileSystem.copy(srcFilename, destFilename) )
+                if ( fileSystem.copy(srcFilename, destFilename) ) {
                     EditorUI.showEditorStatus ( "Copied Asset " + pathInfo.fileName + " into project as " + destFilename);
+                    var db = ToolCore.getAssetDatabase();
+                    db.scan(); // fix up the asset database on success
+                }
                 else {
                     EditorUI.showEditorStatus ( "Warning, could not copy Asset " + pathInfo.fileName + " from " + srcFilename);
                 }

--- a/Script/AtomicEditor/ui/frames/ProjectFrame.ts
+++ b/Script/AtomicEditor/ui/frames/ProjectFrame.ts
@@ -25,6 +25,7 @@ import {default as AtomicEditor} from "editor/Editor";
 import ProjectFrameMenu = require("./menus/ProjectFrameMenu");
 import MenuItemSources = require("./menus/MenuItemSources");
 import SearchBarFiltering = require("resources/SearchBarFiltering");
+import EditorUI = require("ui/EditorUI");
 
 class ProjectFrame extends ScriptWidget {
 
@@ -93,6 +94,21 @@ class ProjectFrame extends ScriptWidget {
         this.subscribeToEvent("DevelopmentUIEvent", (data) => {
             if (data.subEvent == "ScaleFrameWidth" && data.arg0 == "projectframe") {
                 this.handleScaleWidth(data.arg1);
+            }
+        });
+
+        this.subscribeToEvent("ImportAssetEvent", (data) => {
+            if (data.file.length > 0) {  // imported an asset file 
+                var fileSystem = Atomic.getFileSystem();
+                var srcFilename = data.file;
+                var pathInfo = Atomic.splitPath(srcFilename);
+                var destFilename = Atomic.addTrailingSlash(data.destination);
+                destFilename += pathInfo.fileName + pathInfo.ext;
+                if ( fileSystem.copy(srcFilename, destFilename) )
+                    EditorUI.showEditorStatus ( "Copied Asset " + pathInfo.fileName + " into project as " + destFilename);
+                else {
+                    EditorUI.showEditorStatus ( "Warning, could not copy Asset " + pathInfo.fileName + " from " + srcFilename);
+                }
             }
         });
 

--- a/Script/AtomicEditor/ui/frames/menus/ProjectFrameMenu.ts
+++ b/Script/AtomicEditor/ui/frames/menus/ProjectFrameMenu.ts
@@ -105,6 +105,15 @@ class ProjectFrameMenus extends Atomic.ScriptObject {
                 return true;
             }
 
+            if (refid == "import_asset") {
+                var fileUtils = new Editor.FileUtils();
+                var myassets = fileUtils.findFile("" , "");
+                if (  myassets.length > 0 ) {
+                    this.sendEvent("ImportAssetEvent", { "file" : myassets, "destination" : path });
+                }
+                return true;
+            }
+
             if (refid == "force_reimport_folder") {
                 ToolCore.assetDatabase.reimportAllAssetsInDirectory(path);
                 return true;
@@ -196,6 +205,7 @@ var assetFolderContextItems = {
     "Create Material": ["create_material", undefined, "ComponentBitmap"],
     "Create Scene": ["create_scene", undefined, "ComponentBitmap"],
     "Force Reimport": ["force_reimport_folder", undefined, ""],
+    "Import Asset...": ["import_asset", undefined, ""],
     "-1": null,
     [showInFs]: ["reveal_folder", undefined, ""],
     "-2": null,


### PR DESCRIPTION
This PR add the ability to import an asset file by searching for it with a file finder, instead of using OS drag and drop. 
There is a new entry in the context menu in either Project window when a folder is selected, this entry is called "Import Asset...".  Selecting "Import Asset..." brings up the file finder to search for an asset file that will be saved into the Project folder which was originally selected.  Due to limitations in the file finder, only one asset may be imported at at time.  There is a message in the editor's status area which reports the success or failure of the import operation.
This will be for all (AtomicEditor) platforms.
